### PR TITLE
feat: add configurable linear/quadratic constraint-violation penalty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Per-constraint weights: each `Constraint` can be weighted (default 1) to scale its influence on feasibility scoring
+- Constraint-violation penalty is now configurable as linear (default) or quadratic via `MaxDivSolverBuilder.with_constraint_penalty`
 
 ### Changed
 

--- a/docs/concepts/constraints.md
+++ b/docs/concepts/constraints.md
@@ -34,6 +34,26 @@ A violation of a weight-3 constraint counts three times as much as an equal viol
 constraint. Weights must be strictly positive -- a zero weight would let a genuine violation go
 unpenalized and be reported as feasible.
 
+## Penalizing Large Violations
+
+By default, a constraint's contribution to the score grows *linearly* with the size of its
+violation. Switch to *quadratic* penalization to push the solver harder away from large individual
+violations (preferring several small violations over one large one):
+
+```python
+from max_div import MaxDivSolverBuilder
+from max_div.solver import ConstraintPenalty
+
+solver = (
+    MaxDivSolverBuilder(problem)
+    .with_constraint_penalty(ConstraintPenalty.QUADRATIC)  # default is ConstraintPenalty.LINEAR
+    .with_preset(seconds(5))
+    .build()
+)
+```
+
+This is a single global setting for the whole solve, independent of any per-constraint weights.
+
 ## Overlapping Constraints
 
 A single vector can belong to multiple constraint groups. This is useful for modeling

--- a/src/max_div/_core/solver/__init__.py
+++ b/src/max_div/_core/solver/__init__.py
@@ -7,6 +7,7 @@ k: number of vectors to be selected
 m: number of (group) constraints imposed on the problem.
 """
 
+from ._constraint_penalty import ConstraintPenalty
 from ._duration import TargetDuration, TargetIterationCount, TargetTimeDuration, hours, iterations, minutes, seconds
 from ._presets import SolverPreset
 from ._score import Score

--- a/src/max_div/_core/solver/_constraint_penalty.py
+++ b/src/max_div/_core/solver/_constraint_penalty.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class ConstraintPenalty(StrEnum):
+    """How the magnitude of a constraint violation is penalized in the feasibility score.
+
+    Members
+    -------
+
+        - LINEAR:    Penalty proportional to the violation (default).
+        - QUADRATIC: Penalty proportional to the square of the violation, pushing the solver harder
+                     away from large individual constraint violations (relative to many small ones).
+    """
+
+    LINEAR = "linear"
+    QUADRATIC = "quadratic"

--- a/src/max_div/_core/solver/_solver.py
+++ b/src/max_div/_core/solver/_solver.py
@@ -5,6 +5,7 @@ from max_div._core.constraints import Constraint
 from max_div._core.constraints._constraints import _np_con_count_satisfied
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 
+from ._constraint_penalty import ConstraintPenalty
 from ._duration import Elapsed
 from ._progress_reporting import ProgressReporter
 from ._solution import MaxDivSolution
@@ -32,6 +33,7 @@ class MaxDivSolver:
         constraints: list[Constraint],
         solver_steps: list[SolverStep],
         seed: int = 42,
+        constraint_penalty: ConstraintPenalty = ConstraintPenalty.LINEAR,
     ) -> None:
         """Initialize the MaxDivSolver with the given configuration.
 
@@ -45,6 +47,7 @@ class MaxDivSolver:
                                        the first of which needs to be an InitializationStep,
                                        while all latter ones need to be OptimizationSteps.
         :param seed: (int) Random seed for the solver.
