### PR TITLE
feat: add cosine distance metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Cosine distance metric (`DistanceMetric.COSINE`) for embedding-style workloads
 
 ### Changed
 

--- a/docs/concepts/diversity.md
+++ b/docs/concepts/diversity.md
@@ -29,6 +29,7 @@ The distance metric determines how the distance between two vectors is measured.
 | `L2_EUCLIDEAN` | $$d = \sqrt{\sum_i (x_i - y_i)^2}$$ | Standard Euclidean distance. Default. |
 | `L1_MANHATTAN` | $$d = \sum_i \lvert x_i - y_i \rvert$$ | Less sensitive to outlier dimensions. |
 | `L2S_EUCLIDEAN_SQUARED` | $$d = \sum_i (x_i - y_i)^2$$ | Avoids the square root. Produces identical solutions to `L2_EUCLIDEAN` when used with `GEOMEAN_SEPARATION`, since the geometric mean preserves distance ordering regardless of squaring. |
+| `COSINE` | $$d = 1 - \frac{x \cdot y}{\lVert x \rVert \, \lVert y \rVert}$$ | Angular distance in $[0, 2]$, invariant to vector magnitude -- the natural choice for embedding-style vectors. Undefined for zero vectors, which are rejected at problem construction. |
 
 ## Separation
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -127,6 +127,7 @@ problem = MaxDivProblem.new(
     distance_metric=DistanceMetric.L2_EUCLIDEAN,       # default
     # distance_metric=DistanceMetric.L1_MANHATTAN,
     # distance_metric=DistanceMetric.L2S_EUCLIDEAN_SQUARED,
+    # distance_metric=DistanceMetric.COSINE,
 )
 ```
 
@@ -135,6 +136,7 @@ problem = MaxDivProblem.new(
 | `L2_EUCLIDEAN` | Standard Euclidean distance (default) |
 | `L1_MANHATTAN` | Sum of absolute differences |
 | `L2S_EUCLIDEAN_SQUARED` | Squared Euclidean -- avoids the square root, produces identical solutions when used with `GEOMEAN_SEPARATION` |
+| `COSINE` | Cosine distance (1 &minus; cosine similarity) -- angular, magnitude-invariant, for embedding-style vectors; zero vectors are rejected |
 
 ### Diversity metrics
 

--- a/src/max_div/_core/metrics/__init__.py
+++ b/src/max_div/_core/metrics/__init__.py
@@ -1,2 +1,2 @@
-from ._distance import DistanceMetric
+from ._distance import DistanceMetric, validate_cosine_vectors
 from ._diversity import DiversityMetric

--- a/src/max_div/_core/metrics/_distance/__init__.py
+++ b/src/max_div/_core/metrics/_distance/__init__.py
@@ -1,2 +1,9 @@
-from ._compute import compute_pdist, compute_separation, get_pdist_el, update_separation_add, update_separation_remove
+from ._compute import (
+    compute_pdist,
+    compute_separation,
+    get_pdist_el,
+    update_separation_add,
+    update_separation_remove,
+    validate_cosine_vectors,
+)
 from ._enum import DistanceMetric

--- a/src/max_div/_core/metrics/_distance/_compute.py
+++ b/src/max_div/_core/metrics/_distance/_compute.py
@@ -32,7 +32,22 @@ def compute_pdist(vectors: NDArray[np.float32], metric: DistanceMetric) -> NDArr
             _pdist_l2(vectors, out)
         case DistanceMetric.L2S_EUCLIDEAN_SQUARED:
             _pdist_l2s(vectors, out)
+        case DistanceMetric.COSINE:
+            validate_cosine_vectors(vectors)
+            _pdist_cos(vectors, out)
     return out
+
+
+def validate_cosine_vectors(vectors: NDArray[np.float32]) -> None:
+    """Raise ValueError if any vector is all-zero — cosine distance is undefined for zero vectors.
+
+    :param vectors: (n x d ndarray) A set of n vectors in d dimensions.
+    """
+    zero_rows = np.flatnonzero(~vectors.any(axis=1))
+    if zero_rows.size > 0:
+        raise ValueError(
+            f"Cosine distance is undefined for zero vectors; found an all-zero vector at row {zero_rows[0]}."
+        )
 
 
 # =================================================================================================
@@ -87,6 +102,36 @@ def _pdist_l2s(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
     for i in range(n):
         for j in range(i + 1, n):
             out[idx] = np.float32(_l2sq_pair(vectors, i, j))
+            idx += 1
+
+
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+def _pdist_cos(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
+    """Write the condensed cosine distances of `vectors` into pre-allocated `out`, in condensed i<j order.
+
+    Computed as ``0.5 * ||x^ - y^||^2`` on unit-normalized vectors, which equals ``1 - cos(x, y)``
+    algebraically but — unlike the dot-product form — is non-negative by construction and exactly
+    0.0 for identical vectors. Rows are normalized once (norm accumulated in float64) into a
+    float32 scratch array, so the pair loop reuses the squared-L2 accumulation.
+
+    Vectors must contain no all-zero rows (`validate_cosine_vectors` guards the public entry point).
+    """
+    n = vectors.shape[0]
+    d = vectors.shape[1]
+    # --- normalize rows --------------------------
+    normalized = np.empty((n, d), dtype=np.float32)
+    for i in range(n):
+        acc = np.float64(0.0)
+        for c in range(d):
+            acc += np.float64(vectors[i, c]) * np.float64(vectors[i, c])
+        norm = np.sqrt(acc)
+        for c in range(d):
+            normalized[i, c] = np.float32(np.float64(vectors[i, c]) / norm)
+    # --- pairwise distances ----------------------
+    idx = np.int64(0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            out[idx] = np.float32(0.5 * _l2sq_pair(normalized, i, j))
             idx += 1
 
 

--- a/src/max_div/_core/metrics/_distance/_enum.py
+++ b/src/max_div/_core/metrics/_distance/_enum.py
@@ -12,8 +12,12 @@ class DistanceMetric(StrEnum):
         - L2S_EUCLIDEAN_SQUARED:   L2 squared (Euclidean squared) distance   = sum_i (x_i - y_i)^2
                                           --> avoids computing square root
                                           --> and produces identical solutions for GEOMEAN_SEPARATION diversity metric
+        - COSINE:                  cosine distance                           = 1 - (x . y) / (|x| |y|)
+                                          --> range [0, 2]; angular, for embedding-style vectors
+                                          --> undefined for zero vectors (rejected with an error)
     """
 
     L1_MANHATTAN = "L1_MANHATTAN"
     L2_EUCLIDEAN = "L2_EUCLIDEAN"
     L2S_EUCLIDEAN_SQUARED = "L2S_EUCLIDEAN_SQUARED"
+    COSINE = "COSINE"

--- a/src/max_div/_core/problem/_problem.py
+++ b/src/max_div/_core/problem/_problem.py
@@ -4,7 +4,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from max_div._core.constraints import Constraint
-from max_div._core.metrics import DistanceMetric, DiversityMetric
+from max_div._core.metrics import DistanceMetric, DiversityMetric, validate_cosine_vectors
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +69,8 @@ class MaxDivProblem:
             raise ValueError("Vectors must have at least one dimension.")
         if vectors.dtype != np.float32:
             vectors = vectors.astype(np.float32)
+        if distance_metric == DistanceMetric.COSINE:
+            validate_cosine_vectors(vectors)  # fail fast: zero vectors have no defined angle
 
         if not (2 <= k <= vectors.shape[0]):
             raise ValueError(f"k must be in range [2, number of vectors (={vectors.shape[0]})]; here: {k}.")

--- a/tests/_core/metrics/test_distance_metric.py
+++ b/tests/_core/metrics/test_distance_metric.py
@@ -17,6 +17,7 @@ _SCIPY_METRIC = {
     "L1_MANHATTAN": "cityblock",
     "L2_EUCLIDEAN": "euclidean",
     "L2S_EUCLIDEAN_SQUARED": "sqeuclidean",
+    "COSINE": "cosine",
 }
 
 
@@ -28,7 +29,8 @@ def test_compute_pdist_metrics(metric: DistanceMetric):
     """Check if compute_pdist implements all metrics."""
 
     # --- arrange -----------------------------------------
-    vectors = np.array([[0, 0], [3, 4], [1, 0], [0, 1]], dtype=np.float32)
+    # note: no all-zero row — COSINE rejects zero vectors
+    vectors = np.array([[2, 2], [3, 4], [1, 0], [0, 1]], dtype=np.float32)
 
     # --- act ---------------------------------------------
     d = compute_pdist(vectors, metric=metric)
@@ -74,6 +76,39 @@ def test_compute_pdist_matches_scipy(metric: DistanceMetric):
     # --- assert ------------------------------------------
     assert result.dtype == np.float32
     np.testing.assert_allclose(result, expected, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize(
+    "x, y, expected_value",
+    [
+        ([1, 0], [0, 1], 1.0),  # orthogonal
+        ([1, 0], [-1, 0], 2.0),  # opposite
+        ([1, 0], [1, 1], 1.0 - 1.0 / np.sqrt(2.0)),  # 45 degrees
+        ([1, 0], [100, 0], 0.0),  # parallel: magnitude-invariant
+    ],
+)
+def test_compute_pdist_cosine_values(x: list[float], y: list[float], expected_value: float):
+    """Cosine distance produces the expected angular values."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([x, y], dtype=np.float32)
+
+    # --- act ---------------------------------------------
+    d = compute_pdist(vectors, metric=DistanceMetric.COSINE)
+
+    # --- assert ------------------------------------------
+    assert d[0] == pytest.approx(expected_value, abs=1e-6)
+
+
+def test_compute_pdist_cosine_zero_vector_raises():
+    """Cosine distance rejects all-zero vectors with a clear error naming the row."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([[1, 2], [0, 0], [3, 4]], dtype=np.float32)
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match=r"zero vector.*row 1"):
+        compute_pdist(vectors, metric=DistanceMetric.COSINE)
 
 
 @pytest.mark.parametrize("metric", list(DistanceMetric))

--- a/tests/_core/problem/test_problem.py
+++ b/tests/_core/problem/test_problem.py
@@ -81,3 +81,29 @@ def test_problem_new_value_error(ndims: int, n: int, d: int, k: int):
     # --- act & assert ------------------------------------
     with pytest.raises(ValueError):
         _ = MaxDivProblem.new(vectors, k)
+
+
+def test_problem_new_cosine_zero_vector_raises():
+    """COSINE problems reject all-zero vectors at construction time."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.ones((10, 3), dtype=np.float32)
+    vectors[4, :] = 0.0
+
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError, match=r"zero vector.*row 4"):
+        _ = MaxDivProblem.new(vectors, k=3, distance_metric=DistanceMetric.COSINE)
+
+
+def test_problem_new_cosine_non_zero_vectors_ok():
+    """COSINE problems accept vector sets without zero rows."""
+
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(20260713)
+    vectors = rng.standard_normal((10, 3)).astype(np.float32)
+
+    # --- act ---------------------------------------------
+    problem = MaxDivProblem.new(vectors, k=3, distance_metric=DistanceMetric.COSINE)
+
+    # --- assert ------------------------------------------
+    assert problem.distance_metric == DistanceMetric.COSINE


### PR DESCRIPTION
Adds `DistanceMetric.COSINE` for embedding-style workloads: angular, magnitude-invariant, range [0, 2]. Implemented as a dedicated numba kernel that unit-normalizes rows once and computes half the squared Euclidean distance of the normalized vectors — algebraically 1 − cos(x, y), but non-negative by construction and exactly zero for identical vectors. Zero vectors (undefined angle) are rejected with a clear error at problem construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)