### PR TITLE
refactor: add dormant MeanDistanceTracker and per-metric tracker construction

### DIFF
--- a/src/max_div/_core/metrics/__init__.py
+++ b/src/max_div/_core/metrics/__init__.py
@@ -1,2 +1,2 @@
 from ._distance import DistanceMetric, validate_cosine_vectors
-from ._diversity import DiversityMetric
+from ._diversity import DiversityContributionFamily, DiversityMetric

--- a/src/max_div/_core/metrics/_diversity/__init__.py
+++ b/src/max_div/_core/metrics/_diversity/__init__.py
@@ -1,1 +1,1 @@
-from ._enum import DiversityMetric
+from ._enum import DiversityContributionFamily, DiversityMetric

--- a/src/max_div/_core/metrics/_diversity/_enum.py
+++ b/src/max_div/_core/metrics/_diversity/_enum.py
@@ -6,6 +6,20 @@ import numpy as np
 from numpy.typing import NDArray
 
 
+class DiversityContributionFamily(StrEnum):
+    """Enum for the per-point diversity-contribution families that diversity metrics consume.
+
+    Members
+    -------
+
+        - SEPARATION:     contribution = distance to the nearest selected vector
+        - MEAN_DISTANCE:  contribution = mean distance to the selected vectors
+    """
+
+    SEPARATION = "SEPARATION"
+    MEAN_DISTANCE = "MEAN_DISTANCE"
+
+
 class DiversityMetric(StrEnum):
     """Enum for different diversity metrics.
 
@@ -25,6 +39,11 @@ class DiversityMetric(StrEnum):
     GEOMEAN_SEPARATION = "GEOMEAN_SEPARATION"
     APPROX_GEOMEAN_SEPARATION = "APPROX_GEOMEAN_SEPARATION"
     NON_ZERO_SEPARATION_FRAC = "NON_ZERO_SEPARATION_FRAC"
+
+    @cached_property
+    def contribution_family(self) -> DiversityContributionFamily:
+        """Return the diversity-contribution family whose per-point values this metric consumes."""
+        return DiversityContributionFamily.SEPARATION
 
     @cached_property
     def _f(self) -> Callable[[NDArray[np.float32]], np.float32]:

--- a/src/max_div/_core/solver/_diversity_contribution/__init__.py
+++ b/src/max_div/_core/solver/_diversity_contribution/__init__.py
@@ -1,2 +1,5 @@
 from ._base import DiversityContributionTracker
+from ._factory import build_diversity_contribution_tracker
+from ._mean_distance import MeanDistanceTracker
 from ._separation import SeparationTracker
+from ._trackers import DiversityContributionTrackers

--- a/src/max_div/_core/solver/_diversity_contribution/_factory.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_factory.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from max_div._core.metrics import DiversityContributionFamily
+
+from ._mean_distance import MeanDistanceTracker
+from ._separation import SeparationTracker
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+    from ._base import DiversityContributionTracker
+
+
+def build_diversity_contribution_tracker(
+    family: DiversityContributionFamily, pdist: NDArray[np.float32], n: np.int32
+) -> DiversityContributionTracker:
+    """Build a fresh (empty-selection) diversity-contribution tracker for the given contribution family.
+
+    :param family: (DiversityContributionFamily) the contribution family to track.
+    :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
+    :param n: (np.int32) number of vectors
+    """
+    match family:
+        case DiversityContributionFamily.SEPARATION:
+            return SeparationTracker(pdist, n)
+        case DiversityContributionFamily.MEAN_DISTANCE:
+            return MeanDistanceTracker(pdist, n)

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numba
+import numpy as np
+
+from max_div._core.metrics._distance import get_pdist_el
+
+from ._base import DiversityContributionTracker
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+
+# =================================================================================================
+#  Distance sums
+# =================================================================================================
+# Per-point sums of distances to a selection — the pairwise-distance counterpart of the separation
+# kernels above.  Sums accumulate in float64: entries undergo long add/subtract chains over solver
+# iterations, and float32 drift there would change scores with iteration count.  Distances of a
+# point to itself are 0, so a point's own entry never needs special-casing: it always equals the
+# sum of its distances to the *other* selected points.
+@numba.njit("float64[::1](float32[::1], int32)", cache=True)
+def compute_distance_sums(pdist: NDArray[np.float32], n: np.int32) -> NDArray[np.float64]:
+    """Compute sum of distances of each vector wrt all others, given pairwise distance array pdist and n vectors."""
+    dist_sums = np.zeros(n, dtype=np.float64)
+    pdist_idx = 0
+    for i in range(n):
+        for j in range(i + 1, n):
+            # note: the way we iterate over i & j represents the exact order in which pdist stores distances
+            dist_ij = np.float64(pdist[pdist_idx])
+            pdist_idx += 1
+            dist_sums[i] += dist_ij
+            dist_sums[j] += dist_ij
+    return dist_sums
+
+
+@numba.njit("void(float64[::1], float32[::1], int32, int32)", cache=True)
+def update_distance_sums_add(
+    dist_sums: NDArray[np.float64], pdist: NDArray[np.float32], n: np.int32, i_added: np.int32
+) -> None:
+    """Update distance sums of each vector wrt selection, given pdist array and n vectors, after adding i_added."""
+    for j in np.arange(n, dtype=np.int32):
+        if j != i_added:
+            dist_sums[j] += np.float64(get_pdist_el(pdist, i_added, j, n))
+
+
+@numba.njit("void(float64[::1], float32[::1], int32, int32)", cache=True)
+def update_distance_sums_remove(
+    dist_sums: NDArray[np.float64], pdist: NDArray[np.float32], n: np.int32, i_removed: np.int32
+) -> None:
+    """Update distance sums of each vector wrt selection, given pdist array and n vectors, after removing i_removed."""
+    for j in np.arange(n, dtype=np.int32):
+        if j != i_removed:
+            dist_sums[j] -= np.float64(get_pdist_el(pdist, i_removed, j, n))
+
+
+# =================================================================================================
+#  MeanDistanceTracker
+# =================================================================================================
+class MeanDistanceTracker(DiversityContributionTracker):
+    """Diversity-contribution tracker of the mean-distance family: contribution = mean distance to selected points.
+
+    Internally tracks *raw sums* of distances in float64 — incremental updates stay exact add/subtract
+    arithmetic, free of the rescaling (and rounding) that maintaining means directly would need.  Contribution
+    reads expose *mean form* (sum / number of selected neighbors), so values stay in the same "an average
+    distance" unit as other contribution families, and are returned as float32 like all exposed contribution arrays.
+
+    The number of selected neighbors is membership-aware: a selected point's own zero self-distance is
+    not a neighbor, so its divisor is one less than a non-selected point's.  For points with no selected
+    neighbor the contribution is 0.  The global contribution is each point's mean distance to all other points.
+    """
+
+    # -------------------------------------------------------------------------
+    #  Construction & copy
+    # -------------------------------------------------------------------------
+    def __init__(
+        self,
+        pdist: NDArray[np.float32],
+        n: np.int32,
+        contribution_wrt_dataset: NDArray[np.float32] | None = None,
+        dist_sums: NDArray[np.float64] | None = None,
+    ) -> None:
+        """Initialize the MeanDistanceTracker for an empty selection.
+
+        :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
+        :param n: (np.int32) number of vectors
+        :param contribution_wrt_dataset: (np.ndarray[np.float32] | None) precomputed global contribution;
+                                    computed if omitted.
+        :param dist_sums: (np.ndarray[np.float64] | None) current distance sums wrt selection; fresh (all 0.0,
+                          i.e. empty selection) if omitted.  Together with `contribution_wrt_dataset` this
+                          enables copies without recomputation.
+        """
+        self._pdist = pdist  # READ-ONLY
+        self._n = n  # READ-ONLY
+        if contribution_wrt_dataset is not None:
+            self._contribution_wrt_dataset = contribution_wrt_dataset  # READ-ONLY
+        else:
+            self._contribution_wrt_dataset = (compute_distance_sums(pdist, n) / max(int(n) - 1, 1)).astype(np.float32)
+        self._dist_sums = dist_sums if dist_sums is not None else np.zeros(n, dtype=np.float64)
+        self._snapshot_dist_sums: NDArray[np.float64] = _EMPTY_NP_ARRAY_FLOAT64
+
+    def copy(self) -> MeanDistanceTracker:
+        """Return a deep copy of this tracker (without recomputing the global contribution)."""
+        return MeanDistanceTracker(
+            pdist=self._pdist.copy(),
+            n=self._n,
+            contribution_wrt_dataset=self._contribution_wrt_dataset.copy(),
+            dist_sums=self._dist_sums.copy(),
+        )
+
+    # -------------------------------------------------------------------------
+    #  Contribution reads
+    # -------------------------------------------------------------------------
+    def contribution_wrt_selection(self, selected: NDArray[np.bool], n_selected: np.int32) -> NDArray[np.float32]:
+        """Return mean distance of all points wrt the current selection (freshly allocated array)."""
+        # per-point divisor: number of selected neighbors — a selected point's own 0-distance is not a neighbor
+        divisor = np.maximum(n_selected - selected, 1)  # bool subtraction; clip avoids 0/0 for empty neighborhoods
+        return (self._dist_sums / divisor).astype(np.float32)
+
+    @property
+    def contribution_wrt_dataset(self) -> NDArray[np.float32]:
+        """Return mean distance of all points wrt all other points (reference; do not modify)."""
+        return self._contribution_wrt_dataset
+
+    # -------------------------------------------------------------------------
+    #  Mutations
+    # -------------------------------------------------------------------------
+    def add(self, index: np.int32) -> None:
+        """Update distance sums after adding point `index` to the selection."""
+        update_distance_sums_add(self._dist_sums, self._pdist, self._n, index)
+
+    def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
+        """Update distance sums after removing point `index`.
+
+        `new_selection` is not needed by this tracker: removal is exact subtraction.
+        """
+        update_distance_sums_remove(self._dist_sums, self._pdist, self._n, index)
+
+    # -------------------------------------------------------------------------
+    #  Snapshot
+    # -------------------------------------------------------------------------
+    def set_snapshot(self) -> None:
+        """Save a copy of the current distance sums, overwriting any previous snapshot."""
+        self._snapshot_dist_sums = self._dist_sums.copy()
+
+    def restore_snapshot(self) -> None:
+        """Restore the distance sums saved by the last `set_snapshot` call and invalidate the snapshot."""
+        # no copy needed: the snapshot slot is cleared, so the restored array cannot alias a live snapshot
+        self._dist_sums = self._snapshot_dist_sums
+        self._snapshot_dist_sums = _EMPTY_NP_ARRAY_FLOAT64
+
+
+# singleton to avoid repeated, unnecessary allocations for the invalid-snapshot placeholder
+_EMPTY_NP_ARRAY_FLOAT64 = np.array([], dtype=np.float64)

--- a/src/max_div/_core/solver/_diversity_contribution/_trackers.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_trackers.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ._factory import build_diversity_contribution_tracker
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+    from max_div._core.metrics import DiversityContributionFamily, DiversityMetric
+
+    from ._base import DiversityContributionTracker
+
+
+# =================================================================================================
+#  DiversityContributionTrackers
+# =================================================================================================
+class DiversityContributionTrackers:
+    """The set of diversity-contribution trackers backing a solver state.
+
+    Holds one tracker per contribution family needed by the configured metrics (families no metric
+    consumes are simply absent, so they cost nothing to maintain), knows which family is the main
+    diversity metric's, and fans every selection mutation out to all trackers.
+    """
+
+    # -------------------------------------------------------------------------
+    #  Construction & copy
+    # -------------------------------------------------------------------------
+    def __init__(
+        self,
+        trackers_by_family: dict[DiversityContributionFamily, DiversityContributionTracker],
+        main_family: DiversityContributionFamily,
+    ) -> None:
+        """Initialize from an explicit family -> tracker mapping; prefer the for_metrics() factory.
+
+        :param trackers_by_family: (dict) one tracker per tracked contribution family.
+        :param main_family: (DiversityContributionFamily) family of the main diversity metric.
+        """
+        self._trackers_by_family = trackers_by_family  # READ-ONLY
+        self._main_family = main_family  # READ-ONLY
+        self._trackers = tuple(trackers_by_family.values())  # iteration order for mutation fan-out
+        self._main = trackers_by_family[main_family]
+
+    @classmethod
+    def for_metrics(
+        cls,
+        diversity_metric: DiversityMetric,
+        diversity_tie_breakers: list[DiversityMetric],
+        pdist: NDArray[np.float32],
+        n: np.int32,
+    ) -> DiversityContributionTrackers:
+        """Build the tracker set required by the given metrics (main metric's family first).
+
+        :param diversity_metric: (DiversityMetric) the main diversity metric.
+        :param diversity_tie_breakers: (list[DiversityMetric]) the configured tie-breaker metrics.
+        :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
+        :param n: (np.int32) number of vectors
+        """
+        main_family = diversity_metric.contribution_family
+        families = dict.fromkeys([main_family, *(tb.contribution_family for tb in diversity_tie_breakers)])
+        return cls(
+            trackers_by_family={family: build_diversity_contribution_tracker(family, pdist, n) for family in families},
+            main_family=main_family,
+        )
+
+    def copy(self) -> DiversityContributionTrackers:
+        """Return a deep copy of this tracker set."""
+        return DiversityContributionTrackers(
+            trackers_by_family={family: t.copy() for family, t in self._trackers_by_family.items()},
+            main_family=self._main_family,
+        )
+
+    # -------------------------------------------------------------------------
+    #  Main tracker
+    # -------------------------------------------------------------------------
+    @property
+    def main(self) -> DiversityContributionTracker:
+        """Return the main diversity metric's tracker (feeds the strategy-facing contribution reads)."""
+        return self._main
+
+    # -------------------------------------------------------------------------
+    #  Mutation fan-out
+    # -------------------------------------------------------------------------
+    def add(self, index: np.int32) -> None:
+        """Update all trackers after adding point `index` to the selection."""
+        for tracker in self._trackers:
+            tracker.add(index)
+
+    def add_many(self, indices: NDArray[np.int32]) -> None:
+        """Update all trackers after adding all points in `indices` to the selection."""
+        for tracker in self._trackers:
+            tracker.add_many(indices)
+
+    def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
+        """Update all trackers after removing point `index` from the selection."""
+        for tracker in self._trackers:
+            tracker.remove(index, new_selection)
+
+    def remove_many(self, indices: NDArray[np.int32], new_selection: NDArray[np.int32]) -> None:
+        """Update all trackers after removing all points in `indices` from the selection."""
+        for tracker in self._trackers:
+            tracker.remove_many(indices, new_selection)
+
+    # -------------------------------------------------------------------------
+    #  Snapshot
+    # -------------------------------------------------------------------------
+    def set_snapshot(self) -> None:
+        """Save the current contribution state of all trackers, overwriting any previous snapshot."""
+        for tracker in self._trackers:
+            tracker.set_snapshot()
+
+    def restore_snapshot(self) -> None:
+        """Restore all trackers to the state saved by the last `set_snapshot` call and invalidate it."""
+        for tracker in self._trackers:
+            tracker.restore_snapshot()

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from max_div._core.constraints import Constraint, ConstraintList
 
-from ._diversity_contribution import DiversityContributionTracker, SeparationTracker
+from ._diversity_contribution import DiversityContributionTrackers
 from ._score import Score, ScoreGenerator
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ class SolverState:
         self,
         n: np.int32,
         k: np.int32,
-        contribution_tracker: DiversityContributionTracker,
+        contribution_trackers: DiversityContributionTrackers,
         score_generator: ScoreGenerator,
         selected: NDArray[np.bool],
         con_values: NDArray[np.int32],
@@ -44,14 +44,14 @@ class SolverState:
 
             n  : total number of vectors
           ( d  : dimensionality of each vector  (not visible here, since distances are pre-digested
-                 into the contribution tracker) )
+                 into the contribution trackers) )
             k  : target selection size
             m : number of constraints
 
         :param n: (np.int32) number of vectors
         :param k: (np.int32) target number of selected vectors
