### PR TITLE
docs: add contributing guide and security policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing to max-div
+
+Thanks for your interest in contributing.
+
+## Security
+
+Found a vulnerability? Please report it privately — see
+[`SECURITY.md`](SECURITY.md). Do not open a public issue for it.
+
+## Dev setup
+
+One-time setup on a fresh clone:
+
+```bash
+make dev-setup
+```
+
+This syncs dev dependencies via `uv` and installs pre-commit hooks.
+
+## Common commands
+
+```bash
+make test            # Run the test suite (pytest)
+make format          # Format and auto-fix with ruff
+make lint            # Run the full pre-commit hook suite over all files
+make coverage        # Run the test suite with an HTML coverage report
+```
+
+## Branching
+
+Branch names follow the pattern:
+
+```
+<prefix>/<short-slug>
+```
+
+- **Prefix** — one of `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`,
+  `test/`. CI rejects anything else.
+- **Slug** — short kebab-case description, lowercase letters, digits,
+  and hyphens only. When a GitHub issue exists, start the slug with its
+  number (`feat/42-...`).
+
+Examples: `chore/oss-scaffolding`, `feat/07-new-input-format`,
+`fix/12-solver-state-crash`.
+
+## Pull requests
+
+PRs are merged into `main` via **squash merge only** (repo settings
+disable merge commits and rebase merges). Each PR therefore produces
+exactly one commit on `main`. The squash commit subject is the PR
+title and the body is the PR body, so write both with care — they
+become the permanent history. The feature branch is deleted
+automatically on merge.
+
+## Commit messages
+
+Subject line uses the same short-form prefixes as branches:
+
+```
+<prefix>: <imperative summary>
+```
+
+- **Prefix** — `feat`, `fix`, `chore`, `docs`, `refactor`, `test`
+  (matching the branch prefix is the common case but not required).
+- **Summary** — imperative mood, lowercase, no trailing period,
+  ideally under 72 characters.
+
+Examples:
+
+```
+feat: add fairness-constraint presets
+fix: handle empty candidate set
+chore: bump numba floor
+docs: clarify separation-metric semantics
+```
+
+The body (optional) explains *why*, not *what*. Wrap at ~72 characters.
+
+## Changelog
+
+Add an entry under the appropriate category in the `## Unreleased` section
+of [`CHANGELOG.md`](CHANGELOG.md) as part of your PR. CI requires this for
+`feat/` and `fix/` branches.
+
+Changelog entries are **user-facing** — write them for someone deciding
+whether to upgrade, not for someone reviewing the implementation. Focus on
+what changed from the user's perspective.
+
+**Keep each entry to a single line.** Avoid verbosity; omit internal details
+(class names, wiring, refactors that don't affect behavior). Expand to a
+second line only when a single line genuinely can't convey what the change
+is about.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Supported versions
+
+max-div is pre-1.0 and ships frequent releases. Security fixes land in a
+new release on top of the latest published version; older versions are not
+patched in place.
+
+| Version          | Supported          |
+| ---------------- | ------------------ |
+| latest release   | :white_check_mark: |
+| any earlier      | :x:                |
+
+Always upgrade to the most recent release on
+[PyPI](https://pypi.org/project/max-div/) to receive security fixes.
+
+## Reporting a vulnerability
+
+Please report security issues **privately** — do not open a public issue,
+discussion, or pull request for a suspected vulnerability.
+
+Use GitHub's [Private Vulnerability Reporting](https://github.com/bertpl/max-div/security/advisories/new)
+to open a confidential advisory. This is the only supported reporting channel;
+the project publishes no maintainer email address.
+
+When reporting, please include:
+
+- the max-div version and Python version,
+- a description of the issue and its impact,
+- a minimal input or set of steps that reproduces it.
+
+## What to expect
+
+This is a solo-maintained project, so responses are best-effort:
+
+- **Acknowledgment** within 7 days.
+- **Initial assessment** (confirmed / needs-more-info / not-a-vulnerability)
+  within 14 days.
+- A fix released as soon as practical once an issue is confirmed, with the
+  advisory published alongside it.
+
+Please allow a reasonable window for a fix before any public disclosure.
+Coordinated disclosure is appreciated, and reporters are credited in the
+published advisory unless they prefer to remain anonymous.


### PR DESCRIPTION
CONTRIBUTING.md documents dev setup, branching, commit-message and squash-merge conventions, and the changelog policy that the CI changelog gate enforces. SECURITY.md establishes GitHub Private Vulnerability Reporting as the only reporting channel, with best-effort acknowledgment (≤7 days) and assessment (≤14 days) windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)