### PR TITLE
refactor: add dormant MeanDistanceTracker and per-metric tracker construction

### DIFF
--- a/src/max_div/_core/metrics/__init__.py
+++ b/src/max_div/_core/metrics/__init__.py
@@ -1,2 +1,2 @@
 from ._distance import DistanceMetric, validate_cosine_vectors
-from ._diversity import DiversityMetric
+from ._diversity import DiversityMetric, DiversitySignalFamily

--- a/src/max_div/_core/metrics/_diversity/__init__.py
+++ b/src/max_div/_core/metrics/_diversity/__init__.py
@@ -1,1 +1,1 @@
-from ._enum import DiversityMetric
+from ._enum import DiversityMetric, DiversitySignalFamily

--- a/src/max_div/_core/metrics/_diversity/_enum.py
+++ b/src/max_div/_core/metrics/_diversity/_enum.py
@@ -6,6 +6,20 @@ import numpy as np
 from numpy.typing import NDArray
 
 
+class DiversitySignalFamily(StrEnum):
+    """Enum for the per-point diversity-signal families that diversity metrics consume.
+
+    Members
+    -------
+
+        - SEPARATION:     signal = distance to the nearest selected vector
+        - MEAN_DISTANCE:  signal = mean distance to the selected vectors
+    """
+
+    SEPARATION = "SEPARATION"
+    MEAN_DISTANCE = "MEAN_DISTANCE"
+
+
 class DiversityMetric(StrEnum):
     """Enum for different diversity metrics.
 
@@ -25,6 +39,11 @@ class DiversityMetric(StrEnum):
     GEOMEAN_SEPARATION = "GEOMEAN_SEPARATION"
     APPROX_GEOMEAN_SEPARATION = "APPROX_GEOMEAN_SEPARATION"
     NON_ZERO_SEPARATION_FRAC = "NON_ZERO_SEPARATION_FRAC"
+
+    @cached_property
+    def signal_family(self) -> DiversitySignalFamily:
+        """Return the diversity-signal family whose per-point values this metric consumes."""
+        return DiversitySignalFamily.SEPARATION
 
     @cached_property
     def _f(self) -> Callable[[NDArray[np.float32]], np.float32]:

--- a/src/max_div/_core/solver/_signals/__init__.py
+++ b/src/max_div/_core/solver/_signals/__init__.py
@@ -1,2 +1,4 @@
 from ._base import DiversitySignalTracker
+from ._factory import build_tracker
+from ._mean_distance import MeanDistanceTracker
 from ._separation import SeparationTracker

--- a/src/max_div/_core/solver/_signals/_factory.py
+++ b/src/max_div/_core/solver/_signals/_factory.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from max_div._core.metrics import DiversitySignalFamily
+
+from ._mean_distance import MeanDistanceTracker
+from ._separation import SeparationTracker
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+    from ._base import DiversitySignalTracker
+
+
+def build_tracker(family: DiversitySignalFamily, pdist: NDArray[np.float32], n: np.int32) -> DiversitySignalTracker:
+    """Build a fresh (empty-selection) diversity-signal tracker for the given signal family.
+
+    :param family: (DiversitySignalFamily) the signal family to track.
+    :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
+    :param n: (np.int32) number of vectors
+    """
+    match family:
+        case DiversitySignalFamily.SEPARATION:
+            return SeparationTracker(pdist, n)
+        case DiversitySignalFamily.MEAN_DISTANCE:
+            return MeanDistanceTracker(pdist, n)

--- a/src/max_div/_core/solver/_signals/_mean_distance.py
+++ b/src/max_div/_core/solver/_signals/_mean_distance.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from max_div._core.metrics._distance import (
+    compute_distance_sums,
+    update_distance_sums_add,
+    update_distance_sums_remove,
+)
+
+from ._base import DiversitySignalTracker
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+# =================================================================================================
+#  MeanDistanceTracker
+# =================================================================================================
+class MeanDistanceTracker(DiversitySignalTracker):
+    """Diversity-signal tracker of the mean-distance family: signal = mean distance to selected points.
+
+    Internally tracks *raw sums* of distances in float64 — incremental updates stay exact add/subtract
+    arithmetic, free of the rescaling (and rounding) that maintaining means directly would need.  Signal
+    reads expose *mean form* (sum / number of selected neighbors), so values stay in the same "an average
+    distance" unit as other signal families, and are returned as float32 like all exposed signal arrays.
+
+    The number of selected neighbors is membership-aware: a selected point's own zero self-distance is
+    not a neighbor, so its divisor is one less than a non-selected point's.  For points with no selected
+    neighbor the signal is 0.  The global signal is each point's mean distance to all other points.
+    """
+
+    # -------------------------------------------------------------------------
+    #  Construction & copy
+    # -------------------------------------------------------------------------
+    def __init__(
+        self,
+        pdist: NDArray[np.float32],
+        n: np.int32,
+        global_signal: NDArray[np.float32] | None = None,
+        dist_sums: NDArray[np.float64] | None = None,
+    ) -> None:
+        """Initialize the MeanDistanceTracker for an empty selection.
+
+        :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
+        :param n: (np.int32) number of vectors
+        :param global_signal: (np.ndarray[np.float32] | None) precomputed global signal; computed if omitted.
+        :param dist_sums: (np.ndarray[np.float64] | None) current distance sums wrt selection; fresh (all 0.0,
+                          i.e. empty selection) if omitted.  Together with `global_signal` this enables copies
+                          without recomputation.
+        """
+        self._pdist = pdist  # READ-ONLY
+        self._n = n  # READ-ONLY
+        if global_signal is not None:
+            self._global_signal = global_signal  # READ-ONLY
+        else:
+            self._global_signal = (compute_distance_sums(pdist, n) / max(int(n) - 1, 1)).astype(np.float32)
+        self._dist_sums = dist_sums if dist_sums is not None else np.zeros(n, dtype=np.float64)
+        self._snapshot_dist_sums: NDArray[np.float64] = _EMPTY_NP_ARRAY_FLOAT64
+
+    def copy(self) -> MeanDistanceTracker:
+        """Return a deep copy of this tracker (without recomputing the global signal)."""
+        return MeanDistanceTracker(
+            pdist=self._pdist.copy(),
+            n=self._n,
+            global_signal=self._global_signal.copy(),
+            dist_sums=self._dist_sums.copy(),
+        )
+
+    # -------------------------------------------------------------------------
+    #  Signal reads
+    # -------------------------------------------------------------------------
+    def full_signal(self, selected: NDArray[np.bool], n_selected: np.int32) -> NDArray[np.float32]:
+        """Return mean distance of all points wrt the current selection (freshly allocated array)."""
+        # per-point divisor: number of selected neighbors — a selected point's own 0-distance is not a neighbor
+        divisor = np.maximum(n_selected - selected, 1)  # bool subtraction; clip avoids 0/0 for empty neighborhoods
+        return (self._dist_sums / divisor).astype(np.float32)
+
+    @property
+    def global_signal(self) -> NDArray[np.float32]:
+        """Return mean distance of all points wrt all other points (reference; do not modify)."""
+        return self._global_signal
+
+    # -------------------------------------------------------------------------
+    #  Mutations
+    # -------------------------------------------------------------------------
+    def add(self, index: np.int32) -> None:
+        """Update distance sums after adding point `index` to the selection."""
+        update_distance_sums_add(self._dist_sums, self._pdist, self._n, index)
+
+    def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
+        """Update distance sums after removing point `index`.
+
+        `new_selection` is not needed by this tracker: removal is exact subtraction.
+        """
+        update_distance_sums_remove(self._dist_sums, self._pdist, self._n, index)
+
+    # -------------------------------------------------------------------------
+    #  Snapshot
+    # -------------------------------------------------------------------------
+    def set_snapshot(self) -> None:
+        """Save a copy of the current distance sums, overwriting any previous snapshot."""
+        self._snapshot_dist_sums = self._dist_sums.copy()
+
+    def restore_snapshot(self) -> None:
+        """Restore the distance sums saved by the last `set_snapshot` call and invalidate the snapshot."""
+        # no copy needed: the snapshot slot is cleared, so the restored array cannot alias a live snapshot
+        self._dist_sums = self._snapshot_dist_sums
+        self._snapshot_dist_sums = _EMPTY_NP_ARRAY_FLOAT64
+
+
+# singleton to avoid repeated, unnecessary allocations for the invalid-snapshot placeholder
+_EMPTY_NP_ARRAY_FLOAT64 = np.array([], dtype=np.float64)

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -10,12 +10,14 @@ import numpy as np
 from max_div._core.constraints import Constraint, ConstraintList
 
 from ._score import Score, ScoreGenerator
-from ._signals import DiversitySignalTracker, SeparationTracker
+from ._signals import build_tracker
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from max_div._core.metrics import DiversityMetric
+    from max_div._core.metrics import DiversityMetric, DiversitySignalFamily
+
+    from ._signals import DiversitySignalTracker
 
 
 # =================================================================================================
@@ -31,7 +33,8 @@ class SolverState:
         self,
         n: np.int32,
         k: np.int32,
-        signal_tracker: DiversitySignalTracker,
+        signal_trackers: dict[DiversitySignalFamily, DiversitySignalTracker],
+        main_signal_family: DiversitySignalFamily,
         score_generator: ScoreGenerator,
         selected: NDArray[np.bool],
         con_values: NDArray[np.int32],
@@ -44,14 +47,18 @@ class SolverState:
 
             n  : total number of vectors
           ( d  : dimensionality of each vector  (not visible here, since distances are pre-digested
-                 into the signal tracker) )
+                 into the signal trackers) )
             k  : target selection size
             m : number of constraints
 
         :param n: (np.int32) number of vectors
         :param k: (np.int32) target number of selected vectors
-        :param signal_tracker: (DiversitySignalTracker) per-point diversity-signal tracking, incrementally
-                               updated on every selection mutation.
+        :param signal_trackers: (dict[DiversitySignalFamily, DiversitySignalTracker]) per-point diversity-signal
+                                tracking, one tracker per signal family needed by the configured metrics; all are
+                                incrementally updated on every selection mutation.  Trackers of families no metric
+                                needs are simply absent, so their maintenance costs nothing.
+        :param main_signal_family: (DiversitySignalFamily) family of the main diversity metric; its tracker feeds
+                                   the strategy-facing signal properties.
         :param score_generator: (ScoreGenerator) score generator to compute scores for current state
         :param selected: (np.ndarray[np.bool]) array indicating which of the n vectors are initially selected.
         :param con_values: (np.ndarray[np.int32] | None) upper/lower bounds per constraint (m x 2 array of float32)
@@ -65,7 +72,10 @@ class SolverState:
         self._k = k  # READ-ONLY
 
         # diversity signals
-        self._signal_tracker = signal_tracker
+        self._signal_trackers_by_family = signal_trackers  # READ-ONLY
+        self._main_signal_family = main_signal_family  # READ-ONLY
+        self._signal_trackers = tuple(signal_trackers.values())  # iteration order for mutations
+        self._signal_tracker = signal_trackers[main_signal_family]  # strategy-facing tracker
 
         # scoring
         self._score_generator = score_generator  # READ-ONLY
@@ -95,7 +105,8 @@ class SolverState:
         return SolverState(
             n=self._n,
             k=self._k,
-            signal_tracker=self._signal_tracker.copy(),
+            signal_trackers={family: t.copy() for family, t in self._signal_trackers_by_family.items()},
+            main_signal_family=self._main_signal_family,
             score_generator=self._score_generator.copy(),
             selected=self._selected.copy(),
             con_values=self._con_values.copy(),
@@ -116,7 +127,8 @@ class SolverState:
         self._snapshot.selected = self._selected.copy()
         self._snapshot.n_selected = self._n_selected
         self._snapshot.con_values = self._con_values.copy()
-        self._signal_tracker.set_snapshot()
+        for tracker in self._signal_trackers:
+            tracker.set_snapshot()
         # NOTE: Score is immutable and mutators reassign self._score (never modify in place),
         #       so storing the reference is safe — no copy needed.
         self._snapshot.score = self.score
@@ -136,7 +148,8 @@ class SolverState:
         self._selected = self._snapshot.selected
         self._n_selected = self._snapshot.n_selected
         self._con_values = self._snapshot.con_values
-        self._signal_tracker.restore_snapshot()
+        for tracker in self._signal_trackers:
+            tracker.restore_snapshot()
 
         # restore score (cached at set_snapshot time; avoids a full recompute)
         self._score = self._snapshot.score
@@ -156,7 +169,8 @@ class SolverState:
         self._n_selected += np.int32(1)
 
         # --- diversity signals ---------------------------
-        self._signal_tracker.add(index)
+        for tracker in self._signal_trackers:
+            tracker.add(index)
 
         # --- constraints ---------------------------------
         # decrease both min_count and max_count for all constraints that include 'index'
@@ -175,7 +189,8 @@ class SolverState:
         self._n_selected += np.int32(len(indices))
 
         # --- diversity signals ---------------------------
-        self._signal_tracker.add_many(indices)
+        for tracker in self._signal_trackers:
+            tracker.add_many(indices)
 
         # --- constraints ---------------------------------
         # decrease both min_count and max_count for all constraints that include any of 'indices'
@@ -196,7 +211,9 @@ class SolverState:
         self._n_selected -= np.int32(1)
 
         # --- diversity signals ---------------------------
-        self._signal_tracker.remove(index, self.selected_index_array)
+        new_selection = self.selected_index_array
+        for tracker in self._signal_trackers:
+            tracker.remove(index, new_selection)
 
         # --- constraints ---------------------------------
         # increase both min_count and max_count for all constraints that include 'index'
@@ -215,7 +232,9 @@ class SolverState:
         self._n_selected -= np.int32(len(indices))
 
         # --- diversity signals ---------------------------
-        self._signal_tracker.remove_many(indices, self.selected_index_array)
+        new_selection = self.selected_index_array
+        for tracker in self._signal_trackers:
+            tracker.remove_many(indices, new_selection)
 
         # --- constraints ---------------------------------
         # increase both min_count and max_count for all constraints that include any of 'indices'
@@ -331,8 +350,12 @@ class SolverState:
         penalty_quadratic: bool = False,
     ) -> SolverState:
         # --- diversity signals ---
+        # one tracker per signal family needed by the configured metrics (main metric's family first,
+        # so the strategy-facing tracker is always present); unneeded families are never constructed
         n_np = np.int32(n)
-        signal_tracker = SeparationTracker(pdist, n_np)
+        main_signal_family = diversity_metric.signal_family
+        families = dict.fromkeys([main_signal_family, *(tb.signal_family for tb in diversity_tie_breakers)])
+        signal_trackers = {family: build_tracker(family, pdist, n_np) for family in families}
 
         # --- selection ---
         selected = np.full(n_np, False, dtype=np.bool)
@@ -355,7 +378,8 @@ class SolverState:
         return SolverState(
             n=n_np,
             k=np.int32(k),
-            signal_tracker=signal_tracker,
+            signal_trackers=signal_trackers,
+            main_signal_family=main_signal_family,
             score_generator=score_generator,
             selected=selected,
             con_values=con_values,

--- a/tests/_core/metrics/test_diversity_metric.py
+++ b/tests/_core/metrics/test_diversity_metric.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from max_div._core.metrics import DiversityMetric
+from max_div._core.metrics import DiversityMetric, DiversitySignalFamily
 
 
 @pytest.mark.parametrize(
@@ -86,3 +86,10 @@ def test_diversity_metric_small_arrays(metric: DiversityMetric, sep_array: np.nd
 
     # --- assert ------------------------------------------
     assert result == 0.0
+
+
+@pytest.mark.parametrize("metric", list(DiversityMetric))
+def test_diversity_metric_signal_family(metric: DiversityMetric):
+    """Every separation-named metric consumes the SEPARATION signal family."""
+    # --- act / assert ------------------------------------
+    assert metric.signal_family == DiversitySignalFamily.SEPARATION

--- a/tests/_core/solver/_signals/test_factory.py
+++ b/tests/_core/solver/_signals/test_factory.py
@@ -1,0 +1,25 @@
+import numpy as np
+import pytest
+
+from max_div._core.metrics import DistanceMetric, DiversitySignalFamily
+from max_div._core.metrics._distance import compute_pdist
+from max_div._core.solver._signals import MeanDistanceTracker, SeparationTracker, build_tracker
+
+
+@pytest.mark.parametrize(
+    "family, expected_type",
+    [
+        (DiversitySignalFamily.SEPARATION, SeparationTracker),
+        (DiversitySignalFamily.MEAN_DISTANCE, MeanDistanceTracker),
+    ],
+)
+def test_build_tracker(family: DiversitySignalFamily, expected_type: type):
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0.0], [1.0], [3.0]], dtype=np.float32)
+    pdist = compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
+
+    # --- act ---------------------------------------------
+    tracker = build_tracker(family, pdist, np.int32(3))
+
+    # --- assert ------------------------------------------
+    assert type(tracker) is expected_type

--- a/tests/_core/solver/_signals/test_mean_distance.py
+++ b/tests/_core/solver/_signals/test_mean_distance.py
@@ -1,0 +1,161 @@
+import numpy as np
+import pytest
+from numpy import random
+from scipy.spatial.distance import squareform
+
+from max_div._core.metrics import DistanceMetric
+from max_div._core.metrics._distance import compute_pdist
+from max_div._core.solver._signals import MeanDistanceTracker
+
+# =================================================================================================
+#  Fixtures / helpers
+# =================================================================================================
+N = 20
+
+
+@pytest.fixture
+def pdist() -> np.ndarray:
+    rng = random.default_rng(seed=20260713)
+    vectors = rng.random((N, 3)).astype(np.float32)
+    return compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN)
+
+
+@pytest.fixture
+def tracker(pdist: np.ndarray) -> MeanDistanceTracker:
+    return MeanDistanceTracker(pdist, np.int32(N))
+
+
+def _selection_args(indices: list[int]) -> tuple[np.ndarray, np.int32]:
+    """Build the (selected, n_selected) argument pair for signal reads from a list of selected indices."""
+    selected = np.full(N, False, dtype=np.bool)
+    selected[indices] = True
+    return selected, np.int32(len(indices))
+
+
+def _brute_force_signal(pdist: np.ndarray, indices: list[int]) -> np.ndarray:
+    """Compute the mean-distance signal from scratch: mean distance of each point to its selected neighbors."""
+    d_squared = squareform(pdist).astype(np.float64)
+    selected = np.full(N, False, dtype=np.bool)
+    selected[indices] = True
+    sums = d_squared[:, selected].sum(axis=1) if indices else np.zeros(N, dtype=np.float64)
+    divisor = np.maximum(len(indices) - selected, 1)
+    return (sums / divisor).astype(np.float32)
+
+
+# =================================================================================================
+#  Tests
+# =================================================================================================
+def test_construction_fresh(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    selected, n_selected = _selection_args([])
+    expected_global = (squareform(pdist).astype(np.float64).sum(axis=1) / (N - 1)).astype(np.float32)
+
+    # --- assert ------------------------------------------
+    assert tracker.global_signal.dtype == np.float32
+    np.testing.assert_allclose(tracker.global_signal, expected_global, rtol=1e-6)
+    # empty selection: all signals 0.0 (no selected neighbors)
+    np.testing.assert_array_equal(tracker.full_signal(selected, n_selected), np.zeros(N, dtype=np.float32))
+
+
+def test_construction_precomputed_arrays_skip_recompute(pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    global_signal = np.arange(N, dtype=np.float32)
+    dist_sums = np.arange(N, dtype=np.float64)
+
+    # --- act ---------------------------------------------
+    tracker = MeanDistanceTracker(pdist, np.int32(N), global_signal=global_signal, dist_sums=dist_sums)
+
+    # --- assert ------------------------------------------
+    assert tracker.global_signal is global_signal  # taken as-is, not recomputed
+    assert tracker._dist_sums is dist_sums
+
+
+def test_signal_matches_brute_force_incrementally(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    selection: list[int] = []
+
+    # --- act / assert ------------------------------------
+    for index in [3, 17, 0, 9, 12]:
+        tracker.add(np.int32(index))
+        selection.append(index)
+        selected, n_selected = _selection_args(selection)
+        np.testing.assert_allclose(
+            tracker.full_signal(selected, n_selected), _brute_force_signal(pdist, selection), rtol=1e-6
+        )
+
+    for index in [0, 17]:
+        tracker.remove(np.int32(index), new_selection=np.array([], dtype=np.int32))
+        selection.remove(index)
+        selected, n_selected = _selection_args(selection)
+        np.testing.assert_allclose(
+            tracker.full_signal(selected, n_selected), _brute_force_signal(pdist, selection), rtol=1e-6
+        )
+
+
+def test_membership_aware_divisor(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    """A selected point's mean divides by (n_selected - 1); a non-selected point's by n_selected."""
+
+    # --- arrange -----------------------------------------
+    d_squared = squareform(pdist).astype(np.float64)
+    tracker.add(np.int32(2))
+    tracker.add(np.int32(5))
+    selected, n_selected = _selection_args([2, 5])
+
+    # --- act ---------------------------------------------
+    signal = tracker.full_signal(selected, n_selected)
+
+    # --- assert ------------------------------------------
+    # selected point 2: one real neighbor (5) -> mean = d(2,5) / 1
+    assert signal[2] == pytest.approx(d_squared[2, 5], rel=1e-6)
+    # non-selected point 0: two neighbors -> mean = (d(0,2) + d(0,5)) / 2
+    assert signal[0] == pytest.approx((d_squared[0, 2] + d_squared[0, 5]) / 2, rel=1e-6)
+
+
+def test_invariant_random_operations_match_recompute(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    """After arbitrary add/remove/snapshot sequences, signals must match a brute-force recompute."""
+
+    # --- arrange -----------------------------------------
+    rng = random.default_rng(seed=7)
+    selection: list[int] = []
+    snapshot_selection: list[int] | None = None
+
+    # --- act / assert ------------------------------------
+    for _ in range(200):
+        can_restore = snapshot_selection is not None
+        options = ["add", "remove", "set_snapshot"] + (["restore_snapshot"] if can_restore else [])
+        match rng.choice(options):
+            case "add" if len(selection) < N:
+                index = int(rng.choice([i for i in range(N) if i not in selection]))
+                tracker.add(np.int32(index))
+                selection.append(index)
+            case "remove" if selection:
+                index = int(rng.choice(selection))
+                selection.remove(index)
+                tracker.remove(np.int32(index), new_selection=np.array(selection, dtype=np.int32))
+            case "set_snapshot":
+                tracker.set_snapshot()
+                snapshot_selection = selection.copy()
+            case "restore_snapshot":
+                tracker.restore_snapshot()
+                selection = snapshot_selection.copy()  # ty: ignore[possibly-unbound-attribute]  # gated by can_restore
+                snapshot_selection = None
+
+        selected, n_selected = _selection_args(selection)
+        np.testing.assert_allclose(
+            tracker.full_signal(selected, n_selected), _brute_force_signal(pdist, selection), rtol=1e-5
+        )
+
+
+def test_copy_is_independent(tracker: MeanDistanceTracker):
+    # --- arrange -----------------------------------------
+    tracker.add(np.int32(0))
+    clone = tracker.copy()
+    selected, n_selected = _selection_args([0])
+    signal_before = clone.full_signal(selected, n_selected).copy()
+
+    # --- act ---------------------------------------------
+    tracker.add(np.int32(4))
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(clone.full_signal(selected, n_selected), signal_before)
+    assert clone.global_signal is not tracker.global_signal

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -5,6 +5,7 @@ from numpy import random
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 from max_div._core.metrics._distance import compute_pdist
+from max_div._core.solver._signals import SeparationTracker
 from max_div._core.solver._solver_state import SolverState, _build_con_membership
 
 
@@ -229,6 +230,17 @@ def test_solver_state_consistency_stress_test(new_solver_state, seed: int):
 
     assert state.n_selected == state_ref.n_selected
     assert state.n_not_selected == state_ref.n_not_selected
+
+
+def test_solver_state_tracker_set_dormancy(new_solver_state):
+    """Separation-only metric configurations construct exactly one tracker: dormancy by absence."""
+    # --- act ---------------------------------------------
+    trackers = new_solver_state._signal_trackers
+
+    # --- assert ------------------------------------------
+    assert len(trackers) == 1
+    assert type(trackers[0]) is SeparationTracker
+    assert new_solver_state._signal_tracker is trackers[0]
 
 
 def test_build_con_membership():


### PR DESCRIPTION
Second signal family, landed dormant. `MeanDistanceTracker` stores raw per-point distance sums in float64 (incremental updates stay exact add/subtract arithmetic) and exposes mean-form float32 signals with a membership-aware divisor (a selected point's zero self-distance is not a neighbor). `SolverState.new` now derives the tracker set from the configured metrics' signal families — dormancy by absence: no metric consumes the new family yet, so separation solves construct exactly what they did before. Invariant test: after random add/remove/snapshot sequences the incremental signals match a brute-force recompute. Golden master untouched and green; U-series microbench unchanged vs baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)