### PR TITLE
chore: add tier-2 competitor adapters to the benchmark harness

### DIFF
--- a/benchmarks/adapters/__init__.py
+++ b/benchmarks/adapters/__init__.py
@@ -1,9 +1,22 @@
 """Adapters: one per compared tool/baseline, all implementing SelectionAdapter."""
 
+from .apricot_fl import ApricotFacilityLocation
 from .base import SelectionAdapter
+from .fps import FpsampleFPS, SkmatterFPS
+from .greedy_maxsum import GreedyMaxSum
+from .kmedoids_fasterpam import KMedoidsFasterPAM
+from .qc_selector_maxmin import QcSelectorMaxMin
 from .random_baseline import RandomBaseline
+from .rdkit_maxmin import RdkitMaxMin
 
 __all__ = [
+    "ApricotFacilityLocation",
+    "FpsampleFPS",
+    "GreedyMaxSum",
+    "KMedoidsFasterPAM",
+    "QcSelectorMaxMin",
     "RandomBaseline",
+    "RdkitMaxMin",
     "SelectionAdapter",
+    "SkmatterFPS",
 ]

--- a/benchmarks/adapters/_inputs.py
+++ b/benchmarks/adapters/_inputs.py
@@ -1,0 +1,19 @@
+"""Input-shape helpers shared by adapters: vectors and square distance matrices."""
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.spatial.distance import squareform
+
+from max_div.problem import MaxDivProblem, VectorMaxDivProblem
+
+
+def problem_vectors(problem: MaxDivProblem) -> NDArray[np.float32]:
+    """Return the problem's vectors, failing clearly for distance-only problems."""
+    if not isinstance(problem, VectorMaxDivProblem):
+        raise TypeError(f"{type(problem).__name__} carries no vectors; this adapter needs vector input.")
+    return problem.vectors
+
+
+def square_distances(problem: MaxDivProblem) -> NDArray[np.float64]:
+    """Return the full n x n distance matrix (O(n^2) memory; fine at benchmark sizes)."""
+    return squareform(problem.condensed_distances().astype(np.float64))

--- a/benchmarks/adapters/apricot_fl.py
+++ b/benchmarks/adapters/apricot_fl.py
@@ -1,0 +1,31 @@
+"""apricot facility-location adapter: submodular selection, a deliberately different objective."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from ._inputs import problem_vectors
+from .base import SelectionAdapter
+
+
+class ApricotFacilityLocation(SelectionAdapter):
+    """Submodular facility-location selection via apricot (1-1/e guarantee for its own objective).
+
+    Facility location optimizes coverage/representativeness, not dispersion — results pages
+    must label it as a different-objective reference, not a like-for-like competitor.
+    """
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "apricot[facility-location]"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run apricot's greedy facility-location selection (deterministic; seed unused)."""
+        from apricot import FacilityLocationSelection
+
+        vectors = problem_vectors(problem).astype(np.float64)
+        selector = FacilityLocationSelection(problem.k, metric="euclidean")
+        selector.fit(vectors)
+        return np.asarray(selector.ranking, dtype=np.int64)

--- a/benchmarks/adapters/fps.py
+++ b/benchmarks/adapters/fps.py
@@ -1,0 +1,44 @@
+"""Farthest-point-sampling adapters: fpsample (Rust) and skmatter (sklearn-contrib)."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from ._inputs import problem_vectors
+from .base import SelectionAdapter
+
+
+class FpsampleFPS(SelectionAdapter):
+    """Greedy farthest-point sampling via the fpsample package (max-min, 2-approx)."""
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "fpsample[FPS]"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run vanilla FPS, seeding via the start index."""
+        import fpsample
+
+        vectors = problem_vectors(problem)
+        start_idx = seed % problem.n
+        return np.asarray(fpsample.fps_sampling(vectors, problem.k, start_idx=start_idx), dtype=np.int64)
+
+
+class SkmatterFPS(SelectionAdapter):
+    """Greedy farthest-point sampling via skmatter's FPS selector (max-min, 2-approx)."""
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "skmatter[FPS]"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run skmatter FPS, seeding via the initial point."""
+        from skmatter.sample_selection import FPS
+
+        vectors = problem_vectors(problem)
+        selector = FPS(n_to_select=problem.k, initialize=seed % problem.n)
+        selector.fit(vectors)
+        return np.asarray(selector.selected_idx_, dtype=np.int64)

--- a/benchmarks/adapters/greedy_maxsum.py
+++ b/benchmarks/adapters/greedy_maxsum.py
@@ -1,0 +1,42 @@
+"""Greedy max-sum insertion baseline: the classical 1/2-approx construction for max-sum diversity."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from ._inputs import square_distances
+from .base import SelectionAdapter
+
+
+class GreedyMaxSum(SelectionAdapter):
+    """Greedy max-sum insertion (1/2-approx for max-sum).
+
+    Start from the farthest pair, then repeatedly add the item with the largest
+    total distance to the current selection.
+    """
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "greedy[max-sum]"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run the greedy insertion (deterministic; seed unused)."""
+        distances = square_distances(problem)
+        n, k = problem.n, problem.k
+
+        i0, j0 = np.unravel_index(np.argmax(distances), distances.shape)
+        selected = [int(i0), int(j0)]
+        sum_dist_to_selected = distances[:, i0] + distances[:, j0]
+        available = np.ones(n, dtype=bool)
+        available[selected] = False
+
+        while len(selected) < k:
+            candidate_sums = np.where(available, sum_dist_to_selected, -np.inf)
+            nxt = int(np.argmax(candidate_sums))
+            selected.append(nxt)
+            available[nxt] = False
+            sum_dist_to_selected += distances[:, nxt]
+
+        return np.asarray(selected, dtype=np.int64)

--- a/benchmarks/adapters/kmedoids_fasterpam.py
+++ b/benchmarks/adapters/kmedoids_fasterpam.py
@@ -1,0 +1,30 @@
+"""k-medoids (FasterPAM) adapter: a coverage-style baseline, not a dispersion method."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from ._inputs import square_distances
+from .base import SelectionAdapter
+
+
+class KMedoidsFasterPAM(SelectionAdapter):
+    """k-medoids clustering via the kmedoids package's FasterPAM (Rust).
+
+    Medoids are cluster centers, i.e. representativeness — included to show how a
+    coverage objective behaves under dispersion metrics, not as a dispersion competitor.
+    """
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "kmedoids[FasterPAM]"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run FasterPAM on the full distance matrix and return the k medoids."""
+        import kmedoids
+
+        distances = square_distances(problem)
+        result = kmedoids.fasterpam(distances, problem.k, random_state=seed)
+        return np.asarray(result.medoids, dtype=np.int64)

--- a/benchmarks/adapters/qc_selector_maxmin.py
+++ b/benchmarks/adapters/qc_selector_maxmin.py
@@ -1,0 +1,30 @@
+"""qc-selector MaxMin adapter (GPL-3 tool; lives in the opt-in benchmarks-gpl group)."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from ._inputs import square_distances
+from .base import SelectionAdapter
+
+
+class QcSelectorMaxMin(SelectionAdapter):
+    """Greedy max-min selection via qc-selector (import name ``selector``).
+
+    GPL-3-licensed: installed only via the opt-in ``benchmarks-gpl`` dependency group;
+    scenarios must treat this adapter as optional and skip it when the import fails.
+    """
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "qc-selector[MaxMin]"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run qc-selector's MaxMin on the full distance matrix (deterministic; seed unused)."""
+        from selector.methods.distance import MaxMin
+
+        distances = square_distances(problem)
+        selected = MaxMin().select(distances, size=problem.k)
+        return np.asarray(selected, dtype=np.int64)

