### PR TITLE
chore: add comparison-benchmark harness scaffold

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,36 @@
+# Comparison-benchmark harness
+
+Tooling for benchmarking max-div against other freely available subset-selection tools
+(see the docs' *Comparison* page for the landscape). This directory is repo-tracked for
+transparency and reproducibility, but it is **not part of the published package** — its
+dependencies live in the `benchmarks` dependency group, never in package metadata.
+
+## Layout
+
+- `common/` — shared infrastructure: budget ladders, subset-quality evaluation,
+  run records, benchmark problem construction.
+- `adapters/` — one adapter per competing tool/baseline, all implementing
+  `SelectionAdapter`.
+- `runners/` — drivers that execute max-div (anytime ladder) or an adapter
+  (single-shot) against a problem and emit run records.
+- `figures/` — plotting of anytime curves (max-div) vs. single-shot dots (competitors).
+- `tier2/` — benchmark scenarios vs. Python subset-selection heuristics.
+
+## Running
+
+```bash
+uv sync --group benchmarks
+uv run --group benchmarks python -m benchmarks.tier2.smoke
+```
+
+Outputs (JSONL records + figures) are written under `./reports/benchmarks/` (gitignored);
+only curated result tables/figures are ever promoted into `docs/`.
+
+## Measurement protocol
+
+- max-div runs a **budget ladder** (2× steps); every record stores the *measured*
+  wall-clock reported by the solver, never the nominal budget.
+- Single-shot competitors run once per seed; their measured runtime is recorded the
+  same way.
+- Selection quality is always evaluated by `common/quality.py` under max-div's own
+  diversity metrics, for every tool alike.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Comparison-benchmark harness for max-div; repo tooling, not part of the published package."""

--- a/benchmarks/adapters/__init__.py
+++ b/benchmarks/adapters/__init__.py
@@ -1,0 +1,9 @@
+"""Adapters: one per compared tool/baseline, all implementing SelectionAdapter."""
+
+from .base import SelectionAdapter
+from .random_baseline import RandomBaseline
+
+__all__ = [
+    "RandomBaseline",
+    "SelectionAdapter",
+]

--- a/benchmarks/adapters/base.py
+++ b/benchmarks/adapters/base.py
@@ -1,0 +1,37 @@
+"""The adapter contract every compared tool implements."""
+
+import time
+from abc import ABC, abstractmethod
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+
+class SelectionAdapter(ABC):
+    """A single-shot subset-selection tool wrapped behind a uniform interface.
+
+    Adapters return raw selections; quality scoring and record building happen in the
+    runners, identically for every tool.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+
+    @property
+    def supports_constraints(self) -> bool:
+        """Whether the tool can honor the problem's fairness constraints (default: no)."""
+        return False
+
+    @abstractmethod
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Select k item indices for the problem; must be deterministic given the seed."""
+
+    def timed_select(self, problem: MaxDivProblem, seed: int) -> tuple[NDArray[np.int64], float]:
+        """Run select() and measure its wall-clock duration in seconds."""
+        t0 = time.perf_counter()
+        indices = self.select(problem, seed)
+        return indices, time.perf_counter() - t0

--- a/benchmarks/adapters/random_baseline.py
+++ b/benchmarks/adapters/random_baseline.py
@@ -1,0 +1,22 @@
+"""Uniform-random selection: the quality floor every real tool must clear."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from .base import SelectionAdapter
+
+
+class RandomBaseline(SelectionAdapter):
+    """Select k items uniformly at random (constraint-oblivious)."""
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "random"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Draw k distinct indices uniformly at random."""
+        rng = np.random.default_rng(seed)
+        return rng.choice(problem.n, size=problem.k, replace=False).astype(np.int64)

--- a/benchmarks/common/__init__.py
+++ b/benchmarks/common/__init__.py
@@ -1,0 +1,17 @@
+"""Shared benchmark infrastructure: ladders, quality evaluation, run records, problems."""
+
+from .ladders import iteration_ladder, time_ladder
+from .problems import build_problem
+from .quality import evaluate_selection, n_constraints_satisfied
+from .records import RunRecord, load_records, save_records
+
+__all__ = [
+    "RunRecord",
+    "build_problem",
+    "evaluate_selection",
+    "iteration_ladder",
+    "load_records",
+    "n_constraints_satisfied",
+    "save_records",
+    "time_ladder",
+]

--- a/benchmarks/common/ladders.py
+++ b/benchmarks/common/ladders.py
@@ -1,0 +1,41 @@
+"""Budget ladders: the geometric sequences of solve budgets used for anytime measurements."""
+
+
+def time_ladder(t_min_sec: float = 0.001, t_max_sec: float = 1.0, factor: float = 2.0) -> list[float]:
+    """Build a geometric wall-clock budget ladder, in seconds.
+
+    Args:
+        t_min_sec: Bottom rung (first budget).
+        t_max_sec: Ceiling; the last rung is the first value >= this, so the
+            ceiling itself is always covered.
+        factor: Multiplicative step between rungs.
+
+    Returns:
+        Increasing list of budgets in seconds.
+    """
+    if t_min_sec <= 0 or t_max_sec < t_min_sec or factor <= 1.0:
+        raise ValueError("Ladder requires 0 < t_min_sec <= t_max_sec and factor > 1.")
+    rungs = [t_min_sec]
+    while rungs[-1] < t_max_sec:
+        rungs.append(rungs[-1] * factor)
+    return rungs
+
+
+def iteration_ladder(i_min: int = 10, i_max: int = 100_000, factor: float = 2.0) -> list[int]:
+    """Build a geometric iteration-count budget ladder.
+
+    Args:
+        i_min: Bottom rung (first budget).
+        i_max: Ceiling; the last rung is the first value >= this.
+        factor: Multiplicative step between rungs.
+
+    Returns:
+        Increasing list of iteration counts (deduplicated after rounding).
+    """
+    if i_min <= 0 or i_max < i_min or factor <= 1.0:
+        raise ValueError("Ladder requires 0 < i_min <= i_max and factor > 1.")
+    rungs = [i_min]
+    while rungs[-1] < i_max:
+        nxt = max(rungs[-1] + 1, round(rungs[-1] * factor))
+        rungs.append(nxt)
+    return rungs

--- a/benchmarks/common/problems.py
+++ b/benchmarks/common/problems.py
@@ -1,0 +1,19 @@
+"""Benchmark problem construction on top of max-div's built-in problem generators."""
+
+from max_div.benchmark_problems import BenchmarkProblemFactory
+from max_div.metrics import DiversityMetric
+from max_div.problem import VectorMaxDivProblem
+
+
+def build_problem(name: str, size: int, diversity_metric: DiversityMetric) -> VectorMaxDivProblem:
+    """Construct a built-in benchmark problem (U1-U4 / C1-C4) at the given size.
+
+    Args:
+        name: Registered benchmark problem name, e.g. ``"U1"`` or ``"C3"``.
+        size: The generator's size parameter ``s`` (n scales as ~100s).
+        diversity_metric: Diversity metric the constructed problem optimizes.
+
+    Returns:
+        The constructed problem instance.
+    """
+    return BenchmarkProblemFactory.construct_problem(name, size=size, diversity_metric=diversity_metric)

--- a/benchmarks/common/quality.py
+++ b/benchmarks/common/quality.py
@@ -1,0 +1,74 @@
+"""Subset-quality evaluation: score any tool's selection under max-div's own diversity metrics.
+
+Every compared tool is judged with the functions here, so quality numbers are comparable
+across tools by construction. Evaluation works from the problem's condensed distance
+vector, so it applies to vector-based and precomputed-distance problems alike.
+"""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.metrics import DiversityMetric
+from max_div.problem import MaxDivProblem
+
+# The four canonical metrics every selection is scored under (APPROX_GEOMEAN is a speed
+# variant of GEOMEAN, not a distinct objective, so it is not evaluated separately).
+EVALUATED_METRICS: tuple[DiversityMetric, ...] = (
+    DiversityMetric.MIN_SEPARATION,
+    DiversityMetric.MEAN_SEPARATION,
+    DiversityMetric.GEOMEAN_SEPARATION,
+    DiversityMetric.MEAN_PAIRWISE_DISTANCE,
+)
+
+
+def evaluate_selection(problem: MaxDivProblem, i_selected: NDArray[np.integer]) -> dict[str, float]:
+    """Score a selection under all canonical diversity metrics.
+
+    Args:
+        problem: The problem the selection was made for.
+        i_selected: Indices of the selected items (length k, unique).
+
+    Returns:
+        Mapping of diversity-metric name to its value for this selection.
+    """
+    dist = _selection_distance_matrix(problem, i_selected)
+    k = dist.shape[0]
+    off_diag = ~np.eye(k, dtype=bool)
+    separations = np.where(off_diag, dist, np.inf).min(axis=1).astype(np.float32)
+    mean_dists = (dist.sum(axis=1) / (k - 1)).astype(np.float32)
+
+    values: dict[str, float] = {}
+    for metric in EVALUATED_METRICS:
+        contributions = mean_dists if metric == DiversityMetric.MEAN_PAIRWISE_DISTANCE else separations
+        values[metric.name] = float(metric.compute(contributions))
+    return values
+
+
+def n_constraints_satisfied(problem: MaxDivProblem, i_selected: NDArray[np.integer]) -> int:
+    """Count how many of the problem's constraints the selection satisfies."""
+    selected = {int(i) for i in i_selected}
+    n_ok = 0
+    for con in problem.constraints:
+        count = len(con.int_set & selected)
+        if con.min_count <= count <= con.max_count:
+            n_ok += 1
+    return n_ok
+
+
+def _selection_distance_matrix(problem: MaxDivProblem, i_selected: NDArray[np.integer]) -> NDArray[np.float64]:
+    """Build the k x k distance matrix among selected items from the condensed distance vector."""
+    idx = np.asarray(i_selected, dtype=np.int64)
+    k = idx.shape[0]
+    if k < 2:
+        raise ValueError("A selection needs at least 2 items to evaluate diversity.")
+    if len(np.unique(idx)) != k:
+        raise ValueError("Selection contains duplicate indices.")
+    n = problem.n
+    condensed = problem.condensed_distances()
+    ii, jj = np.meshgrid(idx, idx, indexing="ij")
+    lo, hi = np.minimum(ii, jj), np.maximum(ii, jj)
+    condensed_pos = (lo * (2 * n - lo - 1)) // 2 + (hi - lo - 1)
+    dist = np.zeros((k, k), dtype=np.float64)
+    off_diag = ~np.eye(k, dtype=bool)
+    dist[off_diag] = condensed[condensed_pos[off_diag]]
+    return dist

--- a/benchmarks/common/records.py
+++ b/benchmarks/common/records.py
@@ -1,0 +1,42 @@
+"""Run records: the flat result rows every runner emits, with JSONL persistence."""
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class RunRecord:
+    """One benchmark measurement: a tool solving one problem once under one budget.
+
+    ``measured_sec`` is always the observed wall-clock (as reported by the tool),
+    never the nominal budget; figures plot this value.
+    """
+
+    tool: str
+    problem: str
+    size: int
+    n: int
+    k: int
+    diversity_metric: str
+    seed: int
+    budget: str  # e.g. "time:0.004s", "iterations:1280", or "single-shot"
+    measured_sec: float
+    n_iterations: int | None
+    quality: dict[str, float] = field(default_factory=dict)
+    n_constraints: int = 0
+    n_constraints_satisfied: int = 0
+
+
+def save_records(records: list[RunRecord], path: Path) -> None:
+    """Write records as JSONL (one record per line), creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        for rec in records:
+            f.write(json.dumps(asdict(rec)) + "\n")
+
+
+def load_records(path: Path) -> list[RunRecord]:
+    """Read records from a JSONL file written by save_records."""
+    with path.open() as f:
+        return [RunRecord(**json.loads(line)) for line in f if line.strip()]

--- a/benchmarks/figures/__init__.py
+++ b/benchmarks/figures/__init__.py
@@ -1,0 +1,7 @@
+"""Figure emission for benchmark results."""
+
+from .anytime import plot_anytime_curve
+
+__all__ = [
+    "plot_anytime_curve",
+]

--- a/benchmarks/figures/anytime.py
+++ b/benchmarks/figures/anytime.py
@@ -1,0 +1,72 @@
+"""Anytime-curve figure: quality vs. measured wall-clock, ladder curves + single-shot dots."""
+
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+from benchmarks.common.records import RunRecord
+
+
+def plot_anytime_curve(records: list[RunRecord], metric_name: str, path: Path, title: str = "") -> None:
+    """Plot quality (one diversity metric) against measured wall-clock, per tool.
+
+    Ladder tools (multiple budgets) are drawn as a mean-over-seeds curve with a
+    min/max band; single-shot tools as one dot at (mean time, mean quality).
+
+    Args:
+        records: Run records for exactly one (problem, size) combination.
+        metric_name: Which quality metric to plot (a key of ``RunRecord.quality``).
+        path: Output file (suffix decides the format, e.g. ``.svg``/``.png``).
+        title: Optional figure title.
+    """
+    import matplotlib.pyplot as plt  # deferred: keeps record-only workflows matplotlib-free
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    for tool, tool_records in sorted(_group_by_tool(records).items()):
+        single_shot = all(r.budget == "single-shot" for r in tool_records)
+        if single_shot:
+            times = [r.measured_sec for r in tool_records]
+            values = [r.quality[metric_name] for r in tool_records]
+            ax.plot(np.mean(times), np.mean(values), "o", markersize=9, label=tool)
+        else:
+            t_mean, q_mean, q_min, q_max = _ladder_stats(tool_records, metric_name)
+            ax.plot(t_mean, q_mean, "-", marker=".", label=tool)
+            ax.fill_between(t_mean, q_min, q_max, alpha=0.15)
+
+    ax.set_xscale("log")
+    ax.set_xlabel("measured wall-clock [s]")
+    ax.set_ylabel(metric_name)
+    if title:
+        ax.set_title(title)
+    ax.grid(True, which="both", alpha=0.3)
+    ax.legend()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(path, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _group_by_tool(records: list[RunRecord]) -> dict[str, list[RunRecord]]:
+    """Group records by tool name."""
+    grouped: dict[str, list[RunRecord]] = defaultdict(list)
+    for rec in records:
+        grouped[rec.tool].append(rec)
+    return dict(grouped)
+
+
+def _ladder_stats(
+    records: list[RunRecord], metric_name: str
+) -> tuple[list[float], list[float], list[float], list[float]]:
+    """Aggregate ladder records per budget: mean measured time, mean/min/max quality."""
+    by_budget: dict[str, list[RunRecord]] = defaultdict(list)
+    for rec in records:
+        by_budget[rec.budget].append(rec)
+
+    stats = []
+    for budget_records in by_budget.values():
+        times = [r.measured_sec for r in budget_records]
+        values = [r.quality[metric_name] for r in budget_records]
+        stats.append((float(np.mean(times)), float(np.mean(values)), min(values), max(values)))
+    stats.sort()
+    t_mean, q_mean, q_min, q_max = (list(component) for component in zip(*stats))
+    return t_mean, q_mean, q_min, q_max

--- a/benchmarks/runners/__init__.py
+++ b/benchmarks/runners/__init__.py
@@ -1,0 +1,9 @@
+"""Runners: execute max-div's anytime ladder or a single-shot adapter, emitting run records."""
+
+from .adapter_runner import run_adapter
+from .maxdiv_runner import run_maxdiv_ladder
+
+__all__ = [
+    "run_adapter",
+    "run_maxdiv_ladder",
+]

--- a/benchmarks/runners/adapter_runner.py
+++ b/benchmarks/runners/adapter_runner.py
@@ -1,0 +1,41 @@
+"""Run a single-shot adapter, once per seed, emitting the same record schema as max-div runs."""
+
+from benchmarks.adapters.base import SelectionAdapter
+from benchmarks.common.quality import evaluate_selection, n_constraints_satisfied
+from benchmarks.common.records import RunRecord
+from max_div.problem import MaxDivProblem
+
+
+def run_adapter(
+    adapter: SelectionAdapter,
+    problem: MaxDivProblem,
+    problem_name: str,
+    size: int,
+    seeds: tuple[int, ...] = (0, 1, 2),
+) -> list[RunRecord]:
+    """Run the adapter once per seed and record measured time + quality.
+
+    Returns:
+        One record per seed, with the ``single-shot`` budget tag.
+    """
+    records = []
+    for seed in seeds:
+        indices, measured_sec = adapter.timed_select(problem, seed)
+        records.append(
+            RunRecord(
+                tool=adapter.name,
+                problem=problem_name,
+                size=size,
+                n=problem.n,
+                k=problem.k,
+                diversity_metric=problem.diversity_metric.name,
+                seed=seed,
+                budget="single-shot",
+                measured_sec=measured_sec,
+                n_iterations=None,
+                quality=evaluate_selection(problem, indices),
+                n_constraints=problem.m,
+                n_constraints_satisfied=n_constraints_satisfied(problem, indices),
+            )
+        )
+    return records

--- a/benchmarks/runners/maxdiv_runner.py
+++ b/benchmarks/runners/maxdiv_runner.py
@@ -1,0 +1,61 @@
+"""Run max-div across a budget ladder, one independent solve per rung x seed."""
+
+from benchmarks.common.quality import evaluate_selection, n_constraints_satisfied
+from benchmarks.common.records import RunRecord
+from max_div.problem import MaxDivProblem
+from max_div.solver import MaxDivSolverBuilder, SolverPreset, TargetDuration, iterations, seconds
+
+
+def run_maxdiv_ladder(
+    problem: MaxDivProblem,
+    problem_name: str,
+    size: int,
+    time_budgets_sec: list[float] | None = None,
+    iteration_budgets: list[int] | None = None,
+    seeds: tuple[int, ...] = (0, 1, 2),
+    preset: SolverPreset = SolverPreset.DEFAULT,
+) -> list[RunRecord]:
+    """Solve the problem once per (budget, seed) and record measured time + quality.
+
+    Args:
+        problem: Problem to solve.
+        problem_name: Generator name recorded in each record (e.g. ``"U1"``).
+        size: Generator size parameter, recorded in each record.
+        time_budgets_sec: Wall-clock ladder in seconds (may be combined with iteration budgets).
+        iteration_budgets: Iteration-count ladder (recorded with an ``iterations:`` budget tag).
+        seeds: One independent solve per seed per rung.
+        preset: Solver preset to run.
+
+    Returns:
+        One record per (budget, seed), with measured wall-clock as reported by the solver.
+    """
+    budgets: list[tuple[str, TargetDuration]] = []
+    for t in time_budgets_sec or []:
+        budgets.append((f"time:{t}s", seconds(t)))
+    for i in iteration_budgets or []:
+        budgets.append((f"iterations:{i}", iterations(i)))
+
+    records = []
+    for budget_tag, target in budgets:
+        for seed in seeds:
+            solver = MaxDivSolverBuilder(problem).with_preset(target, preset).with_seed(seed).build()
+            solution = solver.solve(verbosity=0)
+            elapsed = solution.duration
+            records.append(
+                RunRecord(
+                    tool=f"max-div[{preset.name}]",
+                    problem=problem_name,
+                    size=size,
+                    n=problem.n,
+                    k=problem.k,
+                    diversity_metric=problem.diversity_metric.name,
+                    seed=seed,
+                    budget=budget_tag,
+                    measured_sec=elapsed.t_elapsed_sec,
+                    n_iterations=elapsed.n_iterations,
+                    quality=evaluate_selection(problem, solution.i_selected),
+                    n_constraints=problem.m,
+                    n_constraints_satisfied=n_constraints_satisfied(problem, solution.i_selected),
+                )
+            )
+    return records

--- a/benchmarks/tier2/__init__.py
+++ b/benchmarks/tier2/__init__.py
@@ -1,0 +1,1 @@
+"""Tier-2 benchmark scenarios: max-div vs. Python subset-selection heuristics."""

--- a/benchmarks/tier2/smoke.py
+++ b/benchmarks/tier2/smoke.py
@@ -1,0 +1,45 @@
+"""Tiny end-to-end validation run: proves ladder runner, adapter runner, records, and figure wiring.
+
+Run with: ``uv run --group benchmarks python -m benchmarks.tier2.smoke``.
+Deliberately minuscule (one problem, short ladder, two seeds) — this validates plumbing,
+not performance; real runs are configured separately.
+"""
+
+from pathlib import Path
+
+from benchmarks.adapters import RandomBaseline
+from benchmarks.common import build_problem, save_records, time_ladder
+from benchmarks.figures import plot_anytime_curve
+from benchmarks.runners import run_adapter, run_maxdiv_ladder
+from max_div.metrics import DiversityMetric
+
+OUTPUT_DIR = Path("reports/benchmarks/smoke")
+
+
+def main() -> None:
+    """Run the smoke scenario and write records + one figure."""
+    problem = build_problem("U1", size=1, diversity_metric=DiversityMetric.GEOMEAN_SEPARATION)
+    seeds = (0, 1)
+
+    records = run_maxdiv_ladder(
+        problem,
+        problem_name="U1",
+        size=1,
+        time_budgets_sec=time_ladder(0.001, 0.064),
+        iteration_budgets=[100, 1000],
+        seeds=seeds,
+    )
+    records += run_adapter(RandomBaseline(), problem, problem_name="U1", size=1, seeds=seeds)
+
+    save_records(records, OUTPUT_DIR / "records.jsonl")
+    plot_anytime_curve(
+        [r for r in records if not r.budget.startswith("iterations:")],
+        metric_name=DiversityMetric.GEOMEAN_SEPARATION.name,
+        path=OUTPUT_DIR / "anytime_u1_s1.svg",
+        title="smoke: U1 size=1 (validation only, not a published result)",
+    )
+    print(f"smoke OK: {len(records)} records -> {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,10 @@ docs = [
 ]
 
 [dependency-groups]
+# Comparison-benchmark harness (see benchmarks/README.md); never part of the published package.
+benchmarks = [
+    "matplotlib>=3.9",
+]
 dev = [
     "check-wheel-contents>=0.6.2",
     "pre-commit>=4.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1654,6 +1654,9 @@ docs = [
 ]
 
 [package.dev-dependencies]
+benchmarks = [
+    { name = "matplotlib" },
+]
 dev = [
     { name = "check-wheel-contents" },
     { name = "pre-commit" },
@@ -1698,6 +1701,7 @@ requires-dist = [
 provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
+benchmarks = [{ name = "matplotlib", specifier = ">=3.9" }]
 dev = [
     { name = "check-wheel-contents", specifier = ">=0.6.2" },
     { name = "pre-commit", specifier = ">=4.0" },


### PR DESCRIPTION
First slice of the comparison-benchmark tooling: a repo-tracked harness under `benchmarks/` with its own uv dependency group (never part of the published package). Includes budget ladders (wall-clock and iteration-count), subset-quality evaluation that scores every tool under max-div's own diversity metrics, JSONL run records storing measured (not nominal) wall-clock, anytime-curve figure emission, a uniform-random baseline, and a smoke scenario that validates the wiring end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)