-        :param contribution_tracker: (DiversityContributionTracker) per-point diversity-contribution tracking,
-                                     incrementally updated on every selection mutation.
+        :param contribution_trackers: (DiversityContributionTrackers) the tracker set backing this state's
+                                       per-point diversity contributions, updated on every selection mutation.
         :param score_generator: (ScoreGenerator) score generator to compute scores for current state
         :param selected: (np.ndarray[np.bool]) array indicating which of the n vectors are initially selected.
         :param con_values: (np.ndarray[np.int32] | None) upper/lower bounds per constraint (m x 2 array of float32)
@@ -65,7 +65,8 @@ class SolverState:
         self._k = k  # READ-ONLY
 
         # diversity contributions
-        self._contribution_tracker = contribution_tracker
+        self._contribution_trackers = contribution_trackers
+        self._contribution_tracker = contribution_trackers.main  # strategy-facing tracker (cached hop)
 
         # scoring
         self._score_generator = score_generator  # READ-ONLY
@@ -95,7 +96,7 @@ class SolverState:
         return SolverState(
             n=self._n,
             k=self._k,
-            contribution_tracker=self._contribution_tracker.copy(),
+            contribution_trackers=self._contribution_trackers.copy(),
             score_generator=self._score_generator.copy(),
             selected=self._selected.copy(),
             con_values=self._con_values.copy(),
@@ -116,7 +117,7 @@ class SolverState:
         self._snapshot.selected = self._selected.copy()
         self._snapshot.n_selected = self._n_selected
         self._snapshot.con_values = self._con_values.copy()
-        self._contribution_tracker.set_snapshot()
+        self._contribution_trackers.set_snapshot()
         # NOTE: Score is immutable and mutators reassign self._score (never modify in place),
         #       so storing the reference is safe — no copy needed.
         self._snapshot.score = self.score
@@ -136,7 +137,7 @@ class SolverState:
         self._selected = self._snapshot.selected
         self._n_selected = self._snapshot.n_selected
         self._con_values = self._snapshot.con_values
-        self._contribution_tracker.restore_snapshot()
+        self._contribution_trackers.restore_snapshot()
 
         # restore score (cached at set_snapshot time; avoids a full recompute)
         self._score = self._snapshot.score
@@ -155,8 +156,8 @@ class SolverState:
         self._selected[index] = True
         self._n_selected += np.int32(1)
 
-        # --- diversity contributions ---------------------------
-        self._contribution_tracker.add(index)
+        # --- diversity contributions ---------------------
+        self._contribution_trackers.add(index)
 
         # --- constraints ---------------------------------
         # decrease both min_count and max_count for all constraints that include 'index'
@@ -174,8 +175,8 @@ class SolverState:
         self._selected[indices] = True
         self._n_selected += np.int32(len(indices))
 
-        # --- diversity contributions ---------------------------
-        self._contribution_tracker.add_many(indices)
+        # --- diversity contributions ---------------------
+        self._contribution_trackers.add_many(indices)
 
         # --- constraints ---------------------------------
         # decrease both min_count and max_count for all constraints that include any of 'indices'
@@ -195,8 +196,8 @@ class SolverState:
         self._selected[index] = False
         self._n_selected -= np.int32(1)
 
-        # --- diversity contributions ---------------------------
-        self._contribution_tracker.remove(index, self.selected_index_array)
+        # --- diversity contributions ---------------------
+        self._contribution_trackers.remove(index, self.selected_index_array)
 
         # --- constraints ---------------------------------
         # increase both min_count and max_count for all constraints that include 'index'
@@ -214,8 +215,8 @@ class SolverState:
         self._selected[indices] = False
         self._n_selected -= np.int32(len(indices))
 
-        # --- diversity contributions ---------------------------
-        self._contribution_tracker.remove_many(indices, self.selected_index_array)
+        # --- diversity contributions ---------------------
+        self._contribution_trackers.remove_many(indices, self.selected_index_array)
 
         # --- constraints ---------------------------------
         # increase both min_count and max_count for all constraints that include any of 'indices'
@@ -334,7 +335,9 @@ class SolverState:
     ) -> SolverState:
         # --- diversity contributions ---
         n_np = np.int32(n)