--- a/benchmarks/adapters/rdkit_maxmin.py
+++ b/benchmarks/adapters/rdkit_maxmin.py
@@ -1,0 +1,36 @@
+"""RDKit MaxMinPicker adapter: lazy greedy max-min with a custom distance callback."""
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from ._inputs import problem_vectors
+from .base import SelectionAdapter
+
+
+class RdkitMaxMin(SelectionAdapter):
+    """Greedy max-min picking via RDKit's MaxMinPicker (lazy distance evaluation).
+
+    The distance callback re-implements the problem's L2 metric on the problem vectors;
+    RDKit's laziness means only the distances the greedy actually needs get computed —
+    that is the tool's designed trade-off and is measured as-is.
+    """
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "RDKit[MaxMinPicker]"
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run LazyPick with a euclidean-distance callback over the problem vectors."""
+        from rdkit.SimDivFilters import rdSimDivPickers
+
+        vectors = problem_vectors(problem)
+
+        def dist(i: int, j: int) -> float:
+            return float(np.linalg.norm(vectors[i] - vectors[j]))
+
+        picker = rdSimDivPickers.MaxMinPicker()
+        picks = picker.LazyPick(dist, problem.n, problem.k, seed=seed)
+        return np.asarray(list(picks), dtype=np.int64)

--- a/benchmarks/tier2/smoke.py
+++ b/benchmarks/tier2/smoke.py
@@ -7,7 +7,17 @@ not performance; real runs are configured separately.
 
 from pathlib import Path
 
-from benchmarks.adapters import RandomBaseline
+from benchmarks.adapters import (
+    ApricotFacilityLocation,
+    FpsampleFPS,
+    GreedyMaxSum,
+    KMedoidsFasterPAM,
+    QcSelectorMaxMin,
+    RandomBaseline,
+    RdkitMaxMin,
+    SelectionAdapter,
+    SkmatterFPS,
+)
 from benchmarks.common import build_problem, save_records, time_ladder
 from benchmarks.figures import plot_anytime_curve
 from benchmarks.runners import run_adapter, run_maxdiv_ladder
@@ -18,25 +28,39 @@ OUTPUT_DIR = Path("reports/benchmarks/smoke")
 
 def main() -> None:
     """Run the smoke scenario and write records + one figure."""
-    problem = build_problem("U1", size=1, diversity_metric=DiversityMetric.GEOMEAN_SEPARATION)
+    problem = build_problem("U1", size=2, diversity_metric=DiversityMetric.GEOMEAN_SEPARATION)
     seeds = (0, 1)
 
     records = run_maxdiv_ladder(
         problem,
         problem_name="U1",
-        size=1,
+        size=2,
         time_budgets_sec=time_ladder(0.001, 0.064),
         iteration_budgets=[100, 1000],
         seeds=seeds,
     )
-    records += run_adapter(RandomBaseline(), problem, problem_name="U1", size=1, seeds=seeds)
+    adapters: list[SelectionAdapter] = [
+        RandomBaseline(),
+        FpsampleFPS(),
+        SkmatterFPS(),
+        RdkitMaxMin(),
+        ApricotFacilityLocation(),
+        KMedoidsFasterPAM(),
+        GreedyMaxSum(),
+        QcSelectorMaxMin(),  # GPL opt-in group; skipped below when not installed
+    ]
+    for adapter in adapters:
+        try:
+            records += run_adapter(adapter, problem, problem_name="U1", size=2, seeds=seeds)
+        except ImportError:
+            print(f"skipped (not installed): {adapter.name}")
 
     save_records(records, OUTPUT_DIR / "records.jsonl")
     plot_anytime_curve(
         [r for r in records if not r.budget.startswith("iterations:")],
         metric_name=DiversityMetric.GEOMEAN_SEPARATION.name,
-        path=OUTPUT_DIR / "anytime_u1_s1.svg",
-        title="smoke: U1 size=1 (validation only, not a published result)",
+        path=OUTPUT_DIR / "anytime_u1_s2.svg",
+        title="smoke: U1 size=2 (validation only, not a published result)",
     )
     print(f"smoke OK: {len(records)} records -> {OUTPUT_DIR}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,15 @@ docs = [
 # Comparison-benchmark harness (see benchmarks/README.md); never part of the published package.
 benchmarks = [
     "matplotlib>=3.9",
+    "fpsample>=1.0",
+    "skmatter>=0.3",
+    "rdkit>=2025.3",
+    "apricot-select>=0.6",
+    "kmedoids>=0.5",
+]
+# GPL-3 competitor kept in its own opt-in group so the default benchmarks group stays GPL-free.
+benchmarks-gpl = [
+    "qc-selector>=0.1",
 ]
 dev = [
     "check-wheel-contents>=0.6.2",

--- a/uv.lock
+++ b/uv.lock
@@ -40,6 +40,19 @@ wheels = [
 ]
 
 [[package]]
+name = "apricot-select"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nose" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/96/7d9aec6ab622449aad7556101e90c2ef67b72b7cf33ded6cc9326a41e169/apricot-select-0.6.1.tar.gz", hash = "sha256:3bf872d43ee96af141c9e4c40e4359aa6ca5e3022ae43b2a8aa46b24947b8bd8", size = 28198, upload-time = "2021-02-18T06:55:02.195Z" }
+
+[[package]]
 name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -156,6 +169,79 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "bitarray"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/eb/e97abd6b7c2245e19be529f6fd70c7dda04c449f4a11b6ddb30079d71ea6/bitarray-3.9.0.tar.gz", hash = "sha256:af5f91e61d868c8f457f66cd726ef31d69264f71edbaccd70fdbb13548c1d652", size = 156643, upload-time = "2026-07-10T07:26:09.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ec/4693fc6f05b5c4d5bd5c9721de280507e325c02eab39e0cee7563b38d584/bitarray-3.9.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d66b965ab369284c187c38c9cd5d6e638e863db856ee244c739ad5ec07769645", size = 152670, upload-time = "2026-07-10T07:23:51.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/a06dcd8f188dbdba6be3ac4b2d1dafc2b4092aec1ac53b837d33c8356ed3/bitarray-3.9.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c019a95da22eca2793dd80db95758ff82cfc17f8813fd6a926cca5fd93b1bd7f", size = 149545, upload-time = "2026-07-10T07:23:52.225Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/6a/9e7cdd675deab50ad57c28f52297d950a23a9501d8a5b0b3469065da72f7/bitarray-3.9.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b9d16a362f454abe9ef7d362fb9260b0a7945e64a53d35effb10c7fd64da415", size = 342159, upload-time = "2026-07-10T07:23:53.692Z" },
+    { url = "https://files.pythonhosted.org/packages/22/62/bda7619bf3e810c7fbf0ef3354ccc581e9c7809221e8c1d0db1c776d0cd9/bitarray-3.9.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8f118e3f43a01d7326c30d95eafda951e0823596f1659f4a5a54ab032341d5f4", size = 372904, upload-time = "2026-07-10T07:23:55.26Z" },
+    { url = "https://files.pythonhosted.org/packages/57/41/688008a859a18942abe5cca8af2a06f2ebede4d3fed52d09745698baca5b/bitarray-3.9.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc6db5b0d52ab31136da48d2913aad14e5ba3bfd5522d75c4d9bda2700c66768", size = 381298, upload-time = "2026-07-10T07:23:56.586Z" },
+    { url = "https://files.pythonhosted.org/packages/70/7f/8b4b1addffe96f22cc2efaf48100bd88d99b6ad3bf209f3464694b29de1f/bitarray-3.9.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b6cbca02cdfb27a6fb6e0d4f9170a53da2c37fce70bc5afa6d58aab6d1f1af", size = 347291, upload-time = "2026-07-10T07:23:57.833Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/b411fd5bd0052f5e4089343aa2bd2e5b7ef7adc0772d8a7dc06a64fb35bb/bitarray-3.9.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9c45b31ddef2d4f50224cb5cbe1ac0af4909555340fdf88e65da5c9c7e912cb3", size = 340076, upload-time = "2026-07-10T07:23:59.068Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/b0/78426b1dfae5ad5478d4d5fc341196ae71e39d230b8a9f7afb12fb841e6c/bitarray-3.9.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:cc9cc3025e9453239843d1c4431c5aca700bec246e9071596b8240193e91af2f", size = 369949, upload-time = "2026-07-10T07:24:00.393Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/55/6a91dc36617fc9f1a01920e58b890c869439321526d3dfa83ef045eab17e/bitarray-3.9.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e79e4c283ed834b0587b0fde21ced22251a569255b338de1e466d901c8d07d5e", size = 364660, upload-time = "2026-07-10T07:24:01.879Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e4/62da749b416838bf061d18ca736be882e9ec04534dca4f6758d79df3fd9c/bitarray-3.9.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4e52b54a8e639da6e80ddeaca9aa3ca324ca20bdcd4cd51f6070ca4b334113a1", size = 344668, upload-time = "2026-07-10T07:24:03.111Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ff/a9dc020651e2d94c7d1f4dd343f29f8c1d88e9f2c24ad1b49561dde66530/bitarray-3.9.0-cp311-cp311-win32.whl", hash = "sha256:b664bd8174795df4f0353c9ff3d997f5ae764285753c785bf6aa0afab75a357a", size = 146058, upload-time = "2026-07-10T07:24:04.353Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2f/15074a393c142aec2a39133ab5e9504a7c4d24a66c6d1f780af98cc06137/bitarray-3.9.0-cp311-cp311-win_amd64.whl", hash = "sha256:eb5e65d4c2da36446a4592f50e0393a0255e832bdd5d519391a216728cface15", size = 152955, upload-time = "2026-07-10T07:24:05.866Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/fd/9e4dbe150f85249ed387d06b1428de602d52b0c092ee8d3fcbeb4a5aa64b/bitarray-3.9.0-cp311-cp311-win_arm64.whl", hash = "sha256:2d7b0167098b7a423e8b8fcd2d4291aa99b97589e53b6b182c0b456a79a78cd5", size = 150910, upload-time = "2026-07-10T07:24:07.098Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/83e594b22122483cb1af90ae747b85e085469c396c9b319f42155f01a322/bitarray-3.9.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:541890dd453021a6f8155e7d091a6589652f703832a41c959eb139b487b67ad2", size = 152779, upload-time = "2026-07-10T07:24:08.305Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/1e/19f2d66274da55c0ca5b815c3588c0fb4341586958eea7ac13d58b22884c/bitarray-3.9.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c5f11802751285f982a333192f1336ce94017eedb6ea5f8e05039484ca00b24d", size = 149502, upload-time = "2026-07-10T07:24:09.567Z" },
+    { url = "https://files.pythonhosted.org/packages/15/29/e7ac040455a66f5c584cd5af70d1018997966dc99e75ecbb3c2806922581/bitarray-3.9.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1acbb40c630d0429d5a7e8879896f43ddb998625d380d94664239dae9bb4978d", size = 345319, upload-time = "2026-07-10T07:24:10.968Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a3/ec4c5daae49bd12129cf5a838d823e92137192c8fee2da5c153ca6e175d2/bitarray-3.9.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e55a6e8e5c14546a90db3c5c93d68dc73c8d86ed19556aa58cd6d558286ae620", size = 375681, upload-time = "2026-07-10T07:24:12.31Z" },
+    { url = "https://files.pythonhosted.org/packages/72/3d/abc67f0fbc641ea506ccb6424248066bb3318ac4f5c5359ad7be329ad4c3/bitarray-3.9.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1f2d47d0f451f42c328544e9a8968d168e452934eef218e6e68e5b14b6711a3a", size = 385149, upload-time = "2026-07-10T07:24:13.661Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/8f/13fa46e1121d194f25dad9a95061d0cf55a07bddf06d99e173b48ef9bf57/bitarray-3.9.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:353430288ff7e2a97029dea750d3095bf85089f8d7757dff52b46d71c0b635ff", size = 351870, upload-time = "2026-07-10T07:24:15.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/1f/9a6f1ede6040ec7ecc3575c473af19a9af0da8360b187cb53f09d7130910/bitarray-3.9.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:63e934aecbad62ed3b591877b7f4ce2c9b7b28376ef70448cb657338911350c1", size = 342760, upload-time = "2026-07-10T07:24:16.402Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c9/be29cb182a5c7b4124dc3272c50606af0ae19f7501a4b79fe922fa83e99a/bitarray-3.9.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:6272808ed86948389e3fb6723474691f4dd3475ccbd2f8b1232feec517b2c394", size = 372884, upload-time = "2026-07-10T07:24:17.778Z" },
+    { url = "https://files.pythonhosted.org/packages/26/36/17d988d1725f4f1e3e8b27cd7eb88e48a1297273bc86fb674a77e5daef97/bitarray-3.9.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2c0aceb582baabb97612647193fd6160f9766250b7d1f034d1be7d5f2b2d88ca", size = 368761, upload-time = "2026-07-10T07:24:19.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cc/c53bda6f4d419b6c137c03f4a4a49af19df38ce201c77c689070339403cf/bitarray-3.9.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6e3fe6fc6bf914e1a538e955c1260f64ccb174136ac798811f2a5f904e437def", size = 348639, upload-time = "2026-07-10T07:24:20.641Z" },
+    { url = "https://files.pythonhosted.org/packages/81/aa/945305b3e16411576be84bc047612d00de6a1ced671290d96fb6dc95c281/bitarray-3.9.0-cp312-cp312-win32.whl", hash = "sha256:7ad4eb391e138958b69d9f1521e45e537ad4a66eba9ba90bb4a99ada6fa1fc90", size = 146349, upload-time = "2026-07-10T07:24:22.194Z" },
+    { url = "https://files.pythonhosted.org/packages/86/80/d0c50617ea2e0579b3c6c4839321a846bd8f0478d3c625f10250db114240/bitarray-3.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:71070085c168cb5cb0972c09c9f36995a34fab2807c15f2f64f0dee6014f1008", size = 153295, upload-time = "2026-07-10T07:24:23.841Z" },
+    { url = "https://files.pythonhosted.org/packages/07/5f/280679f0581dbf8f6747c776e65eb722435c28a0b378b99c3f7a42539979/bitarray-3.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:3075370a7aaec476b0f3ce501f83cfa1797fa722619f7f130981403978b1ad89", size = 151050, upload-time = "2026-07-10T07:24:25.161Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4d/906327dbe7d8bb94a7e46bb403c7304e410e3f9d9963df9760867f590f39/bitarray-3.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:62e5a7520f3d2b632438f94c9b9bddf1b2c0e9154e69c8c62e32accf680b3fdc", size = 152778, upload-time = "2026-07-10T07:24:26.389Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3f/697f7ad7c00108d22db9cc918480f5981cbf569c419c354271bedd1b07c5/bitarray-3.9.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:867994fb56cbfe40c77b1c5d0527e4d6ef4141b3ea2aca2aa02bd89ca08ae2d2", size = 149496, upload-time = "2026-07-10T07:24:27.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/2852f600f24acadb0b8f3fb0e08a80da976b539061093c707571b057bb7a/bitarray-3.9.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:255090e32993dc0b10cd29ad49e21cd7349ed9cdb44d61ad970b4a698b7bd1e7", size = 344479, upload-time = "2026-07-10T07:24:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/82/149e201ff5d8512185199313328f2440b97b30daac193c1bf959f4e30089/bitarray-3.9.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:21facaa003c1a6487eaada863fc93059ee2f542a9ca589f7c5716a1e4ceddfd0", size = 374709, upload-time = "2026-07-10T07:24:30.684Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/3c/84ed3afc80a5fb95eec29915d0b7d27fe880b85b0f9c194f93e289a59737/bitarray-3.9.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c5636104b949b937ef47bcc700665befc2f5a1e906036cba6fdb978501adca11", size = 384245, upload-time = "2026-07-10T07:24:32.099Z" },
+    { url = "https://files.pythonhosted.org/packages/13/79/caba986e6770521b38c3870008649566dacf31b6a4b5ea43ec17ebd6a09a/bitarray-3.9.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17e721ed7695257f5f0a8147633f96a60b5ac13735c73d29b2409d1b5a484062", size = 350997, upload-time = "2026-07-10T07:24:34.238Z" },
+    { url = "https://files.pythonhosted.org/packages/21/4a/2e1d729a4a40cfa3f5cee0e081b2e85d1cdb46aa821db1f373e853e767e8/bitarray-3.9.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:68f66a71bcfbedd1144b8d21b54fa77e32f90067fc3e49abc0a479392697c3cd", size = 342102, upload-time = "2026-07-10T07:24:35.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/87/5a9db50f49ab46facfb13256087a4dda9468dab29e32f2ef8c2c2dece842/bitarray-3.9.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:e780526164e5c4051cf8618e73ecaf0c900c7c3ea2cdd99558b486e47cbe28c9", size = 371995, upload-time = "2026-07-10T07:24:37.508Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/c50e1df174b8d1d60c2e76a44a8052df43f08dd74f0c68895e6f9cf31464/bitarray-3.9.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f6abac81451d0d0ce5ee553b9c7e6b9de165642ffe949c1379e6f553f482066e", size = 367810, upload-time = "2026-07-10T07:24:39.132Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0c/217b120ed58847a543d8c9819bc626b3caf59b6bd15454de6f0b339a4a03/bitarray-3.9.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:db0a55d52d9056187670e8e7e525a2aa5f4a74a4459e9455aa68c0198b4ac2fc", size = 347899, upload-time = "2026-07-10T07:24:40.606Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2d/6149c1d5d71dd3c0dbc169431498808fc35e2d557234895e7109decb1b3d/bitarray-3.9.0-cp313-cp313-win32.whl", hash = "sha256:e5799c01e961273136d95ade2164c689714bdfcdc443f9e2568b45df620248d2", size = 146369, upload-time = "2026-07-10T07:24:42.046Z" },
+    { url = "https://files.pythonhosted.org/packages/51/7c/bea45e1a7a0914dd98bf1bc1f0c26ad3fc9c13b172a828e3512d358f3df4/bitarray-3.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:eba091b89bfaf931709e09b8bc564101c7c834d2978019784dd97e017e84d060", size = 153333, upload-time = "2026-07-10T07:24:43.317Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/f2/2ebc04e8704de30194d3f323231b67742ec990fc8adee481de12d942cf0d/bitarray-3.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:c13cb765f5dd30eefec0046cde1c2eee11b76cd749b045e54f1aa0a15057d219", size = 151070, upload-time = "2026-07-10T07:24:44.585Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/aa/08683173a85ee94a5e783bd2bbb4fed08d6563164fb37df279d2050ba84c/bitarray-3.9.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:988ab837bb55951dbddb8b26db0d4a2e9eb3fd2bcf1dfd29ab96b046ff96dd2a", size = 152764, upload-time = "2026-07-10T07:24:45.904Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/bbc2e3f30afe40602a14105d034e334dffa67e423d5aa90d35eadcaa9f23/bitarray-3.9.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d3d27fa77487455de1a3aa6b593dd23eeb5971357b96453daf60307e7a623188", size = 149522, upload-time = "2026-07-10T07:24:47.416Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/51/98852ff93f460dee8abbb0363e0933fd7cad44e9f85530098a25517e31fe/bitarray-3.9.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4213db72d8ee547df486dce28cde286346bc7a01f8e22fdeea1f8f0c18d1c9eb", size = 344472, upload-time = "2026-07-10T07:24:48.807Z" },
+    { url = "https://files.pythonhosted.org/packages/48/6f/d9570e4a8f4b61bb88915303b84c2c137c1682b694157d4eeff65c422e86/bitarray-3.9.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:212559f1a69c89cdd4ebd487f1581818b67939a3ac157a32f26ab29d29414b84", size = 374934, upload-time = "2026-07-10T07:24:50.69Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d0/261a06750ac8a6b4b288132316fffcdc430e8de50e1588d1b98e699c50c3/bitarray-3.9.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:080e8530a7b56ba843bdad6c4cf9887506944be180222e6691d7aee13f977868", size = 383640, upload-time = "2026-07-10T07:24:52.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/9e/95de1b1605833d7284749c6d982dd83e52592878aba5485391e23ddbd152/bitarray-3.9.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05dc8db96a184eeb4e9d51f558602fa51eaa651790aa5d50f7fd2c5306e1bc16", size = 350704, upload-time = "2026-07-10T07:24:53.52Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/dd/61a0755d4efd462321274defdf77a4362da5356ee20dd046aa997e2063ba/bitarray-3.9.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64ccb1873db36d71c90de7611f3bfcad5cae889293bfe81c28d5c0eefa1065d3", size = 342225, upload-time = "2026-07-10T07:24:54.976Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/b2/4503b24ec7e491343f6852415f31d1f5cde6cdc37091aaa47222db2c35ee/bitarray-3.9.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:eea7a98b277e6a19cdf2e74908a534826f552d7a0d75c17b8fc6f4d886653695", size = 372239, upload-time = "2026-07-10T07:24:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/a3/22841994c4761d00934e8396f2c6b89c08097480159e3e47f1b3ea4b7feb/bitarray-3.9.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:1608a8f62d17323f4b7a92dd731fff8e30562f8a18bab4758aba5fb1d7df9d78", size = 367449, upload-time = "2026-07-10T07:24:58.282Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3b/ee86eff5f3c8b9af48d05bc610c4aae528e0f27687af01279e0e074f92e1/bitarray-3.9.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:21ab3b432cc4d73fdac310bd500bc54473116c85107acecb27b9d6805ff8b48b", size = 347610, upload-time = "2026-07-10T07:24:59.825Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e4/0757980a2b1620dae7e51a63960ac41bbe57cd4dbce47194e89767336c50/bitarray-3.9.0-cp314-cp314-win32.whl", hash = "sha256:a1774b7f06b2d705cc0332245b71e18c6f0ddaf6925cce2d0b8eaa30c58b5164", size = 145407, upload-time = "2026-07-10T07:25:01.666Z" },
+    { url = "https://files.pythonhosted.org/packages/91/ae/8a449f1eb218d5ad79684ef6f3e241e5b85587ea1d96cdd0288f921d0857/bitarray-3.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:fc8c5da04dfce44a9446d3e2348924252b72db98a22d1576b2ce66f34dc7fb99", size = 151886, upload-time = "2026-07-10T07:25:03.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ef/f09985c9cb4cfed3ce282481e6196c3906b34a8e7f51abc70af565faf2cd/bitarray-3.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:784d4180c38a0db82fa4a0c7ac54e92cbb9137b0336f7d5f9f433179fab0e56a", size = 150418, upload-time = "2026-07-10T07:25:04.531Z" },
+    { url = "https://files.pythonhosted.org/packages/64/03/f7fb220b15b7668c3a186a88c073ebf7df6d5e94bea654cf590dec416973/bitarray-3.9.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:737230129bae3649dedfccc4b20040b76805c8a5ff9b3c7f0564775850bcdf58", size = 153839, upload-time = "2026-07-10T07:25:05.94Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/93/cc79a7001927be617abfbc11211650b816b4218af8614dabfb233f81a0f3/bitarray-3.9.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:caaecd574c5ea9c3168654779c0633b08a4c346fe97b38c2896d7846dcfd85cb", size = 150709, upload-time = "2026-07-10T07:25:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/df/12/35e469256688e5843a3e51eb97c46313a2acaa840ea77c16699fd5c5a6e6/bitarray-3.9.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3123de3aee13dad947e4e30e1f580cb78fa24c2d103fd5a11e429ea2d55dc0f", size = 352916, upload-time = "2026-07-10T07:25:09.194Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/01/e41667142a89245cb359bb3edfcd87b4265f00367a8a029a9b36cf2c7959/bitarray-3.9.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:513007e9a05ab9247ff5bba5c5bd43557fc40c8fe80fd50be3570760ef449601", size = 383417, upload-time = "2026-07-10T07:25:11.126Z" },
+    { url = "https://files.pythonhosted.org/packages/66/32/943478d23799788a1d72e123b6194cd2582420cf7ca606dc04b3412ac4e6/bitarray-3.9.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c9fac669b0c19362b69818eb04358d912ffdaf2b6ee039e4f358271ba8095dc", size = 391718, upload-time = "2026-07-10T07:25:12.836Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/7aa25a90e746b39ce11755430b3502ddccdb41502b43ec3b2deab033cd4f/bitarray-3.9.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24cbd77670da7e6fe2218b2905a88ecaafd456017673cc7b47b06caf47ff0d77", size = 357330, upload-time = "2026-07-10T07:25:14.31Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b4/b72f4a859c78b490ff7f823ab08d91125a7cdb358cf8909165c7bb57bd56/bitarray-3.9.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:918a29d788a5a29001dcf20b25da00c0cda6998861d1346358a0a1611dcf2be7", size = 349551, upload-time = "2026-07-10T07:25:15.91Z" },
+    { url = "https://files.pythonhosted.org/packages/38/60/77ce302d4252fdb215062b8b7fcdeaa3c536c9541545707cc038e3441f1b/bitarray-3.9.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:496d8ae6fbc1f870a04d40148ff6daa1357c94543498de5c33612d5969aed074", size = 381116, upload-time = "2026-07-10T07:25:17.343Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/09/942ea5044a2e21ff44c9d91ee246fdfcd21fb5c143df443666df092c1be3/bitarray-3.9.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:52b8690da0334d0d1b0907a5011dc08415d0514468296233dd2296b50be2dcc8", size = 374882, upload-time = "2026-07-10T07:25:19.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2e395d72fc66af09d1ad311df0ed2263853b3d70cc86f624c0d816f2ecc7/bitarray-3.9.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:41807c5be6b3c0730d2472fd5973d44e22498c610f60a3c00aefe41bb3caa2e2", size = 352449, upload-time = "2026-07-10T07:25:20.584Z" },
+    { url = "https://files.pythonhosted.org/packages/27/ea/cd544279542417c887b6b1074d7e14be350f2e7d7bf840d90df1c1e4d792/bitarray-3.9.0-cp314-cp314t-win32.whl", hash = "sha256:81c12f37cd31e254be3a12454e2933d5668d811ecfc5bbf7cd6f9c54cb5fda60", size = 146330, upload-time = "2026-07-10T07:25:22.092Z" },
+    { url = "https://files.pythonhosted.org/packages/31/19/9621d721789a3429f827cef75270059ce6f4db3922d7a476559b543c34f6/bitarray-3.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:feec62af25b9d81c5013280e44d512a2991784c3f9969fde3ca7327016cc1ab0", size = 152829, upload-time = "2026-07-10T07:25:23.949Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/5a/6bee18c8f03ccd59f576285bca64478e3f33a52b2f14fb3c20b17ada7e57/bitarray-3.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6334497cd63bf03c5a7c8b58b2b701a3d9aca692e3d82c722a577fe97f7d085f", size = 151303, upload-time = "2026-07-10T07:25:25.597Z" },
 ]
 
 [[package]]
@@ -791,6 +877,16 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e4/ff/c9a2b66b39f8628531ea58b320d66d951267c98c6a38684daa8f50fb02f8/fonttools-4.61.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2180f14c141d2f0f3da43f3a81bc8aa4684860f6b0e6f9e165a4831f24e6a23b", size = 2400613, upload-time = "2025-12-12T17:31:18.769Z" },
     { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", size = 1148996, upload-time = "2025-12-12T17:31:21.03Z" },
 ]
+
+[[package]]
+name = "fpsample"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pybind11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/0d/c58b12e5dd6c0880b7f420d32af317e5817c54369019c0a04eb350b47ea2/fpsample-1.0.2.tar.gz", hash = "sha256:5e25f97c03412d243767fb9e47f7b6d6c736c7ce1e9d51918894e3fd327749f2", size = 40361, upload-time = "2025-12-20T12:30:21.859Z" }
 
 [[package]]
 name = "fqdn"
@@ -1434,6 +1530,41 @@ wheels = [
 ]
 
 [[package]]
+name = "kmedoids"
+version = "0.5.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/25/192a8beee16f1c74f3421bc418db37835b1090cc5187534c5dfb1966eb3a/kmedoids-0.5.5-cp311-cp311-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:be5b29d701f0efec1c3809866275c6bfa398aad6b2c0761d216b6f30e317f556", size = 814539, upload-time = "2026-05-23T13:14:49.527Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/81/2be3c3ec4a4eee9620c09900dc20e31807a809bfa22038f789fbae031f9e/kmedoids-0.5.5-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:f7b993acea83c9b3ed3e00dbe6fce0da7eeb2d885aae67a1a9c58a66b294f359", size = 426996, upload-time = "2026-05-23T13:14:51.072Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/5e/b16f439db6b43a51dfe7230f18108b7b9a30ce03c31cfd19cdfb53e3682b/kmedoids-0.5.5-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:ee02125a43654838caea43e5155d8cb0ffc4ba5121035eef4b9d242d10d2ba3d", size = 461852, upload-time = "2026-05-23T13:14:52.929Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6c/bf372bde75873d09b5f8812f6bec8348248e791ca00b3b75ad7fcb480344/kmedoids-0.5.5-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e70e8baa124e8ddae3ea5f6d3efa84807d1378858ca559549aaa86bf5af6f6ea", size = 491823, upload-time = "2026-05-23T13:14:54.424Z" },
+    { url = "https://files.pythonhosted.org/packages/16/93/2345157919ce004710bbecba1108eaf37e583d8c1b7ac46de134b9d523b8/kmedoids-0.5.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e52a3ab7156413f43959759fb82b890a400052c32aceb189a4887ffe2d69f231", size = 537812, upload-time = "2026-05-23T13:14:56.396Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ea/6f8e13b6ff8d0025a34dc8275bde360071e8a2fcb0a6b313e4e2d9f2bed7/kmedoids-0.5.5-cp311-none-win_amd64.whl", hash = "sha256:828bb6f56617f691dd0e28ffd108f44fd24aa4bed30ade34addf575b10befab9", size = 374082, upload-time = "2026-05-23T13:14:58.611Z" },
+    { url = "https://files.pythonhosted.org/packages/68/68/b5a749dc5ab9ab34402bad6837f9bbf966c89e30173b14ae68603c56dbc7/kmedoids-0.5.5-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:353ede6766c35aa0f5db4bf1b1c94f92d92b9d8214913de4feeb3accfc31124d", size = 809756, upload-time = "2026-05-23T13:15:00.342Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d9/100bfb79bd2d78645b71550d1f4671b188a9866fd612f3a939a3935b06b5/kmedoids-0.5.5-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:99e3398ab73548abef0d3951724e6f09a8e735e7cf504c9d8f6cc56f12acda4c", size = 424457, upload-time = "2026-05-23T13:15:01.901Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1a/cd0b2afb611d9942dfd6685c9b19d47f9ef98097f8058eef6d3bcc9bec91/kmedoids-0.5.5-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:f03aea5bb4aaeacd6163404722d32b3a182d2cbe12983e8f1b91b5634845c550", size = 458751, upload-time = "2026-05-23T13:15:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/58/6bf4f946cba166b09abe8ef88d85dc43da1264afff30c97b647d6a051db0/kmedoids-0.5.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:13c1d515653797f2630ed915ccbb86ad9382968d4e621689ebe1a35b5f41620f", size = 489890, upload-time = "2026-05-23T13:15:05.218Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/57/af355c8ebc5aa94c2aa2bc123ca6643359ee37f41a242a70d8fa6e2adb68/kmedoids-0.5.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ca8fb5571941c260efc920bab10f6cffd648fcb79d40cff43007a2cb9438ad84", size = 533716, upload-time = "2026-05-23T13:15:07.048Z" },
+    { url = "https://files.pythonhosted.org/packages/19/7d/83ee33f208441a5303df7c6035dfa8d6189e7b9a13c3c9fa80070f34120c/kmedoids-0.5.5-cp312-none-win_amd64.whl", hash = "sha256:ed1c106cd51f904d5c70a96538bd3640eae7e3e6ab75f29533a74dfe19a0e26d", size = 371559, upload-time = "2026-05-23T13:15:08.593Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/9e/82a72c00b8beb611ce09bfcb4735160fb785e19c84bc68465ed4389936ef/kmedoids-0.5.5-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:12f4bf2ec3810b6be130e3fc10c754a36aec4ca26de8a7418e18830acaabdfd4", size = 808897, upload-time = "2026-05-23T13:15:10.462Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/52ddc55071b350c8f5fe96c2e3d8c71f8a3089d93192d8e38381309a359b/kmedoids-0.5.5-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:33494a300ff47cb99779dd4940ee2cd8c297f767fe1fcd32845090362b2842b8", size = 424273, upload-time = "2026-05-23T13:15:11.911Z" },
+    { url = "https://files.pythonhosted.org/packages/31/2c/9756a8aa6f5b54c64a1aad129f4d0c427aade89ecd86c54c46efc6541ecd/kmedoids-0.5.5-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f2173aefdfd584c6bdc801203cfff7a3113bf9bfabd72566d823e6734a014897", size = 457431, upload-time = "2026-05-23T13:15:13.649Z" },
+    { url = "https://files.pythonhosted.org/packages/85/96/e240991dddf6a39b6ad781bad15417ea679a15a4c70641fb41f8697ba358/kmedoids-0.5.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:83127e06239cbfff69d39b95523658b8e85acb55c146d9088148cd86da8b8db5", size = 489741, upload-time = "2026-05-23T13:15:15.444Z" },
+    { url = "https://files.pythonhosted.org/packages/11/53/542ab2b51dec75c86cb854946a72bddc47c6f89495ad1f9265c5ea4fd172/kmedoids-0.5.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d2c5d0d67e9ab000716b00413d6ecbf2835909c8e27e3d900cba002f13f0c423", size = 532668, upload-time = "2026-05-23T13:15:17.066Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/2d/a4cb65a8372521406422f0ca581275508d168b3c97955b8917a37b617525/kmedoids-0.5.5-cp313-none-win_amd64.whl", hash = "sha256:5a5f66e6418f622effac4d9c3e8ac3adbc4c3925adf255d054be2eec096a4917", size = 371206, upload-time = "2026-05-23T13:15:19.01Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b2/cc0c64f398935f9a6d24c0b9b6bd705931631757a7a71c0278b80da289af/kmedoids-0.5.5-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:861f0795cc8afff01ca9af5c6fc24d216a7938895d792d65709936e07f07cddf", size = 809442, upload-time = "2026-05-23T13:15:20.596Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d1/7bbc4226f87ee5fc6e3473ad2580103c6abcd0524c59382eee308676aba0/kmedoids-0.5.5-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:2fc723f21fcad47bd952bc05a233b8163a20be9681455b7e1d2544356852e9af", size = 423702, upload-time = "2026-05-23T13:15:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/62/fd80b2b72be0531f8bb9debff75fa6e1cd6ea3d26a0d660d21c5c989ab2b/kmedoids-0.5.5-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:df7f17cfdf0c105a2f321236d05ae85695daabf31e78f0e9e2340a6e8c3e39da", size = 457157, upload-time = "2026-05-23T13:15:23.819Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/e2/9ec167d486428f4e92d951c6380d9d3fd72da443715b31788ba88fb3499e/kmedoids-0.5.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9b91f56317ad2b27106e363c375e9e37cdaf76afaf61bcb8d3ecd0eb1672dcf6", size = 489587, upload-time = "2026-05-23T13:15:25.401Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/36512c6258aac788e8fb2fcaf5cce8dfdeb1d88027d385cc08aedbcc88b8/kmedoids-0.5.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fe0e22b1c32b983b2d551977f5f710cc291561a5b9e1fb82966c540346424f8c", size = 532640, upload-time = "2026-05-23T13:15:27.352Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/5d3c957fc56dfad8aaf264cdec79acfc8451bbcb5835b969fbfb140502d0/kmedoids-0.5.5-cp314-none-win_amd64.whl", hash = "sha256:0ac7302edb39496529a19d908b6a8f12bf641d594e50c66b64a6fb9429bc004a", size = 371181, upload-time = "2026-05-23T13:15:29.014Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/50/23aa3304f1a4de5e14a99e39b040d523ad59eca43390e072f3278d80a767/kmedoids-0.5.5-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:087d5cc4550db6cb06b45b31d5ad5734b51b2c1d0f565021e336b97f653921d3", size = 423664, upload-time = "2026-05-23T13:15:30.753Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/5b/ab5856be6fcfe2d54bdad0d01e0bc07c90fe5de82659baaff42f42387952/kmedoids-0.5.5-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:f6fc253859a594c01b57a0df046903a45cb91fb553d5600deb580d6bef3811ae", size = 457302, upload-time = "2026-05-23T13:15:32.221Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/cd/e67d45d057ed5870d3d3b8d53d955f88f0ea858f90b577981550699c27bb/kmedoids-0.5.5-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:65776cadadb06f839182ae32731dd7b7628cf862125182261d016ca80095a6c6", size = 489624, upload-time = "2026-05-23T13:15:34.117Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b6/ced74de840b7a72218ebffa925efd491af7c399d480b4fbfa1ddd398cfc2/kmedoids-0.5.5-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:1bc7adb0a0f04d4d05d8dc8315d63bada6263be154df913520eaeea1bcfaf14c", size = 532703, upload-time = "2026-05-23T13:15:36.022Z" },
+]
+
+[[package]]
 name = "lark"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1655,7 +1786,15 @@ docs = [
 
 [package.dev-dependencies]
 benchmarks = [
+    { name = "apricot-select" },
+    { name = "fpsample" },
+    { name = "kmedoids" },
     { name = "matplotlib" },
+    { name = "rdkit" },
+    { name = "skmatter" },
+]
+benchmarks-gpl = [
+    { name = "qc-selector" },
 ]
 dev = [
     { name = "check-wheel-contents" },
@@ -1701,7 +1840,15 @@ requires-dist = [
 provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
-benchmarks = [{ name = "matplotlib", specifier = ">=3.9" }]
+benchmarks = [
+    { name = "apricot-select", specifier = ">=0.6" },
+    { name = "fpsample", specifier = ">=1.0" },
+    { name = "kmedoids", specifier = ">=0.5" },
+    { name = "matplotlib", specifier = ">=3.9" },
+    { name = "rdkit", specifier = ">=2025.3" },
+    { name = "skmatter", specifier = ">=0.3" },
+]
+benchmarks-gpl = [{ name = "qc-selector", specifier = ">=0.1" }]
 dev = [
     { name = "check-wheel-contents", specifier = ">=0.6.2" },
     { name = "pre-commit", specifier = ">=4.0" },
@@ -1959,6 +2106,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "nose"
+version = "1.3.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/a5/0dc93c3ec33f4e281849523a5a913fa1eea9a3068acfa754d44d88107a44/nose-1.3.7.tar.gz", hash = "sha256:f1bffef9cbc82628f6e7d7b40d7e255aefaa1adb6a1b1d26c69a8b79e6208a98", size = 280488, upload-time = "2015-06-02T09:12:32.961Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/d8/dd071918c040f50fa1cf80da16423af51ff8ce4a0f2399b7bf8de45ac3d9/nose-1.3.7-py3-none-any.whl", hash = "sha256:9ff7c6cc443f8c51994b34a667bbcf45afd6d945be7477b52e97516fd17c53ac", size = 154731, upload-time = "2015-06-02T09:12:40.57Z" },
 ]
 
 [[package]]
@@ -2415,6 +2571,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pybind11"
+version = "3.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/f0/35145a3c3baffeef55d4b8324caa33abaa8fa56ab345ecd4b2211d09163e/pybind11-3.0.4.tar.gz", hash = "sha256:3286b59c8a774b9ee650169302dd5a4eedc30a8617905a0560dd8ee44775130c", size = 589533, upload-time = "2026-04-19T03:08:15.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/06/c3a23c9a0263b136c519f033a58d4641e73065fefc7754e9667ec206d992/pybind11-3.0.4-py3-none-any.whl", hash = "sha256:961720ee652da51d531b7b2451a6bd2bc042b0106e6d9baa48ecb7d58034ce63", size = 314166, upload-time = "2026-04-19T03:08:14.091Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -2801,6 +2966,47 @@ wheels = [
 ]
 
 [[package]]
+name = "qc-selector"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bitarray" },
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/35/484c3cde04cad5e98a89bbcbbb11cac9ad04cf7f54034260a588b0bb40d2/qc_selector-0.1.4.tar.gz", hash = "sha256:2e9e875a729e586a5f8137995837ca7a80a79b214cfcd55493cdd00c5546e34b", size = 121368, upload-time = "2026-02-03T02:39:19.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/bb/a0620d7a173e3c218bdaf22f0078ad1ffd299fa4dbed5875f3319b5c23ca/qc_selector-0.1.4-py3-none-any.whl", hash = "sha256:d9fb462937b23d37b2ca217558d95ba56f71df5aa9cd7b8599fa3545e2288aac", size = 105529, upload-time = "2026-02-03T02:39:17.208Z" },
+]
+
+[[package]]
+name = "rdkit"
+version = "2026.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "pillow" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/88/b7ca9475d0da762448c04fa858ec753c1da9753af35559bb380e655960a7/rdkit-2026.3.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5c9c5a9941d2fc4ea407db841768ffba67ac078952d373e73389ee249ecb2c62", size = 29935627, upload-time = "2026-06-05T18:42:24.995Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/c7ca96f0f728d175355a2153dedf3dfa9adf62d05ea2e6f01d834b12023f/rdkit-2026.3.3-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:afa84eda0c1703f7187e1386f56c91931b39772712c235abbd7d53ad0071d06b", size = 35774271, upload-time = "2026-06-05T18:42:28.528Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f9/61fc2cc89472bffc0bb30e616d2dc6ca8eb5a35aa50319ab1f62c35a3e1b/rdkit-2026.3.3-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:49daed64f54ca589590cf63c5ec4c43afb94301cdf4ca85fec270fcd675e2c4d", size = 37257559, upload-time = "2026-06-05T18:42:32.566Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1d/b04460859c12e1a8eac261c63ea39e958d2cfa84cc06cc8a295dde7150f5/rdkit-2026.3.3-cp311-cp311-win_amd64.whl", hash = "sha256:41ac83ad336b8aaf47b5bf5f2c36796b45957e97acecc1f9d5dcbc8235c6bfbe", size = 24599613, upload-time = "2026-06-05T18:42:36.135Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/4f/75315459fdf73837a5cfa0e06f95c64e1a86a9d51ac95e3499c5003a6933/rdkit-2026.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:179d528fa88dd9fbbab31c4c0536546010db970fd784fbdf5e2379c36254dfb5", size = 29981343, upload-time = "2026-06-05T18:42:40.052Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f7/10ab7321d82ef6e079560a75bb81c1ef17be8121c22b8c16c3e9c20a1df5/rdkit-2026.3.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f6e7493518dd526ef46cf96ea7fe77eb6bd6601848a2ae423ee3d7f5f8382753", size = 35653855, upload-time = "2026-06-05T18:42:43.628Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ec/550313f340b10501e72e69faf7a04223f99e4877c1cab7972eb3fbac3617/rdkit-2026.3.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:c69a40ad52a2489cf592d55b41f5f6fa482f028341c038f3ed7d6b46834d1d3d", size = 37188323, upload-time = "2026-06-05T18:42:47.48Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/d9/4c64a2db3cafc2600a8e3d07fb186f925135d653d9dd10c9acb7021f654e/rdkit-2026.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:1f6333feb1267efe31040fbd61397f80d05af01d922fa539fb97243057ce90a8", size = 24619664, upload-time = "2026-06-05T18:42:51.406Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ab/cb5b090defcc86bace4f0aec6702a648b057b56575ebfd29fe3ea9101122/rdkit-2026.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b9583b0c6743c2aca491d7d376ece94aca0f87de275b74f024a8286b9528786f", size = 29980394, upload-time = "2026-06-05T18:42:54.721Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3f/4cbd7d602fb29a2682a21fc4dc31b2784d8792bc90d6855132e0874cf72b/rdkit-2026.3.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:4395555de7f4cc13ec5717f9010e06137a9e6d8665ec6ed09fbff99f88ceb374", size = 35653124, upload-time = "2026-06-05T18:42:58.278Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/1a/a8b64f5304c19181fb4a0b859b7b4bd07d15b4e1379deb024d72cb012b9e/rdkit-2026.3.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9a21f96d92c434c32a4c0d1cc6ebde5f0e57ddbbf24cbfbfd085a3a80e1ceab3", size = 37187145, upload-time = "2026-06-05T18:43:02.283Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d0/5de3d0d7e66f0e7e7795ab94a53b826e257176c15c9ee79f15621ac040ed/rdkit-2026.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:f8bd59b24e128c9c70c975bfb1920cf610ba3096439a24ca2850eb861e767c48", size = 24618400, upload-time = "2026-06-05T18:43:05.962Z" },
+    { url = "https://files.pythonhosted.org/packages/45/da/825325da9989d10a309378754464898c07199a2881fd04171613948aa82f/rdkit-2026.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2a98cb204fc4cb6121558890db61c17b24885ad37c2f763228693c220d50601a", size = 29997029, upload-time = "2026-06-05T18:43:09.32Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7f/da8e8edc80a8686083e481b6b4023b9f67c0749d09402c419d6e92faeba9/rdkit-2026.3.3-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:15ffcb0990362afeb9ed3f2e4e116a6fe70ed09f7b6530efd78fc53323e73c3a", size = 35691184, upload-time = "2026-06-05T18:43:13.009Z" },
+    { url = "https://files.pythonhosted.org/packages/30/7b/0f6916498687aad6aacc28dfa59cc9b2bf03b869d81522a9fe1bf6c1e72a/rdkit-2026.3.3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:b7e920729e5f1e5708dd3a239bae461ae913a199befb36bf6c14faffc0217717", size = 37199685, upload-time = "2026-06-05T18:43:16.808Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6c/bbcaca92a190548053570493bf01628228a5cae12d8f361371f8abc37e3b/rdkit-2026.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:8e2b6b797683a14c4f0cccfcbeacb0c1f99c5dabf06f4a67bc023926e5673a44", size = 25104349, upload-time = "2026-06-05T18:43:20.35Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2996,6 +3202,56 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/92/53ea2181da8ac6bf27170191028aee7251f8f841f8d3edbfdcaf2008fde9/scikit_learn-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:146b4d36f800c013d267b29168813f7a03a43ecd2895d04861f1240b564421da", size = 8595835, upload-time = "2025-12-10T07:07:39.385Z" },
+    { url = "https://files.pythonhosted.org/packages/01/18/d154dc1638803adf987910cdd07097d9c526663a55666a97c124d09fb96a/scikit_learn-1.8.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:f984ca4b14914e6b4094c5d52a32ea16b49832c03bd17a110f004db3c223e8e1", size = 8080381, upload-time = "2025-12-10T07:07:41.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/44/226142fcb7b7101e64fdee5f49dbe6288d4c7af8abf593237b70fca080a4/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5e30adb87f0cc81c7690a84f7932dd66be5bac57cfe16b91cb9151683a4a2d3b", size = 8799632, upload-time = "2025-12-10T07:07:43.899Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4d/4a67f30778a45d542bbea5db2dbfa1e9e100bf9ba64aefe34215ba9f11f6/scikit_learn-1.8.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ada8121bcb4dac28d930febc791a69f7cb1673c8495e5eee274190b73a4559c1", size = 9103788, upload-time = "2025-12-10T07:07:45.982Z" },
+    { url = "https://files.pythonhosted.org/packages/89/3c/45c352094cfa60050bcbb967b1faf246b22e93cb459f2f907b600f2ceda5/scikit_learn-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:c57b1b610bd1f40ba43970e11ce62821c2e6569e4d74023db19c6b26f246cb3b", size = 8081706, upload-time = "2025-12-10T07:07:48.111Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/46/5416595bb395757f754feb20c3d776553a386b661658fb21b7c814e89efe/scikit_learn-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:2838551e011a64e3053ad7618dda9310175f7515f1742fa2d756f7c874c05961", size = 7688451, upload-time = "2025-12-10T07:07:49.873Z" },
+    { url = "https://files.pythonhosted.org/packages/90/74/e6a7cc4b820e95cc38cf36cd74d5aa2b42e8ffc2d21fe5a9a9c45c1c7630/scikit_learn-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5fb63362b5a7ddab88e52b6dbb47dac3fd7dafeee740dc6c8d8a446ddedade8e", size = 8548242, upload-time = "2025-12-10T07:07:51.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d8/9be608c6024d021041c7f0b3928d4749a706f4e2c3832bbede4fb4f58c95/scikit_learn-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:5025ce924beccb28298246e589c691fe1b8c1c96507e6d27d12c5fadd85bfd76", size = 8079075, upload-time = "2025-12-10T07:07:53.697Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/47/f187b4636ff80cc63f21cd40b7b2d177134acaa10f6bb73746130ee8c2e5/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4496bb2cf7a43ce1a2d7524a79e40bc5da45cf598dbf9545b7e8316ccba47bb4", size = 8660492, upload-time = "2025-12-10T07:07:55.574Z" },
+    { url = "https://files.pythonhosted.org/packages/97/74/b7a304feb2b49df9fafa9382d4d09061a96ee9a9449a7cbea7988dda0828/scikit_learn-1.8.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0bcfe4d0d14aec44921545fd2af2338c7471de9cb701f1da4c9d85906ab847a", size = 8931904, upload-time = "2025-12-10T07:07:57.666Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c4/0ab22726a04ede56f689476b760f98f8f46607caecff993017ac1b64aa5d/scikit_learn-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:35c007dedb2ffe38fe3ee7d201ebac4a2deccd2408e8621d53067733e3c74809", size = 8019359, upload-time = "2025-12-10T07:07:59.838Z" },
+    { url = "https://files.pythonhosted.org/packages/24/90/344a67811cfd561d7335c1b96ca21455e7e472d281c3c279c4d3f2300236/scikit_learn-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:8c497fff237d7b4e07e9ef1a640887fa4fb765647f86fbe00f969ff6280ce2bb", size = 7641898, upload-time = "2025-12-10T07:08:01.36Z" },
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
+    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
+    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
+    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3143,6 +3399,19 @@ wheels = [
 ]
 
 [[package]]
+name = "skmatter"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "scikit-learn" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/c7/b7ce13ea8c0de103239d7dd79f450bccfddca6f791f00ea636e5d095e557/skmatter-0.3.3.tar.gz", hash = "sha256:5ecda9f9d2b543184c8ec5853ad3109789360e40b8e14214426918bc01d6ddd1", size = 1890772, upload-time = "2026-01-06T15:58:50.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/a0/75cda48cc8d443de84dcc764a7c4ca91581ddafada5eea76cda32976ee58/skmatter-0.3.3-py3-none-any.whl", hash = "sha256:bd52bf9c7f04cd707a52f333b0fb861e38bd84c0cb2caa4bc626deb86252ad4d", size = 1907658, upload-time = "2026-01-06T15:58:49.024Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3177,6 +3446,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the tier-2 competitor roster behind the SelectionAdapter contract: fpsample FPS, skmatter FPS, RDKit MaxMinPicker (lazy distances), apricot facility location (labeled different-objective), kmedoids FasterPAM (coverage baseline), and a greedy max-sum insertion baseline. GPL-3 qc-selector lives in a separate opt-in `benchmarks-gpl` dependency group so the default group stays GPL-free; the smoke scenario skips it cleanly when not installed. All adapters verified installing and running on py3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)