### PR TITLE
refactor: compute pairwise distances directly in float32 via numba kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Pairwise distances are now computed directly in float32 instead of via a float64 matrix, cutting peak setup memory roughly 3x->1x on large problems
 
 ### Deprecated
 

--- a/src/max_div/_core/metrics/_distance/_compute.py
+++ b/src/max_div/_core/metrics/_distance/_compute.py
@@ -3,7 +3,6 @@
 import numba
 import numpy as np
 from numpy.typing import NDArray
-from scipy.spatial.distance import pdist as scipy_pdist
 
 from ._enum import DistanceMetric
 
@@ -12,24 +11,83 @@ from ._enum import DistanceMetric
 #  pdist computation
 # =================================================================================================
 def compute_pdist(vectors: NDArray[np.float32], metric: DistanceMetric) -> NDArray[np.float32]:
-    """Compute the pair-wise Euclidean distances between a set of n vectors in d dimensions.
+    """Compute the pair-wise distances between a set of n vectors in d dimensions.
 
-    NOTE: scipy's pdist always returns float64 arrays by default, even when input is float32.
-          This represents an inefficiency (both computational & memory), but is not expected to be dominant.
+    Computed directly in float32 by a numba kernel — each pair accumulates in float64 across the d
+    dimensions and narrows to float32 on store — avoiding the float64 distance matrix scipy would
+    otherwise materialize and cast (a ~3x transient in peak setup memory).
 
     :param vectors: (n x d ndarray) A set of n vectors in d dimensions.
     :param metric: (DistanceMetric) The distance metric to use.
-    :return: ((n*(n-1))/2 ndarray) condensed pair-wise distance vector,
-                                         with (i,j)-distance at index m*i + j - ((i+2)*(i+1))//2   for   i<j.
-                                              (i,j)-distance at index m*j + i - ((j+2)*(j+1))//2   for   i>j.
+    :return: ((n*(n-1))//2 ndarray) condensed pair-wise distance vector, in scipy's layout: the
+                                         (i,j)-distance for i<j sits at the offset given by `_pdist_index`.
     """
+    vectors = np.ascontiguousarray(vectors, dtype=np.float32)
+    n = vectors.shape[0]
+    out = np.empty((n * (n - 1)) // 2, dtype=np.float32)
     match metric:
         case DistanceMetric.L1_MANHATTAN:
-            return scipy_pdist(vectors, metric="cityblock").astype(np.float32)
+            _pdist_l1(vectors, out)
         case DistanceMetric.L2_EUCLIDEAN:
-            return scipy_pdist(vectors, metric="euclidean").astype(np.float32)
+            _pdist_l2(vectors, out)
         case DistanceMetric.L2S_EUCLIDEAN_SQUARED:
-            return scipy_pdist(vectors, metric="sqeuclidean").astype(np.float32)
+            _pdist_l2s(vectors, out)
+    return out
+
+
+# =================================================================================================
+#  pdist kernels
+# =================================================================================================
+@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True)
+def _l1_pair(vectors: NDArray[np.float32], i: int, j: int) -> np.float64:
+    """Return the L1 (Manhattan) distance between vectors i and j, accumulated in float64."""
+    acc = np.float64(0.0)
+    for c in range(vectors.shape[1]):
+        acc += abs(np.float64(vectors[i, c]) - np.float64(vectors[j, c]))
+    return acc
+
+
+@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True)
+def _l2sq_pair(vectors: NDArray[np.float32], i: int, j: int) -> np.float64:
+    """Return the squared L2 (Euclidean) distance between vectors i and j, accumulated in float64."""
+    acc = np.float64(0.0)
+    for c in range(vectors.shape[1]):
+        diff = np.float64(vectors[i, c]) - np.float64(vectors[j, c])
+        acc += diff * diff
+    return acc
+
+
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+def _pdist_l1(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
+    """Write the condensed L1 distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
+    n = vectors.shape[0]
+    idx = np.int64(0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            out[idx] = np.float32(_l1_pair(vectors, i, j))
+            idx += 1
+
+
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+def _pdist_l2(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
+    """Write the condensed L2 distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
+    n = vectors.shape[0]
+    idx = np.int64(0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            out[idx] = np.float32(np.sqrt(_l2sq_pair(vectors, i, j)))
+            idx += 1
+
+
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+def _pdist_l2s(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
+    """Write the condensed squared-L2 distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
+    n = vectors.shape[0]
+    idx = np.int64(0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            out[idx] = np.float32(_l2sq_pair(vectors, i, j))
+            idx += 1
 
 
 # =================================================================================================

--- a/tests/_core/metrics/test_distance_metric.py
+++ b/tests/_core/metrics/test_distance_metric.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy.spatial.distance import pdist as scipy_pdist
 from scipy.spatial.distance import squareform
 
 from max_div._core.metrics._distance import (
@@ -11,6 +12,12 @@ from max_div._core.metrics._distance import (
     update_separation_remove,
 )
 from max_div._core.metrics._distance._compute import _pdist_index
+
+_SCIPY_METRIC = {
+    "L1_MANHATTAN": "cityblock",
+    "L2_EUCLIDEAN": "euclidean",
+    "L2S_EUCLIDEAN_SQUARED": "sqeuclidean",
+}
 
 
 # -------------------------------------------------------------------------
@@ -50,6 +57,37 @@ def test_compute_pdist_values(metric: DistanceMetric, expected_value: float):
 
     # --- assert ------------------------------------------
     assert d[0] == pytest.approx(expected_value)
+
+
+@pytest.mark.parametrize("metric", list(DistanceMetric))
+def test_compute_pdist_matches_scipy(metric: DistanceMetric):
+    """The hand-rolled float32 kernel matches scipy's float64→float32 result within float32 tolerance."""
+
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(20260711)
+    vectors = rng.standard_normal((60, 8)).astype(np.float32)
+    expected = scipy_pdist(vectors, metric=_SCIPY_METRIC[metric.value]).astype(np.float32)
+
+    # --- act ---------------------------------------------
+    result = compute_pdist(vectors, metric=metric)
+
+    # --- assert ------------------------------------------
+    assert result.dtype == np.float32
+    np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("metric", list(DistanceMetric))
+def test_compute_pdist_zero_for_identical_vectors(metric: DistanceMetric):
+    """Identical vectors have exactly-zero distance under every metric."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([[1.5, -2.0, 3.0], [1.5, -2.0, 3.0], [4.0, 4.0, 4.0]], dtype=np.float32)
+
+    # --- act ---------------------------------------------
+    result = compute_pdist(vectors, metric=metric)
+
+    # --- assert ------------------------------------------
+    assert result[0] == np.float32(0.0)  # distance between the two identical vectors
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
Replaces the three scipy `pdist` calls — which build a float64 result and then `.astype(float32)`, holding both arrays live at ~3x the final condensed array — with hand-rolled `@njit` kernels (L1/L2/L2S) that accumulate each pair in float64 and store float32 directly. Peak setup memory drops to ~1x the final array.

Output is numerically equivalent to the scipy path, property-tested against `scipy_pdist(...).astype(float32)` for all three metrics; the full suite shows no seeded-solver drift.

Stacked on #46 (base branch `fix/0-7-1-1-pdist-index-int64`) — review/merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)