### PR TITLE
refactor: introduce dormant dirty-flag machinery for lazy score evaluation

### DIFF
--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -80,6 +80,7 @@ class SolverState:
         # scoring
         self._score_generator = score_generator  # READ-ONLY
         self._score: Score | None = None
+        self._score_dirty: bool = False  # when True, _score is stale and recomputed on next 'score' read
 
         # selection
         self._selected = selected
@@ -319,10 +320,13 @@ class SolverState:
             con_values=self._con_values,
             selected_separation_array=self.selected_separation_array,
         )
+        self._score_dirty = False
 
     @property
     def score(self) -> Score:
         """Return overall score of the current selection as a multi-component prioritized Score object."""
+        if self._score_dirty:
+            self._update_score()
         return self._score  # ty: ignore[invalid-return-type]  # always set via _update_score in __init__; hot path, so no assert
 
     # -------------------------------------------------------------------------

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -344,3 +344,20 @@ def test_solver_state_consistency_invariant(seed: int):
     for _ in range(60):
         snapshot_is_valid = _apply_random_operation(state, rng, snapshot_is_valid)
         _assert_state_matches_fresh_rebuild(state)
+
+
+def test_solver_state_score_lazy_recompute(new_solver_state):
+    # --- arrange -----------------------------------------
+    state = new_solver_state
+    state.add_many(np.array([0, 2, 4], dtype=np.int32))
+    expected_score = state.score
+
+    # --- act ---------------------------------------------
+    # force the lazy branch: invalidate the cached score and mark it dirty
+    state._score = None
+    state._score_dirty = True
+    observed_score = state.score
+
+    # --- assert ------------------------------------------
+    assert observed_score == expected_score  # recomputed on read
+    assert not state._score_dirty  # flag cleared by the recompute


### PR DESCRIPTION
Adds a `_score_dirty` flag to `SolverState` and makes the `score` property compute-if-dirty. All mutators still update the score eagerly, so the flag is never observed dirty in normal flow and behavior is literally unchanged (golden master untouched); the lazy branch is exercised by a dedicated unit test. This is pure infrastructure: a follow-up change flips the mutators to set the flag instead of recomputing, so never-read intermediate scores stop being computed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)