### PR TITLE
refactor: activate lazy score evaluation on solver-state mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Solver iterations no longer recompute the selection score when reverting a rejected swap (measured up to ~8% faster iterations for the GUIDED preset)
+- Solver iterations skip redundant selection-score computations (when reverting a rejected swap and for intermediate scores that are never read), measured up to ~18% faster iterations depending on preset and problem size
 
 ### Deprecated
 

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -152,6 +152,7 @@ class SolverState:
 
         # restore score (cached at set_snapshot time; avoids a full recompute)
         self._score = self._snapshot.score
+        self._score_dirty = False
 
         # clear snapshot after restoring
         self._snapshot.clear()
@@ -174,7 +175,7 @@ class SolverState:
         self._con_values[self._con_membership[index], :] -= 1
 
         # --- score ---------------------------------------
-        self._update_score()
+        self._score_dirty = True
 
     def add_many(self, indices: NDArray[np.int32]) -> None:
         # --- validation ----------------------------------
@@ -195,7 +196,7 @@ class SolverState:
             self._con_values[self._con_membership[index], :] -= 1
 
         # --- score ---------------------------------------
-        self._update_score()
+        self._score_dirty = True
 
     def remove(self, index: int | np.int32) -> None:
         # --- validation ----------------------------------
@@ -215,7 +216,7 @@ class SolverState:
         self._con_values[self._con_membership[index], :] += 1
 
         # --- score ---------------------------------------
-        self._update_score()
+        self._score_dirty = True
 
     def remove_many(self, indices: NDArray[np.int32]) -> None:
         # --- validation ----------------------------------
@@ -236,7 +237,7 @@ class SolverState:
             self._con_values[self._con_membership[index], :] += 1
 
         # --- score ---------------------------------------
-        self._update_score()
+        self._score_dirty = True
 
     # -------------------------------------------------------------------------
     #  Properties


### PR DESCRIPTION
Flips the four SolverState mutators from eager score recomputation to marking the score dirty; the score property recomputes on read (machinery introduced in the base branch), set_snapshot materializes via the property, and restore_snapshot reinstates the cached score with the flag cleared. The never-read post-removal score of a guided/random swap iteration is no longer computed, and smart-swaps probes compute exactly one score per probe. Output is bit-identical (golden master unchanged). Cumulative measured effect (with the snapshot score cache): up to ~18% faster iterations (GUIDED, n=1000), shrinking with problem size; ~14% for SMART. Changelog entry updated to the cumulative figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)