### PR TITLE
refactor: rename sampling-layer vocabulary from separation to diversity contribution

### DIFF
--- a/src/max_div/_core/metrics/_diversity/_enum.py
+++ b/src/max_div/_core/metrics/_diversity/_enum.py
@@ -49,20 +49,21 @@ class DiversityMetric(StrEnum):
         #       return type; at runtime it is called exactly like one.
         return _functions[self]  # ty: ignore[invalid-return-type]
 
-    def compute(self, separations: NDArray[np.float32]) -> np.float32:
-        """Compute diversity metric given separations of each vector wrt all others in selection.
+    def compute(self, contribution_values: NDArray[np.float32]) -> np.float32:
+        """Compute diversity metric given the selected vectors' per-point diversity-contribution values.
 
         Parameters
         ----------
-        separations : NDArray[np.float32]
-            Array of separation values.
+        contribution_values : NDArray[np.float32]
+            Per-point diversity-contribution values of the selected vectors (for separation-family
+            metrics: each vector's separation wrt the others in the selection).
 
         Returns:
         -------
         np.float32
             The computed diversity score.
         """
-        if separations.size < 2:
-            # we can only meaningfully compute diversity metrics with at least 2 separation values
+        if contribution_values.size < 2:
+            # we can only meaningfully compute diversity metrics with at least 2 contribution values
             return np.float32(0.0)
-        return self._f(separations)
+        return self._f(contribution_values)

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -279,25 +279,25 @@ class SolverState:
         return np.flatnonzero(~self._selected).astype(np.int32)
 
     @property
-    def selected_separation_array(self) -> NDArray[np.float32]:
-        """Return separation of selected vectors wrt other selected vectors as a numpy array of np.float32."""
+    def selected_contribution_array(self) -> NDArray[np.float32]:
+        """Return diversity contribution of selected vectors wrt the current selection (np.float32 ndarray)."""
         return self._contribution_tracker.contribution_wrt_selection(self._selected, self._n_selected)[self._selected]
 
     @property
-    def not_selected_separation_array(self) -> NDArray[np.float32]:
-        """Return separation of not selected vectors wrt selected vectors as a numpy array of np.float32."""
+    def not_selected_contribution_array(self) -> NDArray[np.float32]:
+        """Return diversity contribution of not selected vectors wrt the current selection (np.float32 ndarray)."""
         return self._contribution_tracker.contribution_wrt_selection(self._selected, self._n_selected)[~self._selected]
 
     @property
-    def full_separation_array(self) -> NDArray[np.float32]:
-        """Return separation of all vectors wrt selected vectors as a numpy array of np.float32."""
+    def full_contribution_array(self) -> NDArray[np.float32]:
+        """Return diversity contribution of all vectors wrt the current selection (np.float32 ndarray)."""
         return self._contribution_tracker.contribution_wrt_selection(
             self._selected, self._n_selected
         )  # should not be modified (!)
 
     @property
-    def global_separation_array(self) -> NDArray[np.float32]:
-        """Return global separation of all vectors wrt all other vectors as a numpy array of np.float32."""
+    def global_contribution_array(self) -> NDArray[np.float32]:
+        """Return static diversity contribution of all vectors wrt the whole dataset (np.float32 ndarray)."""
         return self._contribution_tracker.contribution_wrt_dataset  # should not be modified (!)
 
     # -------------------------------------------------------------------------
@@ -307,7 +307,7 @@ class SolverState:
         self._score = self._score_generator.compute_score(
             n_selected=self._n_selected,
             con_values=self._con_values,
-            selected_separation_array=self.selected_separation_array,
+            selected_separation_array=self.selected_contribution_array,
         )
         self._score_dirty = False
 
@@ -374,8 +374,8 @@ class Snapshot:
     """Class internally used by SolverState to store snapshots of its state.
 
     This class models a subset of the fields of the SolverState class, restricting itself to those that can be
-    modified after construction.  Diversity-contribution state is snapshotted by the signal tracker itself, in lockstep
-    with this snapshot's life cycle.
+    modified after construction.  Diversity-contribution state is snapshotted by the contribution tracker
+    itself, in lockstep with this snapshot's life cycle.
     """
 
     is_valid: bool

--- a/src/max_div/_core/solver/_strategies/_initialization/_base.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_base.py
@@ -49,7 +49,8 @@ class InitializationStrategy(StrategyBase, ABC):
     def fast(cls) -> InitFast:
         """Deterministic greedy initialization.
 
-        Selects vectors one-by-one, always picking the one that maximizes separation from the current selection.
+        Selects vectors one-by-one, always picking the one that maximizes the diversity contribution wrt the
+        current selection.
         Fast but seed-independent.
         """
         from ._init_fast import InitFast
@@ -60,9 +61,9 @@ class InitializationStrategy(StrategyBase, ABC):
     def random_one_shot(cls, uniform: bool = False, ignore_constraints: bool = False) -> InitRandomOneShot:
         """Random initialization that selects all ``k`` vectors in a single batch.
 
-        Probabilities are biased by global separation (unless ``uniform=True``).
+        Probabilities are biased by the global diversity contribution (unless ``uniform=True``).
 
-        :param uniform: If True, sample uniformly instead of using separation-based probabilities.
+        :param uniform: If True, sample uniformly instead of using contribution-based probabilities.
         :param ignore_constraints: If True, ignore constraints during sampling.
         """
         from ._init_random_one_shot import InitRandomOneShot
@@ -76,7 +77,7 @@ class InitializationStrategy(StrategyBase, ABC):
     def random_batched(cls, b: int, ignore_constraints: bool = False) -> InitRandomBatched:
         """Random initialization that selects vectors in batches of ``b``.
 
-        Separations are re-evaluated between batches.
+        Diversity contributions are re-evaluated between batches.
 
         :param b: Batch size (number of vectors to select per batch).
         :param ignore_constraints: If True, ignore constraints during sampling.

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
@@ -14,11 +14,11 @@ class InitEager(InitializationStrategy):
       - start from a set of `nc` randomly sampled candidates
       - we take the candidate which results in the highest score.
 
-    After each iteration, the SolverState updates distances and separations, influencing sampling probabilities
+    After each iteration, the SolverState updates its diversity contributions, influencing sampling probabilities
       of the next batch of candidates.
 
-    When sampling a batch, we use probabilities p[i] ~= (separation of i wrt already selected items)
-                                                                            + (separation of i wrt all items)
+    When sampling a batch, we use probabilities p[i] ~= (contribution of i wrt already selected items)
+                                                                            + (contribution of i wrt all items)
 
     This drives each batch to be sampled from elements that are both well-separated from the selection so far, to
       promote diversity, and also well-separated from each other, to avoid samples within a batch that are far from
@@ -74,7 +74,7 @@ class InitEager(InitializationStrategy):
             selectivity_modifier=modifier,
             rng_state=self._rng_state,
             sampling_type=SamplingType.CANDIDATES,
-            include_within_group_separation=True,
+            include_within_group_contribution=True,
             ignore_constraints=self.ignore_constraints,
         )
 

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_random_batched.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_random_batched.py
@@ -12,11 +12,11 @@ from ._base import InitializationStrategy
 class InitRandomBatched(InitializationStrategy):
     """Initialize by taking `b` (hence: batches) random samples of ~round(k/n_batches) items.
 
-    After each batch, the SolverState updates distances and separations, influencing sampling probabilities
+    After each batch, the SolverState updates its diversity contributions, influencing sampling probabilities
       of the next batch.
 
-    When sampling a batch, we use probabilities p[i] ~= (separation of i wrt already selected items)
-                                                                            + (separation of i wrt all items)
+    When sampling a batch, we use probabilities p[i] ~= (contribution of i wrt already selected items)
+                                                                            + (contribution of i wrt all items)
 
     This drives each batch to be sampled from elements that are both well-separated from the selection so far, to
       promote diversity, and also well-separated from each other, to avoid samples within a batch that are far from
@@ -83,6 +83,6 @@ class InitRandomBatched(InitializationStrategy):
             selectivity_modifier=modifier,
             rng_state=self._rng_state,
             sampling_type=SamplingType.GROUP,
-            include_within_group_separation=True,
+            include_within_group_contribution=True,
             ignore_constraints=self.ignore_constraints,
         )

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_random_one_shot.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_random_one_shot.py
@@ -16,13 +16,14 @@ class InitRandomOneShot(InitializationStrategy):
 
     Parameters:
     - uniform (bool): If `True`, samples uniformly at random.
-                      If `False`, uses vector separations as sampling weights, sampling well-separated vectors
-                                         with higher probability (default: `False`)
+                      If `False`, uses global diversity contributions as sampling weights, favoring
+                                         high-contribution vectors with higher probability (default: `False`)
     - ignore_constraints (bool): If `False`, respects problem constraints during initialization, if present.
                                  If `True`, constraints are ignored. (default: `False`)
 
     Notes:
-        - using separation as sampling weights is a heuristic, not an exactly optimal solution, with known limitations:
+        - using the global diversity contribution as sampling weights is a heuristic, not an exactly optimal
+          solution, with known limitations:
             - in 1D problems this heuristic should be probabilistically optimal, but in higher dimensions (the more
               likely scenario) it is not.  E.g. in 2D where vectors have half the separation as in other regions, we
               should sample 4x fewer, not 2x fewer vectors.
@@ -57,7 +58,7 @@ class InitRandomOneShot(InitializationStrategy):
                 k=state.k,
                 con_values=state.con_values,
                 con_indices=state.con_indices,
-                p=state.global_separation_array,
+                p=state.global_contribution_array,
                 rng_state=self._rng_state,
             )
         # don't take constraints into account
@@ -73,6 +74,6 @@ class InitRandomOneShot(InitializationStrategy):
             n=state.n,
             k=state.k,
             replace=False,
-            p=state.global_separation_array,
+            p=state.global_contribution_array,
             rng_state=self._rng_state,
         )

--- a/src/max_div/_core/solver/_strategies/_optimization/_base.py
+++ b/src/max_div/_core/solver/_strategies/_optimization/_base.py
@@ -232,7 +232,7 @@ class OptimizationStrategy(StrategyBase, ABC):
         remove_selectivity_modifier: float | ParameterSchedule = 0.0,
         add_selectivity_modifier: float | ParameterSchedule = 0.0,
     ) -> OptimGuidedSwaps:
-        """Distance-guided swap strategy: biased towards removing low- and adding high-separation vectors.
+        """Contribution-guided swap strategy: biased towards removing low- and adding high-contribution vectors.
 
         Supports scheduled parameters for constraint softness and selectivity.
         """

