### PR TITLE
feat: add MEAN_PAIRWISE_DISTANCE diversity metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- New `MEAN_PAIRWISE_DISTANCE` diversity metric: maximize the mean pairwise distance among selected vectors (the classical max-sum diversity objective), alongside the existing separation-based metrics
 
 ### Changed
 

--- a/docs/concepts/diversity.md
+++ b/docs/concepts/diversity.md
@@ -5,19 +5,26 @@
 The solver evaluates how diverse a selection is through a three-step process:
 
 ```
-Vectors  ──>  Pairwise Distances  ──>  Separations  ──>  Diversity Score
- (n x d)        (n*(n-1)/2)              (k x 1)           (scalar)
+Vectors  ──>  Pairwise Distances  ──>  Contributions  ──>  Diversity Score
+ (n x d)        (n*(n-1)/2)               (k x 1)                (scalar)
 ```
 
 1. **Pairwise distances** are computed once upfront between all `n` vectors using the chosen
    distance metric. These are stored as a condensed distance vector (like scipy's `pdist`).
 
-2. **Separations** are computed for each selected vector: the distance to its *nearest neighbor*
-   within the current selection. This is the key quantity -- a vector with high separation is
-   well-spread from the rest of the selection; a vector with low separation is close to at
-   least one other selected vector.
+2. A **diversity contribution** is computed for each selected vector -- a per-vector quantity where
+   higher means "contributes more diversity". Which quantity that is depends on the diversity metric's
+   family:
 
-3. The **diversity score** aggregates the `k` separation values into a single scalar using the
+    - **Separation family** (all `*_SEPARATION` metrics): the distance to the vector's
+      *nearest neighbor* within the current selection. A vector with high separation is
+      well-spread from the rest of the selection; a vector with low separation is close to at
+      least one other selected vector.
+    - **Mean-distance family** (`MEAN_PAIRWISE_DISTANCE`): the vector's *mean distance to the
+      other selected vectors* -- exactly how much the vector contributes to the total spread
+      of the selection.
+
+3. The **diversity score** aggregates the `k` contribution values into a single scalar using the
    chosen diversity metric.
 
 ## Distance Metrics
@@ -49,6 +56,16 @@ Separation is maintained incrementally during optimization:
 This incremental update is much cheaper than recomputing all separations from scratch after
 each swap.
 
+## Mean Distance
+
+The **mean distance** of a selected vector is its mean distance to the other selected vectors:
+
+$$\text{md}(v) = \frac{1}{k - 1} \sum_{u \in S,\; u \neq v} d(v, u)$$
+
+It is maintained incrementally as well, and even more cheaply than separation: adding a vector
+adds one distance to every vector's running sum, and removing one subtracts it exactly -- no
+rescan of the selection is ever needed.
+
 ## Diversity Metrics
 
 Each diversity metric aggregates the `k` separation values differently:
@@ -59,6 +76,7 @@ Each diversity metric aggregates the `k` separation values differently:
 | `MIN_SEPARATION` | $$\min_{v \in S} \text{sep}(v)$$ | Only considers the worst-off vector (the closest pair). Equivalent to the *p-dispersion* problem. Many swaps produce tied scores. |
 | `MEAN_SEPARATION` | $$\frac{1}{k}\sum_{v \in S} \text{sep}(v)$$ | Averages all separations. Less sensitive to individual outliers than geomean, but can be dominated by a few very high separations. |
 | `APPROX_GEOMEAN_SEPARATION` | Same as geomean but using fast log/exp approximations | Slightly less accurate but faster per iteration. Useful for large-scale problems where iteration speed matters more than per-iteration precision. |
+| `MEAN_PAIRWISE_DISTANCE` | $$\frac{2}{k(k-1)}\sum_{\{u,v\} \subseteq S} d(u, v)$$ | Mean distance over all selected *pairs* -- the classical **max-sum diversity** objective (MaxSum MDP, also known as *remote-clique*). Maximizes total spread: selections gravitate to the outer regions of the data, and near-duplicates are tolerated if both sit far from everything else. |
 
 ### Which metric to choose?
 
@@ -71,3 +89,11 @@ Each diversity metric aggregates the `k` separation values differently:
   other vectors compensate with large separations.
 - **`APPROX_GEOMEAN_SEPARATION`** is a drop-in replacement for `GEOMEAN_SEPARATION` when
   you want to trade a small amount of precision for more iterations per second.
+- **`MEAN_PAIRWISE_DISTANCE`** is the objective to pick when you want classical max-sum
+  diversity semantics ("maximize total spread") or want results comparable with the MaxSum
+  MDP literature. Unlike every separation metric it does *not* penalize near-duplicates per
+  se -- two nearly identical vectors at the data's boundary can both be kept. Note that the
+  solver's swap heuristics were originally designed and tuned around separation contributions; they
+  are correct for this metric (its per-vector contribution is the vector's exact marginal
+  contribution to the objective), but the separation metrics remain the most battle-tested
+  choice.

--- a/src/max_div/_core/metrics/_diversity/_enum.py
+++ b/src/max_div/_core/metrics/_diversity/_enum.py
@@ -32,6 +32,8 @@ class DiversityMetric(StrEnum):
         - APPROX_GEOMEAN_SEPARATION:  Approximate geometric mean separation of all selected vectors
                                           (uses faster, but still smooth approximations of log(.) and exp(.))
         - NON_ZERO_SEPARATION_FRAC:   Fraction of separation values that are non-zero
+        - MEAN_PAIRWISE_DISTANCE:     Mean distance over all pairs of selected vectors
+                                          (the classical max-sum diversity objective)
     """
 
     MIN_SEPARATION = "MIN_SEPARATION"
@@ -39,10 +41,13 @@ class DiversityMetric(StrEnum):
     GEOMEAN_SEPARATION = "GEOMEAN_SEPARATION"
     APPROX_GEOMEAN_SEPARATION = "APPROX_GEOMEAN_SEPARATION"
     NON_ZERO_SEPARATION_FRAC = "NON_ZERO_SEPARATION_FRAC"
+    MEAN_PAIRWISE_DISTANCE = "MEAN_PAIRWISE_DISTANCE"
 
     @cached_property
     def contribution_family(self) -> DiversityContributionFamily:
         """Return the diversity-contribution family whose per-point values this metric consumes."""
+        if self == DiversityMetric.MEAN_PAIRWISE_DISTANCE:
+            return DiversityContributionFamily.MEAN_DISTANCE
         return DiversityContributionFamily.SEPARATION
 
     @cached_property
@@ -52,6 +57,7 @@ class DiversityMetric(StrEnum):
         from ._numba import (
             approx_geomean_separation,
             geomean_separation,
+            mean_pairwise_distance,
             mean_separation,
             min_separation,
             non_zero_separation_frac,
@@ -63,6 +69,7 @@ class DiversityMetric(StrEnum):
             DiversityMetric.GEOMEAN_SEPARATION: geomean_separation,
             DiversityMetric.APPROX_GEOMEAN_SEPARATION: approx_geomean_separation,
             DiversityMetric.NON_ZERO_SEPARATION_FRAC: non_zero_separation_frac,
+            DiversityMetric.MEAN_PAIRWISE_DISTANCE: mean_pairwise_distance,
         }
         # NOTE: statically, a numba `Dispatcher` does not unify with the plain `Callable`
         #       return type; at runtime it is called exactly like one.

--- a/src/max_div/_core/metrics/_diversity/_numba.py
+++ b/src/max_div/_core/metrics/_diversity/_numba.py
@@ -22,6 +22,16 @@ def mean_separation(sep: NDArray[np.float32]) -> np.float32:
 
 
 @njit("float32(float32[::1])", fastmath=True, inline="always")
+def mean_pairwise_distance(mean_dists: NDArray[np.float32]) -> np.float32:
+    """Mean pairwise distance among all selected vectors, from their mean-distance contribution values.
+
+    Each selected vector's contribution is its mean distance to the other selected vectors; averaging
+    those per-vector means over the selection yields exactly the mean over all selected pairs.
+    """
+    return np.mean(mean_dists)
+
+
+@njit("float32(float32[::1])", fastmath=True, inline="always")
 def geomean_separation(sep: NDArray[np.float32]) -> np.float32:
     """Geometric mean separation of all selected vectors."""
     log_sum = np.float32(0.0)

--- a/tests/_core/metrics/test_diversity_metric.py
+++ b/tests/_core/metrics/test_diversity_metric.py
@@ -20,6 +20,9 @@ from max_div._core.metrics import DiversityContributionFamily, DiversityMetric
         (DiversityMetric.NON_ZERO_SEPARATION_FRAC, [0.1, 0.4], 1.0, 1e-6),
         (DiversityMetric.NON_ZERO_SEPARATION_FRAC, [0.1, 0.0], 0.5, 1e-6),
         (DiversityMetric.NON_ZERO_SEPARATION_FRAC, [0.0, 0.0], 0.0, 1e-6),
+        (DiversityMetric.MEAN_PAIRWISE_DISTANCE, [], 0.0, 1e-6),
+        (DiversityMetric.MEAN_PAIRWISE_DISTANCE, [0.1, 0.4], 0.25, 1e-6),
+        (DiversityMetric.MEAN_PAIRWISE_DISTANCE, [2.0, 3.0, 4.0], 3.0, 1e-6),
     ],
 )
 def test_diversity_compute(metric: DiversityMetric, separation: list[float], expected_result: float, tol: float):
@@ -90,6 +93,13 @@ def test_diversity_metric_small_arrays(metric: DiversityMetric, sep_array: np.nd
 
 @pytest.mark.parametrize("metric", list(DiversityMetric))
 def test_diversity_metric_contribution_family(metric: DiversityMetric):
-    """Every separation-named metric consumes the SEPARATION contribution family."""
+    """Each metric maps to the contribution family its name implies."""
+    # --- arrange -----------------------------------------
+    expected = (
+        DiversityContributionFamily.MEAN_DISTANCE
+        if metric == DiversityMetric.MEAN_PAIRWISE_DISTANCE
+        else DiversityContributionFamily.SEPARATION
+    )
+
     # --- act / assert ------------------------------------
-    assert metric.contribution_family == DiversityContributionFamily.SEPARATION
+    assert metric.contribution_family == expected

--- a/tests/_core/solver/test_solver.py
+++ b/tests/_core/solver/test_solver.py
@@ -127,3 +127,86 @@ def test_solver_vector_and_distance_input_bit_identical():
     # --- assert ------------------------------------------
     assert list(solutions[0].i_selected) == list(solutions[1].i_selected)
     assert solutions[0].score == solutions[1].score
+
+
+# =================================================================================================
+#  MEAN_PAIRWISE_DISTANCE metric
+# =================================================================================================
+def _mean_pairwise_distance_of(vectors: np.ndarray, indices: np.ndarray) -> float:
+    """Brute-force mean pairwise L2 distance among the vectors at 'indices'."""
+    selected = vectors[indices].astype(np.float64)
+    dists = [
+        float(np.linalg.norm(selected[i] - selected[j]))
+        for i in range(len(selected))
+        for j in range(i + 1, len(selected))
+    ]
+    return float(np.mean(dists))
+
+
+def _make_mean_pairwise_distance_problem(n: int = 60, k: int = 8) -> tuple[MaxDivProblem, np.ndarray]:
+    rng = np.random.default_rng(seed=20260713)
+    vectors = rng.random((n, 3)).astype(np.float32)
+    problem = MaxDivProblem.new(
+        vectors=vectors,
+        k=k,
+        distance_metric=DistanceMetric.L2_EUCLIDEAN,
+        diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
+    )
+    return problem, vectors
+
+
+def test_solver_mean_pairwise_distance_end_to_end():
+    # --- arrange -----------------------------------------
+    problem, vectors = _make_mean_pairwise_distance_problem()
+    solver = MaxDivSolverBuilder(problem).with_preset(iterations(300)).with_seed(42).build()
+
+    # --- act ---------------------------------------------
+    solution = solver.solve(verbosity=0)
+
+    # --- assert ------------------------------------------
+    assert len(solution.i_selected) == problem.k
+    assert len(set(solution.i_selected)) == problem.k
+    # reported diversity equals brute-force mean pairwise distance of the returned selection
+    expected = _mean_pairwise_distance_of(vectors, solution.i_selected)
+    assert solution.score.diversity == pytest.approx(expected, rel=1e-5)
+
+
+def test_solver_mean_pairwise_distance_deterministic():
+    # --- arrange -----------------------------------------
+    problem, _ = _make_mean_pairwise_distance_problem()
+
+    # --- act ---------------------------------------------
+    solutions = [
+        MaxDivSolverBuilder(problem).with_preset(iterations(300)).with_seed(7).build().solve(verbosity=0)
+        for _ in range(2)
+    ]
+
+    # --- assert ------------------------------------------
+    assert np.array_equal(solutions[0].i_selected, solutions[1].i_selected)
+    assert solutions[0].score == solutions[1].score
+
+
+def _greedy_max_sum_selection(vectors: np.ndarray, k: int) -> np.ndarray:
+    """Classical greedy insertion for max-sum diversity (1/2-approximation baseline)."""
+    v = vectors.astype(np.float64)
+    d = np.sqrt(((v[:, None, :] - v[None, :, :]) ** 2).sum(axis=2))
+    selection = list(np.unravel_index(np.argmax(d), d.shape))  # start from the farthest pair
+    while len(selection) < k:
+        sums = d[:, selection].sum(axis=1)
+        sums[selection] = -np.inf  # already selected
+        selection.append(int(np.argmax(sums)))
+    return np.array(selection, dtype=np.int32)
+
+
+def test_solver_mean_pairwise_distance_meets_greedy_baseline():
+    """The solver must meet or beat the classical greedy max-sum baseline on a modest budget."""
+
+    # --- arrange -----------------------------------------
+    problem, vectors = _make_mean_pairwise_distance_problem()
+    greedy_score = _mean_pairwise_distance_of(vectors, _greedy_max_sum_selection(vectors, problem.k))
+
+    # --- act ---------------------------------------------
+    solution = MaxDivSolverBuilder(problem).with_preset(iterations(1500)).with_seed(3).build().solve(verbosity=0)
+
+    # --- assert ------------------------------------------
+    assert solution.score.diversity >= greedy_score * (1.0 - 1e-6)

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -5,7 +5,7 @@ from numpy import random
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 from max_div._core.metrics._distance import compute_pdist
-from max_div._core.solver._diversity_contribution import SeparationTracker
+from max_div._core.solver._diversity_contribution import MeanDistanceTracker, SeparationTracker
 from max_div._core.solver._solver_state import SolverState, _build_con_membership
 
 
@@ -241,6 +241,57 @@ def test_solver_state_tracker_set_dormancy(new_solver_state):
     assert len(trackers) == 1
     assert type(trackers[0]) is SeparationTracker
     assert new_solver_state._contribution_tracker is trackers[0]
+
+
+def test_solver_state_tracker_set_mean_distance(new_solver_state):
+    """A mean-distance main metric constructs only a MeanDistanceTracker; mixed metrics construct both."""
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0.0], [1.0], [2.0], [3.0]], dtype=np.float32)
+    pdist = compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
+
+    # --- act ---------------------------------------------
+    state_pure = SolverState.new(
+        n=4,
+        pdist=pdist,
+        k=2,
+        diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
+        diversity_tie_breakers=[],
+        constraints=[],
+    )
+    state_mixed = SolverState.new(
+        n=4,
+        pdist=pdist,
+        k=2,
+        diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
+        diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
+        constraints=[],
+    )
+
+    # --- assert ------------------------------------------
+    assert [type(t) for t in state_pure._contribution_trackers._trackers] == [MeanDistanceTracker]
+    assert type(state_pure._contribution_tracker) is MeanDistanceTracker
+    assert {type(t) for t in state_mixed._contribution_trackers._trackers} == {MeanDistanceTracker, SeparationTracker}
+    assert type(state_mixed._contribution_tracker) is MeanDistanceTracker  # main metric's tracker faces the strategies
+
+
+def test_solver_state_mean_pairwise_distance_score():
+    """The diversity score under MEAN_PAIRWISE_DISTANCE equals the brute-force mean over selected pairs."""
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0.0], [1.0], [3.0], [7.0]], dtype=np.float32)
+    state = SolverState.new(
+        n=4,
+        pdist=compute_pdist(vectors, DistanceMetric.L1_MANHATTAN),
+        k=3,
+        diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
+        diversity_tie_breakers=[],
+        constraints=[],
+    )
+
+    # --- act ---------------------------------------------
+    state.add_many(np.array([0, 1, 3], dtype=np.int32))  # points 0, 1, 7 -> pair distances 1, 7, 6
+
+    # --- assert ------------------------------------------
+    assert state.score.diversity == pytest.approx((1 + 7 + 6) / 3)
 
 
 def test_build_con_membership():


### PR DESCRIPTION
Activates the mean-distance contribution family with the classical **max-sum diversity** objective: `DiversityMetric.MEAN_PAIRWISE_DISTANCE` maximizes the mean distance over all selected pairs. Because each vector's mean-distance contribution is its exact marginal contribution to this objective, the existing guided/smart swap strategies bias correctly without modification. No default tie-breakers — the objective is smooth, ties are rare. Docs gain the second-family story (taxonomy: MaxSum MDP / remote-clique) with guidance on when to choose it.

Verification: end-to-end solve reports a diversity equal to the brute-force mean pairwise distance of the returned selection; seeded runs are reproducible; and the solver meets-or-beats the classical greedy insertion baseline (1/2-approximation) on a modest iteration budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)