### PR TITLE
feat: add per-constraint weights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Per-constraint weights: each `Constraint` can be weighted (default 1) to scale its influence on feasibility scoring
 
 ### Changed
 

--- a/docs/concepts/constraints.md
+++ b/docs/concepts/constraints.md
@@ -8,6 +8,7 @@ from specific groups. Each constraint is defined by:
 - **`int_set`** -- a set of vector indices that form the group
 - **`min_count`** -- minimum number of vectors to select from this group
 - **`max_count`** -- maximum number of vectors to select from this group
+- **`weight`** -- how strongly this constraint counts toward feasibility (default `1`, must be `> 0`)
 
 ```python
 from max_div import Constraint
@@ -15,6 +16,23 @@ from max_div import Constraint
 # At least 3 and at most 7 vectors from indices 0-49
 Constraint(int_set=set(range(50)), min_count=3, max_count=7)
 ```
+
+## Weighting Constraints
+
+By default every constraint counts equally toward the feasibility score. Raise a constraint's
+`weight` above `1` to make the solver prioritize satisfying it over lower-weight constraints when
+they cannot all be satisfied at once:
+
+```python
+constraints = [
+    Constraint(int_set=must_have_indices, min_count=2, max_count=5, weight=3.0),  # prioritized
+    Constraint(int_set=nice_to_have_indices, min_count=1, max_count=4),           # weight 1
+]
+```
+
+A violation of a weight-3 constraint counts three times as much as an equal violation of a weight-1
+constraint. Weights must be strictly positive -- a zero weight would let a genuine violation go
+unpenalized and be reported as feasible.
 
 ## Overlapping Constraints
 

--- a/src/max_div/_core/constraints/_constraints.py
+++ b/src/max_div/_core/constraints/_constraints.py
@@ -56,11 +56,21 @@ from numpy.typing import NDArray
 # =================================================================================================
 @dataclass
 class Constraint:
-    """Constraint indicating we want to sample at least `min_count` and at most `max_count` integers from `int_set`."""
+    """Constraint indicating we want to sample at least `min_count` and at most `max_count` integers from `int_set`.
+
+    `weight` scales how strongly this constraint's violations count toward the feasibility score
+    (default 1); a larger weight makes the solver prioritize satisfying it over lower-weight constraints.
+    """
 
     int_set: set[int]
     min_count: int
     max_count: int
+    weight: float = 1.0
+
+    def __post_init__(self) -> None:
+        """Validate that the weight is strictly positive (a zero weight would hide a real violation)."""
+        if self.weight <= 0:
+            raise ValueError(f"Constraint weight must be > 0 (got {self.weight}).")
 
 
 class ConstraintList:

--- a/src/max_div/_core/solver/_score.py
+++ b/src/max_div/_core/solver/_score.py
@@ -151,7 +151,7 @@ class ScoreGenerator:
 
         # --- constraint score computation ------
         self._penalty_quadratic = penalty_quadratic
-        self._con_weights = np.ones(len(constraints), dtype=np.float32)  # per-constraint weights (all 1 for now)
+        self._con_weights = np.array([con.weight for con in constraints], dtype=np.float32)
         if len(constraints) > 0:
             max_con_violations = [
                 max(
@@ -164,8 +164,8 @@ class ScoreGenerator:
             self._con_c = _con_norm_constant(max_con_violations, self._con_weights, penalty_quadratic)
         else:
             self._con_c = 0.0  # no constraints -> always perfect score
-        # fast unweighted-linear aggregation applies while weights are all 1 and penalization is linear
-        self._use_fast_con_path = not penalty_quadratic
+        # fast unweighted-linear aggregation applies only when all weights are 1 and penalization is linear
+        self._use_fast_con_path = (not penalty_quadratic) and bool(np.all(self._con_weights == 1.0))
 
         # --- diversity & tie-breakers ----------
         self._diversity_metric = diversity_metric

--- a/tests/_core/constraints/test_constraints.py
+++ b/tests/_core/constraints/test_constraints.py
@@ -15,6 +15,21 @@ from max_div._core.constraints._constraints import (
 )
 
 
+def test_constraint_default_weight():
+    # --- act ---------------------------------------------
+    con = Constraint(int_set={0, 1}, min_count=1, max_count=2)
+
+    # --- assert ------------------------------------------
+    assert con.weight == 1.0
+
+
+@pytest.mark.parametrize("weight", [0, 0.0, -1.0, -0.001])
+def test_constraint_rejects_non_positive_weight(weight: float):
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError, match="weight must be > 0"):
+        Constraint(int_set={0, 1}, min_count=1, max_count=2, weight=weight)
+
+
 def test_build_array_repr():
     # --- arrange -----------------------------------------
     cons = [

--- a/tests/_core/solver/test_score.py
+++ b/tests/_core/solver/test_score.py
@@ -204,6 +204,32 @@ def test_score_generator_constraints_linear_vs_quadratic():
     assert con_quad == pytest.approx(1 - 8 / 30)  # 1 - (1/30)·(2² + 2²)
 
 
+def test_score_generator_constraints_weighted():
+    # --- arrange -----------------------------------------
+    # max_con_violations = [2, 5], weights = [1, 2] -> _con_c = 1 / (1 + 1·2 + 2·5) = 1/13
+    constraints = [
+        Constraint(int_set={0, 1, 2, 3, 4}, min_count=2, max_count=3),
+        Constraint(int_set=set(range(5, 16)), min_count=2, max_count=3, weight=2.0),
+    ]
+    gen = ScoreGenerator(
+        n=100, k=8, diversity_metric=DiversityMetric.MIN_SEPARATION, diversity_tie_breakers=[], constraints=constraints
+    )
+    sep = np.ones(5, dtype=np.float32)
+
+    # --- act ---------------------------------------------
+    con_violate_light = gen.compute_score(
+        8, np.array([[1, 3], [0, 1]], dtype=np.int32), sep
+    ).constraints  # con0 short 1
+    con_violate_heavy = gen.compute_score(
+        8, np.array([[0, 1], [1, 3]], dtype=np.int32), sep
+    ).constraints  # con1 short 1
+
+    # --- assert ------------------------------------------
+    assert con_violate_light == pytest.approx(1 - 1 / 13)
+    assert con_violate_heavy == pytest.approx(1 - 2 / 13)
+    assert con_violate_heavy < con_violate_light  # violating the higher-weight constraint hurts more
+
+
 def test_score_generator_constraints_no_constraints():
     # --- arrange -----------------------------------------
     generator = ScoreGenerator(


### PR DESCRIPTION
Adds an optional `weight` to `Constraint` (default 1, must be > 0) that scales how strongly its violations count toward the feasibility score — so the solver prioritizes satisfying higher-weight constraints when they cannot all be met at once. A zero or negative weight is rejected at construction, since it would let a genuine violation go unpenalized and be reported as feasible.

Weights feed the general scoring path introduced in the base PR; solves with all-default weights still take the integer fast path. Includes concept-doc coverage of weighting and exact-value scoring tests (equal violations of a weight-2 vs weight-1 constraint score differently, in the expected direction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)