--- a/src/max_div/_core/solver/_strategies/_optimization/_optim_guided_swaps.py
+++ b/src/max_div/_core/solver/_strategies/_optimization/_optim_guided_swaps.py
@@ -84,7 +84,7 @@ class OptimGuidedSwaps(SwapBasedOptimizationStrategy):
             selectivity_modifier=self.add_selectivity_modifier,
             rng_state=self._rng_state,
             sampling_type=SamplingType.GROUP,
-            include_within_group_separation=(n_to_add > 1),
+            include_within_group_contribution=(n_to_add > 1),
             ignore_constraints=ignore_constraints,
         )
 

--- a/src/max_div/_core/solver/_strategies/_optimization/_optim_smart_swaps.py
+++ b/src/max_div/_core/solver/_strategies/_optimization/_optim_smart_swaps.py
@@ -223,7 +223,7 @@ class OptimSmartSwaps(SwapBasedOptimizationStrategy):
                 selectivity_modifier=self.selectivity_modifier_add,
                 rng_state=self._rng_state,
                 sampling_type=SamplingType.GROUP,
-                include_within_group_separation=(n_to_add > 1),
+                include_within_group_contribution=(n_to_add > 1),
                 ignore_constraints=False,
             )
 

--- a/src/max_div/_core/solver/_strategies/_sampling/__init__.py
+++ b/src/max_div/_core/solver/_strategies/_sampling/__init__.py
@@ -5,7 +5,7 @@ Items can be sampled to be removed from the selection (remove.py) or added to th
 These methods bridge the gap between following 3 pieces of functionality:
     1) SolverState offering information about...
         - selected and unselected items
