### PR TITLE
chore: add codeql, scorecard, and a blocking pip-audit gate

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,41 @@
+name: CodeQL
+
+# Static analysis (SAST) for the Python package. Advisory, not blocking:
+# this is an independent security scanner, deliberately NOT part of the
+# `CI gate` aggregation — a code-scanning alert should surface without
+# failing an unrelated PR. Complements zizmor/actionlint (which lint the
+# workflows, not the package code).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 2"  # weekly, Tuesday 06:00 UTC — catches new query packs between PRs
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (python)
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload analysis results to code scanning
+      contents: read          # checkout
+      actions: read           # read workflow run metadata (CodeQL requirement)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          languages: python  # pure-Python package: no build step, CodeQL analyzes sources directly
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -86,6 +86,31 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_package_check.yml
 
+  # Synchronous dependency-CVE gate: audits the locked runtime dependencies
+  # against the advisory DB at PR time — the blocking complement to the async,
+  # repo-level Dependabot alerts. Hard-fails on any advisory; accepted ones go
+  # in `ignore-vulns` below with a justification.
+  pip-audit:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: ${{ vars.UV_VERSION }}
+      - name: Export the locked runtime dependencies
+        run: uv export --frozen --no-emit-project --no-dev --no-hashes --format requirements-txt -o requirements.txt
+      - uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
+        with:
+          inputs: requirements.txt
+          no-deps: "true"  # requirements.txt is already the full pinned closure
+          # Accepted/unfixable advisories go here (one id per line) with a reason:
+          # ignore-vulns: |
+          #   GHSA-xxxx-xxxx-xxxx  # why accepted
+
   ci-gate:
     name: CI gate
     # The single stable required check on main: branch protection requires only
@@ -93,7 +118,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, package]
+    needs: [preflight, pre-commit, test, package, pip-audit]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,46 @@
+name: Scorecard
+
+# OpenSSF Scorecard: continuously scores the repo's security posture (branch
+# protection, pinned dependencies, SAST presence, signed releases, …) and
+# publishes the result so the README badge stays live. It makes that posture
+# externally visible and tracked; it does not itself change any individual check.
+
+on:
+  workflow_dispatch:        # allow an on-demand re-score from the Actions tab
+  branch_protection_rule:   # re-score when branch-protection settings change
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 3"     # weekly, Wednesday 06:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # upload SARIF results to code scanning
+      id-token: write         # publish results to the public Scorecard API (OIDC)
+      contents: read          # checkout
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Run analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true  # required for the badge + the public scorecard.dev viewer
+      - name: Upload SARIF as an artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/max-div.svg)](https://pypi.org/project/max-div/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue)](https://github.com/bertpl/max-div/blob/main/LICENSE)
 [![code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230)](https://github.com/astral-sh/ruff)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bertpl/max-div/badge)](https://scorecard.dev/viewer/?uri=github.com/bertpl/max-div)
 <p>
   <img src="images/splash_with_version.webp" alt="max-div logo" style="max-width: max(60%, min(100%,800px)); height: auto;">
 </p>


### PR DESCRIPTION
Three scanners land at the fleet-standard seams: CodeQL (PR + main + weekly cron) and OpenSSF Scorecard (main + weekly cron, results published for the new README badge) run advisory — outside the `CI gate` aggregation, so a scanning alert surfaces without failing unrelated PRs. pip-audit audits the exported locked runtime closure as a blocking job in the PR pipeline, with a commented `ignore-vulns` slot for accepted advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)