### PR TITLE
chore: enable simplify, bugbear, naming, and complexity lint rules (batch 3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,22 @@ select = [
     "S",       # flake8-bandit: security lint
     "D",       # pydocstyle (Google convention)
     "ANN",     # flake8-annotations
+    "SIM",     # flake8-simplify
+    "B",       # flake8-bugbear
+    "N",       # pep8-naming
+    "PT",      # flake8-pytest-style
+    "C901",    # mccabe complexity gate (threshold in [tool.ruff.lint.mccabe])
 ]
+ignore = [
+    "B905",    # numba nopython mode can't take zip()'s strict= kwarg
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.flake8-pytest-style]
+parametrize-names-type = "csv"                     # names given as a single "a, b" string
+raises-require-match-for = ["Exception", "BaseException"]  # only the truly broad base exceptions need match=
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
@@ -144,6 +159,15 @@ convention = "google"
 "__init__.py" = ["F401"]                 # re-export modules: naked imports, no `as` alias
 "scripts/**" = ["INP001", "S", "D", "ANN"]           # maintainer tooling, not the shipped library
 ".github/scripts/**" = ["INP001", "S", "D", "ANN"]   # maintainer tooling, not held to shipped-source style
+# benchmark closures are constructed and invoked within the same loop iteration, so late binding never bites
+"src/max_div/_core/_cli/bm_internal/**" = ["B023"]
+# problem-ID / benchmark-ID class-name suffixes (C1..C4, U1..U4, _Initialization, ...) are deliberate
+"src/max_div/_core/benchmark_problems/_problems/**" = ["N801"]
+"src/max_div/_core/_cli/bm_solver_strategies/**" = ["N801"]
+# calibration tooling & tests import the currently-committed constants under working-variable aliases
+"src/max_div/_core/_math/fast_pow/_calibration.py" = ["N811"]
+"tests/_core/_math/fast_log_exp/test_calibration.py" = ["N811"]
+"tests/_core/_math/fast_pow/test_calibration.py" = ["N811"]
 
 [tool.coverage.run]
 source_pkgs = ["max_div"]

--- a/src/max_div/_core/_cli/_cmd_benchmark_solver_presets.py
+++ b/src/max_div/_core/_cli/_cmd_benchmark_solver_presets.py
@@ -213,10 +213,7 @@ def resolve_problems(problem: str) -> list[str]:
     """Resolve problem string into list of problem names."""
     if problem == "all":
         return BenchmarkProblemFactory.get_all_benchmark_names()
-    if "," in problem:
-        problems = [p.strip() for p in problem.split(",")]
-    else:
-        problems = [problem]
+    problems = [p.strip() for p in problem.split(",")] if "," in problem else [problem]
     all_supported_problem_names = BenchmarkProblemFactory.get_all_benchmark_names()
     for problem in problems:
         if problem not in all_supported_problem_names:

--- a/src/max_div/_core/_cli/bm_internal/randint_constrained.py
+++ b/src/max_div/_core/_cli/bm_internal/randint_constrained.py
@@ -174,10 +174,7 @@ def _benchmark(
         lst_con_values.append(con_values)
         lst_con_indices.append(con_indices)
 
-    if p is None:
-        p = np.zeros(0, dtype=np.float32)
-    else:
-        p = p.astype(np.float32)
+    p = np.zeros(0, dtype=np.float32) if p is None else p.astype(np.float32)
 
     rng_state = new_rng_state(np.int64(42))
 
@@ -229,10 +226,7 @@ def _determine_precision(
     mode: str,
 ) -> TablePercentage:
     """Determines how often (%) the constraints are satisfied when sampling."""
-    if p is None:
-        p = np.zeros(0, dtype=np.float32)
-    else:
-        p = p.astype(np.float32)
+    p = np.zeros(0, dtype=np.float32) if p is None else p.astype(np.float32)
 
     # Calculate number of runs based on speed (200 at speed=0, 1 at speed=1)
     n_runs = round(200 ** (1 - speed))

--- a/src/max_div/_core/_cli/bm_solver_strategies/presets/_init_presets.py
+++ b/src/max_div/_core/_cli/bm_solver_strategies/presets/_init_presets.py
@@ -51,16 +51,13 @@ class InitPreset(StrEnum):
     #  Meta-Data
     # -------------------------------------------------------------------------
     def is_constraint_aware(self) -> bool:
-        if self in [InitPreset.FAST, InitPreset.ROS_U_UNCON, InitPreset.ROS_NU_UNCON]:
-            return False
-        return True
+        return self not in [InitPreset.FAST, InitPreset.ROS_U_UNCON, InitPreset.ROS_NU_UNCON]
 
     def is_relevant_for_problem(self, problem_has_constraints: bool) -> bool:
         if problem_has_constraints:
             return True
-        if self in [InitPreset.ROS_U_UNCON, InitPreset.ROS_NU_UNCON]:
-            return False  # the constraint-aware versions will behave the same as these on unconstrained problems
-        return True
+        # the constraint-aware versions will behave the same as these on unconstrained problems
+        return self not in [InitPreset.ROS_U_UNCON, InitPreset.ROS_NU_UNCON]
 
     def class_name(self) -> str:
         cls, _ = _INIT_CLASSES_AND_KWARGS[self]

--- a/src/max_div/_core/_markdown/_report_element.py
+++ b/src/max_div/_core/_markdown/_report_element.py
@@ -37,10 +37,7 @@ class ReportHeader(ReportElement):
             lines = ["", f"{'#' * self.level} {self.txt}", ""]
         else:
             txt = self.txt.replace("`", "'")
-            if self.level == 1:
-                lines = ["", txt.upper(), ""]
-            else:
-                lines = ["", txt, ""]
+            lines = ["", txt.upper(), ""] if self.level == 1 else ["", txt, ""]
 
         return lines
 

--- a/src/max_div/_core/_markdown/_table.py
+++ b/src/max_div/_core/_markdown/_table.py
@@ -38,7 +38,7 @@ class Table(ReportElement):
         row = [TableText(str(cell)) if not isinstance(cell, TableElement) else cell for cell in row]
         self.rows.append(row)
 
-    def add_aggregate_row(
+    def add_aggregate_row(  # noqa: C901 — case-dispatch structure is clearer un-split
         self,
         agg_type: TableAggregationType,
         restrict_to_types: list[type[TableElement]] | None = None,

--- a/src/max_div/_core/_markdown/_table_element.py
+++ b/src/max_div/_core/_markdown/_table_element.py
@@ -160,10 +160,7 @@ class TableValueWithUncertainty(_QuantiledTableElement):
         if self.decimals == 0:
             s_median = f"{round(self.q_50):_}"
         else:
-            if self.scientific:
-                s_median = f"{self.q_50:.{self.decimals}e}"
-            else:
-                s_median = f"{self.q_50:.{self.decimals}f}"
+            s_median = f"{self.q_50:.{self.decimals}e}" if self.scientific else f"{self.q_50:.{self.decimals}f}"
         s_perc = f"{50 * (self.q_75 - self.q_25) / self.q_50:.1f}%"
         return f"{s_median} ± {s_perc}"
 
@@ -203,7 +200,7 @@ class TableValueRange(_QuantiledTableElement):
         self.max_decimals = max_decimals
         self.diff_decimals = diff_decimals
 
-    def to_mark_down(self) -> str:
+    def to_mark_down(self) -> str:  # noqa: C901 — case-dispatch structure is clearer un-split
         prefix = suffix_min = suffix_max = ""
         for n_decimals in range(self.max_decimals, -1, -1):
             # Render q25 and q75 with n_decimals

--- a/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
+++ b/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
@@ -11,7 +11,7 @@ def exponential_selectivity(
     p_out: NDArray[np.float32],
     modifier: np.float32,
     reverse: bool = False,
-    low_value: np.float32 = np.float32(0.1),
+    low_value: np.float32 = np.float32(0.1),  # noqa: B008 — numba needs a concrete typed default
 ) -> None:
     """Populate p_out with values depending exponentially on the non-normalized probabilities in p_in.
 

--- a/src/max_div/_core/_math/modify_p_selectivity/_main.py
+++ b/src/max_div/_core/_math/modify_p_selectivity/_main.py
@@ -22,7 +22,7 @@ __MODIFIER_MAX = np.float32(1.0 - 10.0 * EPS_F32)
 #  Main Numba entrypoint
 # =================================================================================================
 @njit("void(float32[::1], float32, int32, float32[::1])", fastmath=True, inline="always")
-def modify_p_selectivity(
+def modify_p_selectivity(  # noqa: C901 — case-dispatch structure is clearer un-split
     p: NDArray[np.float32], modifier: np.float32, method: np.int32, p_out: NDArray[np.float32]
 ) -> None:
     """Modify the p array by applying a selectivity modification.

--- a/src/max_div/_core/_math/select_k_minmax.py
+++ b/src/max_div/_core/_math/select_k_minmax.py
@@ -7,7 +7,7 @@ from numpy.typing import NDArray
 #  select_k_min
 # =================================================================================================
 @numba.njit("int32[:](float32[:], int32)", fastmath=True, inline="always", cache=True)
-def select_k_min(arr: NDArray[np.float32], k: np.int32) -> NDArray[np.int32]:
+def select_k_min(arr: NDArray[np.float32], k: np.int32) -> NDArray[np.int32]:  # noqa: C901 — case-dispatch structure is clearer un-split
     """Find indices of k smallest elements in a float32 array using Numba.
 
     This implementation uses a max-heap approach with O(n log k) complexity,
@@ -130,7 +130,7 @@ def select_k_min(arr: NDArray[np.float32], k: np.int32) -> NDArray[np.int32]:
 #  select_k_max
 # =================================================================================================
 @numba.njit("int32[:](float32[:], int32)", fastmath=True, inline="always", cache=True)
-def select_k_max(arr: NDArray[np.float32], k: np.int32) -> NDArray[np.int32]:
+def select_k_max(arr: NDArray[np.float32], k: np.int32) -> NDArray[np.int32]:  # noqa: C901 — case-dispatch structure is clearer un-split
     """Find indices of k largest elements in a float32 array using Numba.
 
     This implementation uses a min-heap approach with O(n log k) complexity,

--- a/src/max_div/_core/_random/_choice/_choice_constrained.py
+++ b/src/max_div/_core/_random/_choice/_choice_constrained.py
@@ -15,7 +15,7 @@ def choice_constrained(
     con_values: NDArray[np.int32],
     con_indices: NDArray[np.int32],
     eager: bool = False,
-    k_context: np.int32 = np.int32(-1),
+    k_context: np.int32 = np.int32(-1),  # noqa: B008 — numba needs a concrete typed default
 ) -> NDArray[np.int32]:
     """Sample from a provided 'values' array instead of the range [0, n), respecting the provided constraints.
 

--- a/src/max_div/_core/_random/_randint/_randint.py
+++ b/src/max_div/_core/_random/_randint/_randint.py
@@ -28,7 +28,7 @@ P_UNIFORM = np.zeros(0, dtype=np.float32)
 #  randint
 # =================================================================================================
 @numba.njit("int32[:](int32, int32, bool, float32[:], uint64[:])", fastmath=True, cache=True)
-def randint(
+def randint(  # noqa: C901 — case-dispatch structure is clearer un-split
     n: np.int32,
     k: np.int32,
     replace: bool,

--- a/src/max_div/_core/_random/_randint/_randint_constrained.py
+++ b/src/max_div/_core/_random/_randint/_randint_constrained.py
@@ -46,10 +46,7 @@ def _compute_score(
     m = con_values.shape[0]
 
     # --- init --------------------------------------------
-    if hard_max_constraints:
-        max_count_penalty = _SCORE_PENALTY_HARD_CONSTRAINT
-    else:
-        max_count_penalty = np.int32(1)
+    max_count_penalty = _SCORE_PENALTY_HARD_CONSTRAINT if hard_max_constraints else np.int32(1)
     scores = np.zeros(n, dtype=np.int32)
 
     # --- min_count / max_count ---------------------------
@@ -77,16 +74,16 @@ def _compute_score(
 
 
 @numba.njit(fastmath=True, cache=True)
-def randint_constrained(
+def randint_constrained(  # noqa: C901 — case-dispatch structure is clearer un-split
     n: np.int32,
     k: np.int32,
     con_values: NDArray[np.int32],
     con_indices: NDArray[np.int32],
     rng_state: NDArray[np.uint64],
-    p: NDArray[np.float32] = np.zeros(0, dtype=np.float32),
+    p: NDArray[np.float32] = np.zeros(0, dtype=np.float32),  # noqa: B008 — numba needs a concrete typed default
     eager: bool = False,
-    k_context: np.int32 = np.int32(-1),
-    i_forbidden: NDArray[np.int32] = np.empty(0, dtype=np.int32),
+    k_context: np.int32 = np.int32(-1),  # noqa: B008 — numba needs a concrete typed default
+    i_forbidden: NDArray[np.int32] = np.empty(0, dtype=np.int32),  # noqa: B008 — numba needs a concrete typed default
 ) -> NDArray[np.int32]:
     """Generate `k` unique random integers from the range `[0, n)` while satisfying given constraints.
 
@@ -186,10 +183,7 @@ def randint_constrained(
 
         # Get already sampled integers
         # (we include i_forbidden, since they're excluded from sampling, with equal priority as already sampled values)
-        if n_forbidden:
-            already_sampled = np.concatenate((samples[:sample_idx], i_forbidden))
-        else:
-            already_sampled = samples[:sample_idx]
+        already_sampled = np.concatenate((samples[:sample_idx], i_forbidden)) if n_forbidden else samples[:sample_idx]
 
         # determine how much each integer would help us satisfy min_count constraints
         score = _compute_score(n, con_values_working, con_indices, already_sampled, True)

--- a/src/max_div/_core/_random/_randint/_randint_python.py
+++ b/src/max_div/_core/_random/_randint/_randint_python.py
@@ -2,7 +2,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 
-def randint_python(
+def randint_python(  # noqa: C901 — case-dispatch structure is clearer un-split
     n: np.int32 | int,
     k: np.int32 | int,
     replace: bool,

--- a/src/max_div/_core/_utils/_format_time_durations.py
+++ b/src/max_div/_core/_utils/_format_time_durations.py
@@ -84,7 +84,7 @@ def format_short_time_duration(
 # =================================================================================================
 #  Helpers
 # =================================================================================================
-def _format_long_time_duration_to_spec(
+def _format_long_time_duration_to_spec(  # noqa: C901 — case-dispatch structure is clearer un-split
     dt_sec: float, precision: str = Literal["d", "h", "m", "s", "s.s", "s.ss", "s.sss"]
 ) -> str:
     # --- rounding ----------------------------------------
@@ -166,10 +166,7 @@ def _format_short_time_duration_to_spec(
         value = round(dt_sec * c, ndigits=n_digits)
         if (value < 1000) or (value_str == ""):
             unit_str = unit
-            if n_digits > 0:
-                value_str = f"{value:.{n_digits}f}".lstrip()
-            else:
-                value_str = str(int(value))
+            value_str = f"{value:.{n_digits}f}".lstrip() if n_digits > 0 else str(int(value))
 
     # --- final result ------------------------------------
     if spaced:

--- a/src/max_div/_core/_utils/_micro_benchmark.py
+++ b/src/max_div/_core/_utils/_micro_benchmark.py
@@ -81,7 +81,7 @@ class BenchmarkResult:
 # =================================================================================================
 #  Main benchmarking function
 # =================================================================================================
-def benchmark(
+def benchmark(  # noqa: C901 — case-dispatch structure is clearer un-split
     f: Callable,
     t_per_run: float = 0.1,
     n_warmup: int = 5,
@@ -105,10 +105,8 @@ def benchmark(
     # --- init --------------------------------------------
     lst_t = []  # list of measured times per execution in seconds
     n_executions = 1  # number of executions per run, adjusted dynamically
-    if index_range is None:
-        f_baseline = _baseline_fun  # baseline function to subtract overhead
-    else:
-        f_baseline = _baseline_fun_indexed  # baseline function to subtract overhead, with index
+    # baseline function to subtract overhead (indexed variant when an index is cycled)
+    f_baseline = _baseline_fun if index_range is None else _baseline_fun_indexed
 
     if not silent:
         print("Benchmarking: ", end="")

--- a/src/max_div/_core/_utils/_stdout.py
+++ b/src/max_div/_core/_utils/_stdout.py
@@ -15,7 +15,7 @@ def stdout_to_file(enabled: bool = True, filename: str | Path | None = None) -> 
     old_stdout = sys.stdout
     f = None
     if enabled:
-        f = Path(filename).open("w")
+        f = Path(filename).open("w")  # noqa: SIM115 — closed in the finally block of this context manager
         sys.stdout = f
 
     try:

--- a/src/max_div/_core/benchmark_problems/__init__.py
+++ b/src/max_div/_core/benchmark_problems/__init__.py
@@ -8,5 +8,5 @@ Purposes:
 """
 
 from ._factory import BenchmarkProblemFactory
-from ._problems import IMPORT_ME_FOR_BENCHMARK_PROBLEM_DISCOVERY as __
+from ._problems import IMPORT_ME_FOR_BENCHMARK_PROBLEM_DISCOVERY
 from ._registry import BenchmarkProblem

--- a/src/max_div/_core/benchmark_problems/_registry.py
+++ b/src/max_div/_core/benchmark_problems/_registry.py
@@ -73,7 +73,7 @@ class BenchmarkProblem(ABC):
         """
         # --- validate ----------------
         supported_params = cls.supported_params().keys()
-        for key in kwargs.keys():
+        for key in kwargs:
             if key not in supported_params:
                 raise ValueError(
                     f"Parameter '{key}' is not supported by benchmark problem '{cls.name()}'."

--- a/src/max_div/_core/solver/_duration.py
+++ b/src/max_div/_core/solver/_duration.py
@@ -197,10 +197,7 @@ class _IterationTracker(ProgressTracker):
         self._max_iters = max_iters
 
     def get_progress(self) -> Progress:
-        if self._iter_count >= self._max_iters:
-            fraction = 1.0
-        else:
-            fraction = self._iter_count / self._max_iters
+        fraction = 1.0 if self._iter_count >= self._max_iters else self._iter_count / self._max_iters
 
         return Progress(
             tqdm_n_total=self._max_iters,

--- a/src/max_div/_core/solver/_score.py
+++ b/src/max_div/_core/solver/_score.py
@@ -177,10 +177,8 @@ class ScoreGenerator:
         else:
             size_score = 1.0 - self._size_c1 * (n_selected - self._k)
 
-        if self._con_c == 0.0:
-            con_score = 1.0  # no constraints -> perfect score
-        else:
-            con_score = 1.0 - self._con_c * _np_con_total_violation(con_values)
+        # no constraints -> perfect score
+        con_score = 1.0 if self._con_c == 0.0 else 1.0 - self._con_c * _np_con_total_violation(con_values)
 
         # --- construct Score object ----------------------
         return Score(

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
@@ -90,10 +90,8 @@ class InitEager(InitializationStrategy):
             state.restore_snapshot()
 
             # see if sample is better
-            if self.ignore_constraints:
-                score_tuple = score.as_tuple(soft=1.0)  # ignore constraint score
-            else:
-                score_tuple = score.as_tuple()  # consider full score, including constraints
+            # soft=1.0 ignores the constraint score; otherwise consider the full score, including constraints
+            score_tuple = score.as_tuple(soft=1.0) if self.ignore_constraints else score.as_tuple()
 
             if (best_score_tuple is None) or (score_tuple > best_score_tuple):
                 best_score_tuple = score_tuple

--- a/src/max_div/_core/solver/_strategies/_optimization/_base.py
+++ b/src/max_div/_core/solver/_strategies/_optimization/_base.py
@@ -72,7 +72,7 @@ class OptimizationStrategy(StrategyBase, ABC):
         """
         super().__init__(name)
         self.ignore_infeasible_diversity_up_to_fraction = ignore_infeasible_diversity_up_to_fraction
-        self.ignore_infeasible_diversity = 0.0 <= ignore_infeasible_diversity_up_to_fraction
+        self.ignore_infeasible_diversity = ignore_infeasible_diversity_up_to_fraction >= 0.0
 
         # --- initialize scheduled parameters ---
         #  --> first initialize as if we don't have any; potentially overridden by _configure_dynamic_params

--- a/src/max_div/_core/solver/_strategies/_optimization/_optim_smart_swaps.py
+++ b/src/max_div/_core/solver/_strategies/_optimization/_optim_smart_swaps.py
@@ -214,7 +214,7 @@ class OptimSmartSwaps(SwapBasedOptimizationStrategy):
         best_score_tuple: tuple | None = None
 
         # a) repeat 'nc' times...
-        for i in range(self.nc_add):
+        for _i in range(self.nc_add):
             # 1) select group of 'n_to_add' samples
             candidate_samples_to_add = select_items_to_add(
                 state=state,

--- a/tests/_core/_cli/strategy_presets/test_init_presets.py
+++ b/tests/_core/_cli/strategy_presets/test_init_presets.py
@@ -21,7 +21,7 @@ def test_init_preset_properties(init_preset: InitPreset):
     assert isinstance(init_strat, InitializationStrategy)
     assert init_strat.__class__.__name__ == init_preset.class_name()
     assert isinstance(init_preset.class_kwargs(), dict)
-    assert all(isinstance(k, str) for k in init_preset.class_kwargs().keys())
+    assert all(isinstance(k, str) for k in init_preset.class_kwargs())
 
     assert isinstance(init_preset.is_constraint_aware(), bool)
     assert isinstance(init_preset.is_relevant_for_problem(problem_has_constraints=True), bool)

--- a/tests/_core/_cli/strategy_presets/test_optim_presets.py
+++ b/tests/_core/_cli/strategy_presets/test_optim_presets.py
@@ -21,7 +21,7 @@ def test_optim_preset_properties(optim_preset: OptimPreset):
     assert isinstance(optim_strat, OptimizationStrategy)
     assert optim_strat.__class__.__name__ == optim_preset.class_name()
     assert isinstance(optim_preset.class_kwargs(), dict)
-    assert all(isinstance(k, str) for k in optim_preset.class_kwargs().keys())
+    assert all(isinstance(k, str) for k in optim_preset.class_kwargs())
 
     assert isinstance(optim_preset.is_constraint_aware(), bool)
     assert isinstance(optim_preset.is_relevant_for_problem(problem_has_constraints=True), bool)

--- a/tests/_core/_math/fast_pow/test_calibration.py
+++ b/tests/_core/_math/fast_pow/test_calibration.py
@@ -21,10 +21,7 @@ def test_calibrate_fast_pow(start_from_current: bool):
 
     # --- assert ------------------------------------------
 
-    if start_from_current:
-        tol = 0.05
-    else:
-        tol = 0.25
+    tol = 0.05 if start_from_current else 0.25
 
     # fast_log coefficients
     assert abs(c0 - c0_actual) <= tol

--- a/tests/_core/_random/_choice/test_choice_constrained.py
+++ b/tests/_core/_random/_choice/test_choice_constrained.py
@@ -67,10 +67,7 @@ def test_choice_constrained_invariants(eager: bool, n: int, k_context: int, unif
     values = [0, 1, 2, 3, 4, 10, 11, 12, 13, 14] + [round(i) for i in np.linspace(14, n - 1, 10)]
     values = np.array(sorted(set(values)), dtype=np.int32)
 
-    if uniform:
-        p = P_UNIFORM
-    else:
-        p = np.array(np.random.random(values.size), dtype=np.float32)  # random probabilities
+    p = P_UNIFORM if uniform else np.array(np.random.random(values.size), dtype=np.float32)
 
     # copies to check for modification later
     p_before = p.copy()

--- a/tests/_core/_random/_choice/test_choice_unconstrained.py
+++ b/tests/_core/_random/_choice/test_choice_unconstrained.py
@@ -28,10 +28,7 @@ def test_choice(n_values: int, k: int, replace: bool, uniform: bool) -> None:
     # --- arrange -----------------------------------------
     values = randint(10000, np.int32(n_values), replace=False, p=P_UNIFORM, rng_state=new_rng_state(42))
     values_set = set(values)
-    if uniform:
-        p = P_UNIFORM
-    else:
-        p = get_probabilities(values.size)
+    p = P_UNIFORM if uniform else get_probabilities(values.size)
     p_copy = p.copy()
     rng_state = new_rng_state(123456)
 
@@ -60,10 +57,7 @@ def test_choice1(n_values: int, k: int, uniform: bool) -> None:
     # --- arrange -----------------------------------------
     values = randint(10000, np.int32(n_values), replace=False, p=P_UNIFORM, rng_state=new_rng_state(42))
     values_set = set(values)
-    if uniform:
-        p = P_UNIFORM
-    else:
-        p = get_probabilities(values.size)
+    p = P_UNIFORM if uniform else get_probabilities(values.size)
     p_copy = p.copy()
     rng_state = new_rng_state(123456)
 

--- a/tests/_core/_random/_distributions/test_truncated_poisson.py
+++ b/tests/_core/_random/_distributions/test_truncated_poisson.py
@@ -54,7 +54,7 @@ def test_sample_truncated_poisson_distribution(min_value: int, max_value: int, _
 
     # --- act ---------------------------------------------
     rng_state = new_rng_state(np.int64(42))
-    for i in range(n_samples):
+    for _ in range(n_samples):
         sample = sample_truncated_poisson(
             min_value=np.int32(min_value),
             max_value=np.int32(max_value),

--- a/tests/_core/_random/_randint/test_randint.py
+++ b/tests/_core/_random/_randint/test_randint.py
@@ -155,8 +155,8 @@ def test_randint_uniform_with_replacement_rng_state(n: int, k: int, p: np.ndarra
     np.testing.assert_array_equal(samples_1, samples_2)
     if k >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
     # check p unmodified
     assert np.array_equal(p, p_before), "p array should never be modified."
@@ -233,8 +233,8 @@ def test_randint_uniform_without_replacement_rng_state(n: int, k: int, p: np.nda
     np.testing.assert_array_equal(samples_1, samples_2)
     if k >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
     # check p unmodified
     assert np.array_equal(p, p_before), "p array should never be modified."
@@ -328,8 +328,8 @@ def test_randint_non_uniform_with_replacement_rng_state(n: int, k: int):
     np.testing.assert_array_equal(samples_1, samples_2)
     if k >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
     # check p unmodified
     assert np.array_equal(p, p_before), "p array should never be modified."
@@ -430,8 +430,8 @@ def test_randint_non_uniform_without_replacement_rng_state(n: int, k: int):
     np.testing.assert_array_equal(samples_1, samples_2)
     if k >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
     # check p unmodified
     assert np.array_equal(p, p_before), "p array should never be modified."

--- a/tests/_core/_random/_randint/test_randint1_unconstrained.py
+++ b/tests/_core/_random/_randint/test_randint1_unconstrained.py
@@ -120,8 +120,8 @@ def test_randint1_uniform_rng_state(n: int, k: int, uniform: bool):
     np.testing.assert_array_equal(samples_1, samples_2)
     if k >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
     # check p unmodified
     assert np.array_equal(p, p_before), "p array should never be modified."

--- a/tests/_core/_random/_randint/test_randint_python.py
+++ b/tests/_core/_random/_randint/test_randint_python.py
@@ -131,8 +131,8 @@ def test_randint_python_uniform_with_replacement_seed(p: np.ndarray | None, n: i
     np.testing.assert_array_equal(samples_1, samples_2)
     if (k or 1) >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
 
 # =================================================================================================
@@ -200,8 +200,8 @@ def test_randint_python_uniform_without_replacement_seed(p: np.ndarray | None, n
     np.testing.assert_array_equal(samples_1, samples_2)
     if (k or 1) >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
 
 # =================================================================================================
@@ -288,8 +288,8 @@ def test_randint_python_non_uniform_with_replacement_seed(n: int, k: int | None)
     np.testing.assert_array_equal(samples_1, samples_2)
     if (k or 1) >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
     # check p unmodified
     assert np.array_equal(p, p_before), "p array should never be modified."
@@ -388,8 +388,8 @@ def test_randint_python_non_uniform_without_replacement_seed(n: int, k: int | No
     np.testing.assert_array_equal(samples_1, samples_2)
     if (k or 1) >= 10:
         # in this case, it's very unlikely that samples_3 matches samples_1 or samples_2
-        assert not list(samples_1) == list(samples_3)
-        assert not list(samples_2) == list(samples_3)
+        assert list(samples_1) != list(samples_3)
+        assert list(samples_2) != list(samples_3)
 
     # check p unmodified
     assert np.array_equal(p, p_before), "p array should never be modified."

--- a/tests/_core/_utils/test_stdout.py
+++ b/tests/_core/_utils/test_stdout.py
@@ -22,6 +22,5 @@ def test_stdout_to_file(tmp_path, enabled):
 
 def test_stdout_to_file_no_filename():
     # --- act & assert ------------------------------------
-    with pytest.raises(ValueError):
-        with stdout_to_file(enabled=True, filename=None):
-            pass
+    with pytest.raises(ValueError), stdout_to_file(enabled=True, filename=None):
+        pass

--- a/tests/_core/benchmark_problems/test_factory.py
+++ b/tests/_core/benchmark_problems/test_factory.py
@@ -16,10 +16,10 @@ def test_benchmark_problem_factory_get_all_benchmark_problems():
     # --- assert ------------------------------------------
     assert isinstance(problems_dict, dict)
     assert len(problems_dict) == 8  # number of built-in problems; adjust number as we add more
-    assert all(isinstance(name, str) for name in problems_dict.keys())
+    assert all(isinstance(name, str) for name in problems_dict)
     assert all(isinstance(cls, type) and issubclass(cls, BenchmarkProblem) for cls in problems_dict.values())
 
-    assert "all" not in [name.lower().strip() for name in problems_dict.keys()], (
+    assert "all" not in [name.lower().strip() for name in problems_dict], (
         "'all' should not be used as name, to avoid conflict with `benchmark solver run all` CLI command"
     )
 

--- a/tests/_core/problem/test_problem.py
+++ b/tests/_core/problem/test_problem.py
@@ -76,10 +76,7 @@ def test_problem_new_happy_path(con_type: str):
 )
 def test_problem_new_value_error(ndims: int, n: int, d: int, k: int):
     # --- arrange -----------------------------------------
-    if ndims == 1:
-        vectors = np.ones(100, dtype=np.float64)
-    else:
-        vectors = np.ones((n, d), dtype=np.float64)
+    vectors = np.ones(100, dtype=np.float64) if ndims == 1 else np.ones((n, d), dtype=np.float64)
 
     # --- act & assert ------------------------------------
     with pytest.raises(ValueError):

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -10,7 +10,7 @@ from max_div._core.solver._solver_state import SolverState, _build_con_membershi
 # =================================================================================================
 #  Fixtures
 # =================================================================================================
-@pytest.fixture(scope="function")
+@pytest.fixture
 def new_solver_state() -> SolverState:
     return SolverState.new(
         vectors=np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]], dtype=np.float32),
@@ -25,7 +25,7 @@ def new_solver_state() -> SolverState:
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def new_solver_state_unconstrained() -> SolverState:
     return SolverState.new(
         vectors=np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]], dtype=np.float32),


### PR DESCRIPTION
Final lint-expansion batch: enables SIM, B, N, PT, and the C901 complexity gate. Straightforward findings are fixed (ternaries, dict-key iteration, unused loop variables, negated comparisons); deliberate patterns get documented suppressions — benchmark closures invoked within their own loop iteration (B023), problem-ID class names (N801), calibration constant aliases (N811), numba typed-array defaults (B008), and ten case-dispatch functions over the complexity threshold. No behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)