-        - separation distances between items
+        - per-point diversity contributions (higher = contributes more diversity)
         - constraints
     2) Methods to modify selectivity of an array of probabilities
     3) Sampling strategies that decide which items to sample based on the above information

--- a/src/max_div/_core/solver/_strategies/_sampling/add.py
+++ b/src/max_div/_core/solver/_strategies/_sampling/add.py
@@ -34,7 +34,7 @@ def select_items_to_add(
     selectivity_modifier: float,
     rng_state: NDArray[np.uint64],
     sampling_type: SamplingType = SamplingType.GROUP,
-    include_within_group_separation: bool | np.bool_ = True,
+    include_within_group_contribution: bool | np.bool_ = True,
     ignore_constraints: bool = False,
 ) -> NDArray[np.int32]:
     """Select k items from 'candidates' to be added to the provided SolverState.
@@ -45,35 +45,35 @@ def select_items_to_add(
     :param candidates: (NDArray[np.int32]) array of candidate item indices to choose from
                                                     (must be a subset of not-selected items; must be of size>=k)
     :param k: (int) number of items to add to the selection.
-    :param selectivity_modifier: (float) value in [-1, 1] that modifies the selectivity of the separation-based
-                                 probabilities used for sampling items to be added.
+    :param selectivity_modifier: (float) value in [-1, 1] that modifies the selectivity of the
+                                 diversity-contribution-based probabilities used for sampling items to be added.
                                     -1: maximally un-selective --> uniform
-                                     0: no modification to the separation-based probabilities
-                                    +1: maximally selective --> only the items with very lowest separation are sampled
+                                     0: no modification to the contribution-based probabilities
+                                    +1: maximally selective --> only the items with very lowest contribution are sampled
     :param rng_state: (NDArray[np.uint64]) The RNG state to be used (and updated in-place) for random sampling
     :param sampling_type: (SamplingType) context in which the k items are being sampled (GROUP vs CANDIDATES)
-    :param include_within_group_separation: (bool) flag that influences how sampling probabilities are built.
-                                            True: start from sep. to already selected items + within-group separation
-                                            False: start from sep. to already selected items only
+    :param include_within_group_contribution: (bool) flag that influences how sampling probabilities are built.
+                                 True: start from contribution wrt already selected items + within-group contribution
+                                 False: start from contribution wrt already selected items only
     :param ignore_constraints: (bool) If True, constraints are ignored even if present in the SolverState.
     :return: list of np.int32 indices of the items to be added to the selection (unique values, unsorted).
     """
     # --- prepare probabilities ---------------------------
     if state.n_selected == 0:
-        # the only option is to look at separation wrt all other items, as we don't have a selection yet
+        # the only option is to look at the global contribution (wrt all other items), as we don't have a selection yet
         # this branch is only taken in the first iteration of initialization strategies
-        p = state.global_separation_array[candidates]  # add separation of candidates wrt to all other items
+        p = state.global_contribution_array[candidates]  # contribution of candidates wrt all other items
     else:
         # standard path
-        p = state.full_separation_array[candidates]  # new array; separation of candidates to selected items
-        if include_within_group_separation:
-            p += state.global_separation_array[candidates]  # add separation of candidates wrt to all other items
+        p = state.full_contribution_array[candidates]  # new array; contribution of candidates wrt selected items
+        if include_within_group_contribution:
+            p += state.global_contribution_array[candidates]  # add contribution of candidates wrt all other items
 
     exponential_selectivity(
         p_in=p,
         p_out=p,  # in-place
         modifier=np.float32(selectivity_modifier),
-        reverse=False,  # for adding, we want to have vectors with high separation have higher probability
+        reverse=False,  # for adding, we want to have vectors with high diversity contribution have higher probability
     )
 
     # --- actual sampling ---------------------------------

--- a/src/max_div/_core/solver/_strategies/_sampling/remove.py
+++ b/src/max_div/_core/solver/_strategies/_sampling/remove.py
@@ -13,21 +13,21 @@ def select_items_to_remove(
 
     :param state: (SolverState) The current solver state containing selected items and other relevant information.
     :param k: (int) number of items to remove from the selection.
-    :param selectivity_modifier: (float) value in [-1, 1] that modifies the selectivity of the separation-based
-                                 probabilities used for sampling items to be removed.
+    :param selectivity_modifier: (float) value in [-1, 1] that modifies the selectivity of the
+                                 diversity-contribution-based probabilities used for sampling items to be removed.
                                     -1: maximally un-selective --> uniform
-                                     0: no modification to the separation-based probabilities
-                                    +1: maximally selective --> only the items with very lowest separation are sampled
+                                     0: no modification to the contribution-based probabilities
+                                    +1: maximally selective --> only the items with very lowest contribution are sampled
     :param rng_state: (NDArray[np.uint64]) The RNG state to be used (and updated in-place) for random sampling
     :return: list of np.int32 indices of the items to be removed from the selection (unique values, unsorted).
     """
     # --- guiding probabilities for removal ---
-    p = state.selected_separation_array  # this creates a copy
+    p = state.selected_contribution_array  # this creates a copy
     exponential_selectivity(
         p_in=p,
         p_out=p,  # in-place
         modifier=np.float32(selectivity_modifier),
-        reverse=True,  # for removal, we want to have vectors with small separation have higher probability
+        reverse=True,  # for removal, we want to have vectors with small diversity contribution have higher probability
     )
 
     # --- sample ---

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -97,7 +97,7 @@ def test_solver_state_end_to_end(new_solver_state):
     assert state.score.constraints < 1.0  # constraints not satisfied
     assert np.array_equal(state.con_values, state._con_values)
     assert np.array_equal(state.con_indices, state._con_indices)
-    assert np.array_equal(state.global_separation_array, state._contribution_tracker.contribution_wrt_dataset)
+    assert np.array_equal(state.global_contribution_array, state._contribution_tracker.contribution_wrt_dataset)
     assert state.n_selected == 0
     assert state.n_not_selected == 6
 
@@ -109,7 +109,7 @@ def test_solver_state_end_to_end(new_solver_state):
     # --- assert 2 ----------------------------------------
     assert np.array_equal(state.selected_index_array, [0, 2, 5])
     assert np.array_equal(state.not_selected_index_array, [1, 3, 4])
-    assert np.allclose(state.selected_separation_array, [2, 2, 3])
+    assert np.allclose(state.selected_contribution_array, [2, 2, 3])
     assert state.score.size == 1.0  # correct number of vectors selected
     assert state.score.constraints == 1.0  # all constraints satisfied
     assert state.score.diversity == pytest.approx((2 * 2 * 3) ** (1 / 3))  # geomean of separations 2, 2, 3
@@ -123,8 +123,8 @@ def test_solver_state_end_to_end(new_solver_state):
     # --- assert 3 ----------------------------------------
     assert np.array_equal(state.selected_index_array, [0, 2, 4])
     assert np.array_equal(state.not_selected_index_array, [1, 3, 5])
-    assert np.allclose(state.selected_separation_array, [2, 2, 2])
-    assert np.allclose(state.not_selected_separation_array, [1, 1, 1])
+    assert np.allclose(state.selected_contribution_array, [2, 2, 2])
+    assert np.allclose(state.not_selected_contribution_array, [1, 1, 1])
     assert state.score.size == 1.0  # correct number of vectors selected
     assert state.score.constraints == 1.0  # all constraints satisfied
     assert state.score.diversity == pytest.approx(2.0)  # geomean of separations 2, 2, 2
@@ -141,7 +141,7 @@ def test_solver_state_snapshot(new_solver_state):
     # current state so we can compare with state after
     orig_selected_array = state.selected_index_array.copy()
     orig_not_selected_array = state.not_selected_index_array.copy()
-    orig_separation_array = state.selected_separation_array.copy()
+    orig_separation_array = state.selected_contribution_array.copy()
     orig_con_values = state._con_values.copy()
 
     # --- act & assert ------------------------------------
@@ -159,7 +159,7 @@ def test_solver_state_snapshot(new_solver_state):
     # --- assert ------------------------------------------
     assert np.array_equal(state.selected_index_array, orig_selected_array)
     assert np.array_equal(state.not_selected_index_array, orig_not_selected_array)
-    assert np.allclose(state.selected_separation_array, orig_separation_array)
+    assert np.allclose(state.selected_contribution_array, orig_separation_array)
     assert np.array_equal(state.con_values, orig_con_values)
 
 
@@ -219,9 +219,9 @@ def test_solver_state_consistency_stress_test(new_solver_state, seed: int):
     # check if they're the same
     assert np.array_equal(state.selected_index_array, state_ref.selected_index_array)
     assert np.array_equal(state.not_selected_index_array, state_ref.not_selected_index_array)
-    assert np.array_equal(state.global_separation_array, state_ref.global_separation_array)
-    assert np.array_equal(state.not_selected_separation_array, state_ref.not_selected_separation_array)
-    assert np.array_equal(state.selected_separation_array, state_ref.selected_separation_array)
+    assert np.array_equal(state.global_contribution_array, state_ref.global_contribution_array)
+    assert np.array_equal(state.not_selected_contribution_array, state_ref.not_selected_contribution_array)
+    assert np.array_equal(state.selected_contribution_array, state_ref.selected_contribution_array)
     assert np.array_equal(state.con_values, state_ref.con_values)
     assert np.array_equal(state.con_indices, state_ref.con_indices)
 


### PR DESCRIPTION
Pure rename/rewording pass: the sampling + initialization layers only rely on the diversity-contribution contract (higher = contributes more diversity), so the code now says exactly that — `SolverState` facade properties become `*_contribution_array`, `include_within_group_separation` becomes `include_within_group_contribution`, and `DiversityMetric.compute`'s parameter/docstring go family-neutral. No logic changes; golden master untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)