-        contribution_tracker = SeparationTracker(pdist, n_np)
+        contribution_trackers = DiversityContributionTrackers.for_metrics(
+            diversity_metric, diversity_tie_breakers, pdist, n_np
+        )
 
         # --- selection ---
         selected = np.full(n_np, False, dtype=np.bool)
@@ -357,7 +360,7 @@ class SolverState:
         return SolverState(
             n=n_np,
             k=np.int32(k),
-            contribution_tracker=contribution_tracker,
+            contribution_trackers=contribution_trackers,
             score_generator=score_generator,
             selected=selected,
             con_values=con_values,
@@ -374,8 +377,8 @@ class Snapshot:
     """Class internally used by SolverState to store snapshots of its state.
 
     This class models a subset of the fields of the SolverState class, restricting itself to those that can be
-    modified after construction.  Diversity-contribution state is snapshotted by the contribution tracker
-    itself, in lockstep with this snapshot's life cycle.
+    modified after construction.  Diversity-contribution state is snapshotted by the contribution trackers
+    themselves, in lockstep with this snapshot's life cycle.
     """
 
     is_valid: bool

--- a/tests/_core/metrics/test_diversity_metric.py
+++ b/tests/_core/metrics/test_diversity_metric.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from max_div._core.metrics import DiversityMetric
+from max_div._core.metrics import DiversityContributionFamily, DiversityMetric
 
 
 @pytest.mark.parametrize(
@@ -86,3 +86,10 @@ def test_diversity_metric_small_arrays(metric: DiversityMetric, sep_array: np.nd
 
     # --- assert ------------------------------------------
     assert result == 0.0
+
+
+@pytest.mark.parametrize("metric", list(DiversityMetric))
+def test_diversity_metric_contribution_family(metric: DiversityMetric):
+    """Every separation-named metric consumes the SEPARATION contribution family."""
+    # --- act / assert ------------------------------------
+    assert metric.contribution_family == DiversityContributionFamily.SEPARATION

--- a/tests/_core/solver/_diversity_contribution/test_factory.py
+++ b/tests/_core/solver/_diversity_contribution/test_factory.py
@@ -1,0 +1,29 @@
+import numpy as np
+import pytest
+
+from max_div._core.metrics import DistanceMetric, DiversityContributionFamily
+from max_div._core.metrics._distance import compute_pdist
+from max_div._core.solver._diversity_contribution import (
+    MeanDistanceTracker,
+    SeparationTracker,
+    build_diversity_contribution_tracker,
+)
+
+
+@pytest.mark.parametrize(
+    "family, expected_type",
+    [
+        (DiversityContributionFamily.SEPARATION, SeparationTracker),
+        (DiversityContributionFamily.MEAN_DISTANCE, MeanDistanceTracker),
+    ],
+)
+def test_build_diversity_contribution_tracker(family: DiversityContributionFamily, expected_type: type):
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0.0], [1.0], [3.0]], dtype=np.float32)
+    pdist = compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
+
+    # --- act ---------------------------------------------
+    tracker = build_diversity_contribution_tracker(family, pdist, np.int32(3))
+
+    # --- assert ------------------------------------------
+    assert type(tracker) is expected_type

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -1,0 +1,247 @@
+import numpy as np
+import pytest
+from numpy import random
+from scipy.spatial.distance import squareform
+
+from max_div._core.metrics import DistanceMetric
+from max_div._core.metrics._distance import compute_pdist
+from max_div._core.solver._diversity_contribution import MeanDistanceTracker
+from max_div._core.solver._diversity_contribution._mean_distance import (
+    compute_distance_sums,
+    update_distance_sums_add,
+    update_distance_sums_remove,
+)
+
+# =================================================================================================
+#  Fixtures / helpers
+# =================================================================================================
+N = 20
+
+
+@pytest.fixture
+def pdist() -> np.ndarray:
+    rng = random.default_rng(seed=20260713)
+    vectors = rng.random((N, 3)).astype(np.float32)
+    return compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN)
+
+
+@pytest.fixture
+def tracker(pdist: np.ndarray) -> MeanDistanceTracker:
+    return MeanDistanceTracker(pdist, np.int32(N))
+
+
+def _selection_args(indices: list[int]) -> tuple[np.ndarray, np.int32]:
+    """Build the (selected, n_selected) argument pair for contribution reads from a list of selected indices."""
+    selected = np.full(N, False, dtype=np.bool)
+    selected[indices] = True
+    return selected, np.int32(len(indices))
+
+
+def _brute_force_contribution(pdist: np.ndarray, indices: list[int]) -> np.ndarray:
+    """Compute the mean-distance contribution from scratch: mean distance of each point to its selected neighbors."""
+    d_squared = squareform(pdist).astype(np.float64)
+    selected = np.full(N, False, dtype=np.bool)
+    selected[indices] = True
+    sums = d_squared[:, selected].sum(axis=1) if indices else np.zeros(N, dtype=np.float64)
+    divisor = np.maximum(len(indices) - selected, 1)
+    return (sums / divisor).astype(np.float32)
+
+
+# =================================================================================================
+#  Tests
+# =================================================================================================
+def test_construction_fresh(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    selected, n_selected = _selection_args([])
+    expected_global = (squareform(pdist).astype(np.float64).sum(axis=1) / (N - 1)).astype(np.float32)
+
+    # --- assert ------------------------------------------
+    assert tracker.contribution_wrt_dataset.dtype == np.float32
+    np.testing.assert_allclose(tracker.contribution_wrt_dataset, expected_global, rtol=1e-6)
+    # empty selection: all contributions 0.0 (no selected neighbors)
+    np.testing.assert_array_equal(
+        tracker.contribution_wrt_selection(selected, n_selected), np.zeros(N, dtype=np.float32)
+    )
+
+
+def test_construction_precomputed_arrays_skip_recompute(pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    contribution_wrt_dataset = np.arange(N, dtype=np.float32)
+    dist_sums = np.arange(N, dtype=np.float64)
+
+    # --- act ---------------------------------------------
+    tracker = MeanDistanceTracker(
+        pdist, np.int32(N), contribution_wrt_dataset=contribution_wrt_dataset, dist_sums=dist_sums
+    )
+
+    # --- assert ------------------------------------------
+    assert tracker.contribution_wrt_dataset is contribution_wrt_dataset  # taken as-is, not recomputed
+    assert tracker._dist_sums is dist_sums
+
+
+def test_contribution_matches_brute_force_incrementally(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    selection: list[int] = []
+
+    # --- act / assert ------------------------------------
+    for index in [3, 17, 0, 9, 12]:
+        tracker.add(np.int32(index))
+        selection.append(index)
+        selected, n_selected = _selection_args(selection)
+        np.testing.assert_allclose(
+            tracker.contribution_wrt_selection(selected, n_selected),
+            _brute_force_contribution(pdist, selection),
+            rtol=1e-6,
+        )
+
+    for index in [0, 17]:
+        tracker.remove(np.int32(index), new_selection=np.array([], dtype=np.int32))
+        selection.remove(index)
+        selected, n_selected = _selection_args(selection)
+        np.testing.assert_allclose(
+            tracker.contribution_wrt_selection(selected, n_selected),
+            _brute_force_contribution(pdist, selection),
+            rtol=1e-6,
+        )
+
+
+def test_membership_aware_divisor(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    """A selected point's mean divides by (n_selected - 1); a non-selected point's by n_selected."""
+
+    # --- arrange -----------------------------------------
+    d_squared = squareform(pdist).astype(np.float64)
+    tracker.add(np.int32(2))
+    tracker.add(np.int32(5))
+    selected, n_selected = _selection_args([2, 5])
+
+    # --- act ---------------------------------------------
+    contribution = tracker.contribution_wrt_selection(selected, n_selected)
+
+    # --- assert ------------------------------------------
+    # selected point 2: one real neighbor (5) -> mean = d(2,5) / 1
+    assert contribution[2] == pytest.approx(d_squared[2, 5], rel=1e-6)
+    # non-selected point 0: two neighbors -> mean = (d(0,2) + d(0,5)) / 2
+    assert contribution[0] == pytest.approx((d_squared[0, 2] + d_squared[0, 5]) / 2, rel=1e-6)
+
+
+def test_invariant_random_operations_match_recompute(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    """After arbitrary add/remove/snapshot sequences, contributions must match a brute-force recompute."""
+
+    # --- arrange -----------------------------------------
+    rng = random.default_rng(seed=7)
+    selection: list[int] = []
+    snapshot_selection: list[int] | None = None
+
+    # --- act / assert ------------------------------------
+    for _ in range(200):
+        can_restore = snapshot_selection is not None
+        options = ["add", "remove", "set_snapshot"] + (["restore_snapshot"] if can_restore else [])
+        match rng.choice(options):
+            case "add" if len(selection) < N:
+                index = int(rng.choice([i for i in range(N) if i not in selection]))
+                tracker.add(np.int32(index))
+                selection.append(index)
+            case "remove" if selection:
+                index = int(rng.choice(selection))
+                selection.remove(index)
+                tracker.remove(np.int32(index), new_selection=np.array(selection, dtype=np.int32))
+            case "set_snapshot":
+                tracker.set_snapshot()
+                snapshot_selection = selection.copy()
+            case "restore_snapshot":
+                tracker.restore_snapshot()
+                selection = snapshot_selection.copy()  # ty: ignore[possibly-unbound-attribute]  # gated by can_restore
+                snapshot_selection = None
+
+        selected, n_selected = _selection_args(selection)
+        np.testing.assert_allclose(
+            tracker.contribution_wrt_selection(selected, n_selected),
+            _brute_force_contribution(pdist, selection),
+            rtol=1e-5,
+        )
+
+
+def test_copy_is_independent(tracker: MeanDistanceTracker):
+    # --- arrange -----------------------------------------
+    tracker.add(np.int32(0))
+    clone = tracker.copy()
+    selected, n_selected = _selection_args([0])
+    contribution_before = clone.contribution_wrt_selection(selected, n_selected).copy()
+
+    # --- act ---------------------------------------------
+    tracker.add(np.int32(4))
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(clone.contribution_wrt_selection(selected, n_selected), contribution_before)
+    assert clone.contribution_wrt_dataset is not tracker.contribution_wrt_dataset
+
+
+# =================================================================================================
+#  Kernels
+# =================================================================================================
+def test_compute_distance_sums():
+    """Check if compute_distance_sums matches a brute-force row-sum of the full distance matrix."""
+
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(20260713)
+    vectors = rng.standard_normal((30, 4)).astype(np.float32)
+    m = vectors.shape[0]
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+    expected = squareform(d).astype(np.float64).sum(axis=1)
+
+    # --- act ---------------------------------------------
+    dist_sums = compute_distance_sums(d, np.int32(m))
+
+    # --- assert ------------------------------------------
+    assert dist_sums.dtype == np.float64
+    np.testing.assert_allclose(dist_sums, expected, rtol=1e-6)
+
+
+def test_update_distance_sums_add_remove():
+    """Incremental add/remove updates match brute-force sums over the selection at every step."""
+
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(20260713)
+    vectors = rng.standard_normal((20, 3)).astype(np.float32)
+    m = vectors.shape[0]
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+    d_squared = squareform(d).astype(np.float64)
+
+    dist_sums = np.zeros(m, dtype=np.float64)
+    selection: list[int] = []
+
+    def expected_sums() -> np.ndarray:
+        # brute-force: each point's sum of distances to the selected points (self-distance is 0)
+        return d_squared[:, selection].sum(axis=1) if selection else np.zeros(m, dtype=np.float64)
+
+    # --- act / assert ------------------------------------
+    for index in [3, 17, 0, 9, 12]:
+        update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(index))
+        selection.append(index)
+        np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
+
+    for index in [0, 3, 12]:
+        update_distance_sums_remove(dist_sums, d, np.int32(m), np.int32(index))
+        selection.remove(index)
+        np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
+
+
+def test_update_distance_sums_own_entry_untouched():
+    """A point's own entry is unchanged by adding/removing that point (its self-distance is 0)."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0, 0], [3, 4], [1, 0], [0, 2]], dtype=np.float32)
+    m = vectors.shape[0]
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+    dist_sums = np.zeros(m, dtype=np.float64)
+
+    # selection {1}: point 1's own entry stays 0 (no other selected points yet)
+    update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(1))
+    assert dist_sums[1] == 0.0
+
+    # --- act ---------------------------------------------
+    # selection {1, 2}: point 2's own entry must equal its distance to point 1 only
+    update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(2))
+
+    # --- assert ------------------------------------------
+    assert dist_sums[2] == pytest.approx(squareform(d)[2, 1])

--- a/tests/_core/solver/_diversity_contribution/test_trackers.py
+++ b/tests/_core/solver/_diversity_contribution/test_trackers.py
@@ -1,0 +1,117 @@
+import numpy as np
+import pytest
+
+from max_div._core.metrics import DistanceMetric, DiversityContributionFamily, DiversityMetric
+from max_div._core.metrics._distance import compute_pdist
+from max_div._core.solver._diversity_contribution import (
+    DiversityContributionTrackers,
+    MeanDistanceTracker,
+    SeparationTracker,
+)
+
+# =================================================================================================
+#  Fixtures / helpers
+# =================================================================================================
+N = 6
+
+
+@pytest.fixture
+def pdist() -> np.ndarray:
+    vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0], [15.0]], dtype=np.float32)
+    return compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
+
+
+# =================================================================================================
+#  Tests
+# =================================================================================================
+def test_for_metrics_single_family(pdist: np.ndarray):
+    # --- act ---------------------------------------------
+    trackers = DiversityContributionTrackers.for_metrics(
+        diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
+        diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
+        pdist=pdist,
+        n=np.int32(N),
+    )
+
+    # --- assert ------------------------------------------
+    # both metrics are separation-family -> exactly one tracker, which is also the main one
+    assert len(trackers._trackers) == 1
+    assert type(trackers.main) is SeparationTracker
+    assert trackers.main is trackers._trackers[0]
+
+
+def test_for_metrics_mixed_families(pdist: np.ndarray):
+    # --- act ---------------------------------------------
+    trackers = DiversityContributionTrackers.for_metrics(
+        diversity_metric=DiversityMetric.MIN_SEPARATION,
+        diversity_tie_breakers=[DiversityMetric.MIN_SEPARATION, DiversityMetric.MEAN_SEPARATION],
+        pdist=pdist,
+        n=np.int32(N),
+    )
+
+    # --- assert ------------------------------------------
+    # duplicate families are deduplicated
+    assert len(trackers._trackers) == 1
+    assert type(trackers.main) is SeparationTracker
+
+
+def test_mutations_fan_out_to_all_trackers(pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    # hand-built two-family set, mirroring what a mixed-metric configuration would construct
+    sep, mean = SeparationTracker(pdist, np.int32(N)), MeanDistanceTracker(pdist, np.int32(N))
+    trackers = DiversityContributionTrackers(
+        trackers_by_family={
+            DiversityContributionFamily.SEPARATION: sep,
+            DiversityContributionFamily.MEAN_DISTANCE: mean,
+        },
+        main_family=DiversityContributionFamily.MEAN_DISTANCE,
+    )
+    sep_ref, mean_ref = SeparationTracker(pdist, np.int32(N)), MeanDistanceTracker(pdist, np.int32(N))
+    selected = np.full(N, False, dtype=np.bool)
+    selected[[0, 3]] = True
+
+    # --- act ---------------------------------------------
+    trackers.add(np.int32(0))
+    trackers.add_many(np.array([2, 3], dtype=np.int32))
+    trackers.set_snapshot()
+    trackers.remove_many(np.array([2, 3], dtype=np.int32), new_selection=np.array([0], dtype=np.int32))
+    trackers.restore_snapshot()
+    trackers.remove(np.int32(2), new_selection=np.array([0, 3], dtype=np.int32))
+
+    for ref in (sep_ref, mean_ref):
+        ref.add(np.int32(0))
+        ref.add_many(np.array([2, 3], dtype=np.int32))
+        ref.remove(np.int32(2), new_selection=np.array([0, 3], dtype=np.int32))
+
+    # --- assert ------------------------------------------
+    assert trackers.main is mean
+    np.testing.assert_array_equal(
+        sep.contribution_wrt_selection(selected, np.int32(2)),
+        sep_ref.contribution_wrt_selection(selected, np.int32(2)),
+    )
+    np.testing.assert_array_equal(
+        mean.contribution_wrt_selection(selected, np.int32(2)),
+        mean_ref.contribution_wrt_selection(selected, np.int32(2)),
+    )
+
+
+def test_copy_is_independent(pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    trackers = DiversityContributionTrackers.for_metrics(
+        diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
+        diversity_tie_breakers=[],
+        pdist=pdist,
+        n=np.int32(N),
+    )
+    trackers.add(np.int32(0))
+    clone = trackers.copy()
+    selected = np.full(N, False, dtype=np.bool)
+    selected[0] = True
+    before = clone.main.contribution_wrt_selection(selected, np.int32(1)).copy()
+
+    # --- act ---------------------------------------------
+    trackers.add(np.int32(4))
+
+    # --- assert ------------------------------------------
+    assert clone.main is not trackers.main
+    np.testing.assert_array_equal(clone.main.contribution_wrt_selection(selected, np.int32(1)), before)

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -5,6 +5,7 @@ from numpy import random
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 from max_div._core.metrics._distance import compute_pdist
+from max_div._core.solver._diversity_contribution import SeparationTracker
 from max_div._core.solver._solver_state import SolverState, _build_con_membership
 
 
@@ -229,6 +230,17 @@ def test_solver_state_consistency_stress_test(new_solver_state, seed: int):
 
     assert state.n_selected == state_ref.n_selected
     assert state.n_not_selected == state_ref.n_not_selected
+
+
+def test_solver_state_tracker_set_dormancy(new_solver_state):
+    """Separation-only metric configurations construct exactly one tracker: dormancy by absence."""
+    # --- act ---------------------------------------------
+    trackers = new_solver_state._contribution_trackers._trackers
+
+    # --- assert ------------------------------------------
+    assert len(trackers) == 1
+    assert type(trackers[0]) is SeparationTracker
+    assert new_solver_state._contribution_tracker is trackers[0]
 
 
 def test_build_con_membership():


### PR DESCRIPTION
Second contribution family, landed dormant. `MeanDistanceTracker` stores raw per-point distance sums in float64 (incremental updates stay exact add/subtract arithmetic; kernels live alongside the tracker) and exposes mean-form float32 contributions with a membership-aware divisor (a selected point's zero self-distance is not a neighbor). `SolverState.new` now derives the tracker set from the configured metrics' contribution families — dormancy by absence: no metric consumes the new family yet, so separation solves construct exactly what they did before. Invariant test: after random add/remove/snapshot sequences the incremental contributions match a brute-force recompute. Golden master untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)