+        :param constraint_penalty: (ConstraintPenalty) How constraint violations are penalized (default: LINEAR).
         """
         # --- problem description -------------------------
         self._vectors = vectors
@@ -57,6 +60,7 @@ class MaxDivSolver:
         self._diversity_tie_breakers = diversity_tie_breakers
         self._solver_steps = solver_steps
         self._seed = seed
+        self._constraint_penalty = constraint_penalty
 
     # -------------------------------------------------------------------------
     #  API
@@ -114,6 +118,7 @@ class MaxDivSolver:
                 diversity_metric=self._diversity_metric,
                 diversity_tie_breakers=self._diversity_tie_breakers,
                 constraints=self._constraints,
+                penalty_quadratic=(self._constraint_penalty == ConstraintPenalty.QUADRATIC),
             )
             progress_reporter.solver_step_finished(None, state)
 

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Self
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 from max_div._core.problem import MaxDivProblem
 
+from ._constraint_penalty import ConstraintPenalty
 from ._duration import TargetDuration
 from ._presets import SolverPreset, get_preset_strategies
 from ._solver import MaxDivSolver
@@ -45,6 +46,7 @@ class MaxDivSolverBuilder:
             InitializationStep(InitializationStrategy.random_one_shot()),  # Default initialization strategy
         ]
         self._seed = 42
+        self._constraint_penalty: ConstraintPenalty = ConstraintPenalty.LINEAR
 
     # -------------------------------------------------------------------------
     #  Builder API
@@ -82,6 +84,11 @@ class MaxDivSolverBuilder:
     def with_seed(self, seed: int) -> Self:
         """Set the random seed for reproducibility (default: 42)."""
         self._seed = seed
+        return self
+
+    def with_constraint_penalty(self, penalty: ConstraintPenalty) -> Self:
+        """Set how constraint violations are penalized in the feasibility score (default: LINEAR)."""
+        self._constraint_penalty = penalty
         return self
 
     # -------------------------------------------------------------------------
@@ -152,4 +159,5 @@ class MaxDivSolverBuilder:
             constraints=self._constraints,
             solver_steps=self._solver_steps,
             seed=self._seed,
+            constraint_penalty=self._constraint_penalty,
         )

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -334,6 +334,7 @@ class SolverState:
         diversity_metric: DiversityMetric,
         diversity_tie_breakers: list[DiversityMetric],
         constraints: list[Constraint],
+        penalty_quadratic: bool = False,
     ) -> SolverState:
         # --- distances ---
         n = np.int32(vectors.shape[0])
@@ -355,6 +356,7 @@ class SolverState:
             diversity_metric=diversity_metric,
             diversity_tie_breakers=diversity_tie_breakers,
             constraints=constraints,
+            penalty_quadratic=penalty_quadratic,
         )
 
         # --- construct & return ---

--- a/src/max_div/solver.py
+++ b/src/max_div/solver.py
@@ -1,6 +1,7 @@
 """Public API for building and running Maximum Diversity solvers."""
 
 from ._core.solver import (
+    ConstraintPenalty,
     InitializationStrategy,
     MaxDivSolver,
     MaxDivSolverBuilder,
@@ -16,6 +17,7 @@ from ._core.solver import (
 )
 
 __all__ = [
+    "ConstraintPenalty",
     "InitializationStrategy",
     "MaxDivSolver",
     "MaxDivSolverBuilder",

--- a/tests/_core/solver/test_solver_builder.py
+++ b/tests/_core/solver/test_solver_builder.py
@@ -6,6 +6,7 @@ from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 from max_div._core.problem import MaxDivProblem
 from max_div._core.solver import (
+    ConstraintPenalty,
     MaxDivSolver,
     MaxDivSolverBuilder,
     SolverPreset,
@@ -181,6 +182,50 @@ def test_max_div_solver_builder_end_to_end():
     assert solver._diversity_metric == DiversityMetric.MIN_SEPARATION
     assert solver._constraints == constraints
     assert solver._seed == 123
+
+
+# =================================================================================================
+#  MaxDivSolverBuilder - Constraint penalty
+# =================================================================================================
+def test_solver_builder_constraint_penalty_default(dummy_problem):
+    # --- act ---------------------------------------------
+    solver = MaxDivSolverBuilder(dummy_problem).build()
+
+    # --- assert ------------------------------------------
+    assert solver._constraint_penalty == ConstraintPenalty.LINEAR
+
+
+def test_solver_builder_constraint_penalty_quadratic(dummy_problem):
+    # --- act ---------------------------------------------
+    solver = MaxDivSolverBuilder(dummy_problem).with_constraint_penalty(ConstraintPenalty.QUADRATIC).build()
+
+    # --- assert ------------------------------------------
+    assert solver._constraint_penalty == ConstraintPenalty.QUADRATIC
+
+
+def test_max_div_solver_quadratic_penalty_end_to_end():
+    # --- arrange -----------------------------------------
+    problem = MaxDivProblem.new(
+        vectors=np.random.rand(20, 5).astype(np.float32),
+        k=5,
+        diversity_metric=DiversityMetric.MIN_SEPARATION,
+        constraints=[Constraint(set(range(10)), min_count=2, max_count=3)],
+    )
+    solver = (
+        MaxDivSolverBuilder(problem)
+        .with_seed(7)
+        .with_preset(iterations(100))
+        .with_constraint_penalty(ConstraintPenalty.QUADRATIC)
+    ).build()
+
+    # --- act ---------------------------------------------
+    result = solver.solve(verbosity=0)
+
+    # --- assert ------------------------------------------
+    assert len(result.i_selected) == problem.k
+    score_after_initialization = result.score_checkpoints[1][2]
+    score_after_optimization = result.score_checkpoints[-1][2]
+    assert score_after_optimization >= score_after_initialization
 
 
 # =================================================================================================


### PR DESCRIPTION
Adds a global `ConstraintPenalty` setting (`LINEAR` default, `QUADRATIC`), configured via `MaxDivSolverBuilder.with_constraint_penalty(...)`, choosing how a constraint violation's *magnitude* is penalized in the feasibility score. Quadratic penalization pushes the solver harder away from large individual violations, preferring several small ones over one large one.

The enum is a solver-level config concept exported from `max_div.solver`; it threads builder → `MaxDivSolver` → `SolverState` → scoring, where it selects the general aggregation path introduced earlier in the stack (the boolean the scoring layer consumes). Presets are untouched — they emit only strategies, never scoring config. Default `LINEAR` preserves existing behavior exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)