### PR TITLE
refactor: bind score metrics to their signal family at construction

### DIFF
--- a/src/max_div/_core/solver/_score.py
+++ b/src/max_div/_core/solver/_score.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from max_div._core.constraints._constraints import _np_con_total_violation, _np_con_total_weighted_violation
+from max_div._core.metrics._diversity import DiversitySignalFamily
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -168,8 +169,12 @@ class ScoreGenerator:
         self._use_fast_con_path = (not penalty_quadratic) and bool(np.all(self._con_weights == 1.0))
 
         # --- diversity & tie-breakers ----------
+        # each metric is bound to its signal family here, once — compute_score then just picks the
+        # matching signal array per metric, without any per-call family lookups
         self._diversity_metric = diversity_metric
+        self._diversity_metric_family: DiversitySignalFamily = diversity_metric.signal_family
         self._diversity_tie_breakers = diversity_tie_breakers
+        self._tie_breakers_with_family = [(tb, tb.signal_family) for tb in diversity_tie_breakers]
 
         # --- store other params ---------------
         self._constraints = constraints
@@ -192,8 +197,24 @@ class ScoreGenerator:
     #  Score computation
     # -------------------------------------------------------------------------
     def compute_score(
-        self, n_selected: int | np.int32, con_values: NDArray[np.int32], selected_separation_array: NDArray[np.float32]
+        self,
+        n_selected: int | np.int32,
+        con_values: NDArray[np.int32],
+        separation_signals: NDArray[np.float32] | None = None,
+        mean_distance_signals: NDArray[np.float32] | None = None,
     ) -> Score:
+        """Compute the multi-component Score of a selection.
+
+        :param n_selected: (int | np.int32) current number of selected vectors.
+        :param con_values: (np.ndarray[np.int32]) current constraint-bound status (m x 2 array).
+        :param separation_signals: (np.ndarray[np.float32] | None) the selected vectors' separation-family
+                                   signal values; may be omitted when no configured metric consumes them.
+        :param mean_distance_signals: (np.ndarray[np.float32] | None) the selected vectors' mean-distance-family
+                                      signal values; may be omitted when no configured metric consumes them.
+
+        The caller must pass the signal array of every family that the configured metrics (main +
+        tie-breakers) consume; families no metric consumes may be omitted.
+        """
         # --- individual scores ---------------------------
         if n_selected <= self._k:
             size_score = 1.0 - self._size_c0 * (self._k - n_selected)
@@ -211,9 +232,22 @@ class ScoreGenerator:
             )
 
         # --- construct Score object ----------------------
+        # each metric reads the signal array of the family it was bound to at construction
+        main_signals = (
+            separation_signals
+            if self._diversity_metric_family == DiversitySignalFamily.SEPARATION
+            else mean_distance_signals
+        )
         return Score(
             size=size_score,
             constraints=con_score,
-            diversity=float(self._diversity_metric.compute(selected_separation_array)),
-            div_tie_breakers=tuple(float(tb.compute(selected_separation_array)) for tb in self._diversity_tie_breakers),
+            diversity=float(self._diversity_metric.compute(main_signals)),  # ty: ignore[invalid-argument-type]  # caller passes required families; hot path, so no assert
+            div_tie_breakers=tuple(
+                float(
+                    tb.compute(
+                        separation_signals if family == DiversitySignalFamily.SEPARATION else mean_distance_signals  # ty: ignore[invalid-argument-type]  # caller passes required families; hot path, so no assert
+                    )
+                )
+                for tb, family in self._tie_breakers_with_family
+            ),
         )

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 from max_div._core.constraints import Constraint, ConstraintList
+from max_div._core.metrics import DiversitySignalFamily
 
 from ._score import Score, ScoreGenerator
 from ._signals import build_tracker
@@ -15,7 +16,7 @@ from ._signals import build_tracker
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from max_div._core.metrics import DiversityMetric, DiversitySignalFamily
+    from max_div._core.metrics import DiversityMetric
 
     from ._signals import DiversitySignalTracker
 
@@ -76,6 +77,9 @@ class SolverState:
         self._main_signal_family = main_signal_family  # READ-ONLY
         self._signal_trackers = tuple(signal_trackers.values())  # iteration order for mutations
         self._signal_tracker = signal_trackers[main_signal_family]  # strategy-facing tracker
+        # per-family trackers for scoring (resolved once here; None = family not needed by any metric)
+        self._separation_tracker = signal_trackers.get(DiversitySignalFamily.SEPARATION)
+        self._mean_distance_tracker = signal_trackers.get(DiversitySignalFamily.MEAN_DISTANCE)
 
         # scoring
         self._score_generator = score_generator  # READ-ONLY
@@ -321,10 +325,23 @@ class SolverState:
     #  Scoring
     # -------------------------------------------------------------------------
     def _update_score(self) -> None:
+        # pass the selected vectors' signal values of every family a configured metric consumes
+        # (a family's tracker is None exactly when no metric needs it)
+        sep_tracker = self._separation_tracker
+        mean_tracker = self._mean_distance_tracker
         self._score = self._score_generator.compute_score(
             n_selected=self._n_selected,
             con_values=self._con_values,
-            selected_separation_array=self.selected_signal_array,
+            separation_signals=(
+                sep_tracker.full_signal(self._selected, self._n_selected)[self._selected]
+                if sep_tracker is not None
+                else None
+            ),
+            mean_distance_signals=(
+                mean_tracker.full_signal(self._selected, self._n_selected)[self._selected]
+                if mean_tracker is not None
+                else None
+            ),
         )
         self._score_dirty = False
 

--- a/tests/_core/solver/test_score.py
+++ b/tests/_core/solver/test_score.py
@@ -337,3 +337,25 @@ def test_score_str(score: Score, expected_str: str):
 
     # --- assert ------------------------------------------
     assert result == expected_str
+
+
+def test_compute_score_binds_metrics_to_their_signal_family():
+    """Separation-family metrics must read separation_signals, regardless of what else is passed."""
+
+    # --- arrange -----------------------------------------
+    generator = ScoreGenerator(
+        n=10,
+        k=4,
+        diversity_metric=DiversityMetric.MEAN_SEPARATION,
+        diversity_tie_breakers=[DiversityMetric.MIN_SEPARATION],
+        constraints=[],
+    )
+    separation_signals = np.array([2.0, 4.0, 6.0], dtype=np.float32)
+    decoy_signals = np.array([100.0, 100.0, 100.0], dtype=np.float32)
+
+    # --- act ---------------------------------------------
+    score = generator.compute_score(3, np.empty((0, 2), dtype=np.int32), separation_signals, decoy_signals)
+
+    # --- assert ------------------------------------------
+    assert score.diversity == pytest.approx(4.0)  # mean of separation signals, not of the decoy
+    assert score.div_tie_breakers[0] == pytest.approx(2.0)  # min of separation signals, not of the decoy


### PR DESCRIPTION
`ScoreGenerator` records each metric's signal family once at construction; `compute_score` takes one selected-signal array per active family (`separation_signals`, `mean_distance_signals`) and each metric reads the array it was bound to. `SolverState._update_score` passes the arrays for exactly the families its tracker set maintains. The generator holds no tracker references (no state↔generator cycle) and there is no per-call family dispatch. All defined metrics are separation-family, so scoring behavior is unchanged — golden master untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)