### PR TITLE
refactor: add per-point distance-sum kernels

### DIFF
--- a/src/max_div/_core/metrics/_distance/__init__.py
+++ b/src/max_div/_core/metrics/_distance/__init__.py
@@ -1,7 +1,10 @@
 from ._compute import (
+    compute_distance_sums,
     compute_pdist,
     compute_separation,
     get_pdist_el,
+    update_distance_sums_add,
+    update_distance_sums_remove,
     update_separation_add,
     update_separation_remove,
     validate_cosine_vectors,

--- a/src/max_div/_core/metrics/_distance/_compute.py
+++ b/src/max_div/_core/metrics/_distance/_compute.py
@@ -206,3 +206,46 @@ def update_separation_remove(
                         if dist_jk < new_sep_j:
                             new_sep_j = dist_jk
                 sep[j] = new_sep_j
+
+
+# =================================================================================================
+#  Distance sums
+# =================================================================================================
+# Per-point sums of distances to a selection — the pairwise-distance counterpart of the separation
+# kernels above.  Sums accumulate in float64: entries undergo long add/subtract chains over solver
+# iterations, and float32 drift there would change scores with iteration count.  Distances of a
+# point to itself are 0, so a point's own entry never needs special-casing: it always equals the
+# sum of its distances to the *other* selected points.
+@numba.njit("float64[::1](float32[::1], int32)", cache=True)
+def compute_distance_sums(pdist: NDArray[np.float32], n: np.int32) -> NDArray[np.float64]:
+    """Compute sum of distances of each vector wrt all others, given pairwise distance array pdist and n vectors."""
+    dist_sums = np.zeros(n, dtype=np.float64)
+    pdist_idx = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            # note: the way we iterate over i & j represents the exact order in which pdist stores distances
+            dist_ij = np.float64(pdist[pdist_idx])
+            pdist_idx += 1
+            dist_sums[i] += dist_ij
+            dist_sums[j] += dist_ij
+    return dist_sums
+
+
+@numba.njit("void(float64[::1], float32[::1], int32, int32)", cache=True)
+def update_distance_sums_add(
+    dist_sums: NDArray[np.float64], pdist: NDArray[np.float32], n: np.int32, i_added: np.int32
+) -> None:
+    """Update distance sums of each vector wrt selection, given pdist array and n vectors, after adding i_added."""
+    for j in np.arange(n, dtype=np.int32):
+        if j != i_added:
+            dist_sums[j] += np.float64(get_pdist_el(pdist, i_added, j, n))
+
+
+@numba.njit("void(float64[::1], float32[::1], int32, int32)", cache=True)
+def update_distance_sums_remove(
+    dist_sums: NDArray[np.float64], pdist: NDArray[np.float32], n: np.int32, i_removed: np.int32
+) -> None:
+    """Update distance sums of each vector wrt selection, given pdist array and n vectors, after removing i_removed."""
+    for j in np.arange(n, dtype=np.int32):
+        if j != i_removed:
+            dist_sums[j] -= np.float64(get_pdist_el(pdist, i_removed, j, n))

--- a/tests/_core/metrics/test_distance_metric.py
+++ b/tests/_core/metrics/test_distance_metric.py
@@ -5,9 +5,12 @@ from scipy.spatial.distance import squareform
 
 from max_div._core.metrics._distance import (
     DistanceMetric,
+    compute_distance_sums,
     compute_pdist,
     compute_separation,
     get_pdist_el,
+    update_distance_sums_add,
+    update_distance_sums_remove,
     update_separation_add,
     update_separation_remove,
 )
@@ -274,3 +277,74 @@ def test_update_separation_remove():
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(separation, expected_separation)
+
+
+# -------------------------------------------------------------------------
+#  Distance sums
+# -------------------------------------------------------------------------
+def test_compute_distance_sums():
+    """Check if compute_distance_sums matches a brute-force row-sum of the full distance matrix."""
+
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(20260713)
+    vectors = rng.standard_normal((30, 4)).astype(np.float32)
+    m = vectors.shape[0]
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+    expected = squareform(d).astype(np.float64).sum(axis=1)
+
+    # --- act ---------------------------------------------
+    dist_sums = compute_distance_sums(d, np.int32(m))
+
+    # --- assert ------------------------------------------
+    assert dist_sums.dtype == np.float64
+    np.testing.assert_allclose(dist_sums, expected, rtol=1e-6)
+
+
+def test_update_distance_sums_add_remove():
+    """Incremental add/remove updates match brute-force sums over the selection at every step."""
+
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(20260713)
+    vectors = rng.standard_normal((20, 3)).astype(np.float32)
+    m = vectors.shape[0]
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+    d_squared = squareform(d).astype(np.float64)
+
+    dist_sums = np.zeros(m, dtype=np.float64)
+    selection: list[int] = []
+
+    def expected_sums() -> np.ndarray:
+        # brute-force: each point's sum of distances to the selected points (self-distance is 0)
+        return d_squared[:, selection].sum(axis=1) if selection else np.zeros(m, dtype=np.float64)
+
+    # --- act / assert ------------------------------------
+    for index in [3, 17, 0, 9, 12]:
+        update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(index))
+        selection.append(index)
+        np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
+
+    for index in [0, 3, 12]:
+        update_distance_sums_remove(dist_sums, d, np.int32(m), np.int32(index))
+        selection.remove(index)
+        np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
+
+
+def test_update_distance_sums_own_entry_untouched():
+    """A point's own entry is unchanged by adding/removing that point (its self-distance is 0)."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0, 0], [3, 4], [1, 0], [0, 2]], dtype=np.float32)
+    m = vectors.shape[0]
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+    dist_sums = np.zeros(m, dtype=np.float64)
+
+    # selection {1}: point 1's own entry stays 0 (no other selected points yet)
+    update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(1))
+    assert dist_sums[1] == 0.0
+
+    # --- act ---------------------------------------------
+    # selection {1, 2}: point 2's own entry must equal its distance to point 1 only
+    update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(2))
+
+    # --- assert ------------------------------------------
+    assert dist_sums[2] == pytest.approx(squareform(d)[2, 1])


### PR DESCRIPTION
Adds numba kernels that incrementally maintain each point's sum of distances to a selection, plus a whole-dataset row-sum variant — the pairwise-distance counterpart of the existing separation kernels. Sums accumulate in float64 so long add/subtract chains stay drift-free; a point's own entry needs no special-casing since its self-distance is 0. Nothing consumes these yet; they are groundwork for tracking pairwise-distance diversity incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)