### PR TITLE
chore: add code-FDM adapter for constrained comparisons

### DIFF
--- a/benchmarks/adapters/__init__.py
+++ b/benchmarks/adapters/__init__.py
@@ -2,6 +2,7 @@
 
 from .apricot_fl import ApricotFacilityLocation
 from .base import SelectionAdapter
+from .code_fdm import CodeFdmFairFlow
 from .fps import FpsampleFPS, SkmatterFPS
 from .greedy_maxsum import GreedyMaxSum
 from .kmedoids_fasterpam import KMedoidsFasterPAM
@@ -11,6 +12,7 @@ from .rdkit_maxmin import RdkitMaxMin
 
 __all__ = [
     "ApricotFacilityLocation",
+    "CodeFdmFairFlow",
     "FpsampleFPS",
     "GreedyMaxSum",
     "KMedoidsFasterPAM",

--- a/benchmarks/adapters/code_fdm.py
+++ b/benchmarks/adapters/code_fdm.py
@@ -30,7 +30,7 @@ class CodeFdmFairFlow(SelectionAdapter):
     """Fair max-min selection via code-FDM's FairFlow algorithm.
 
     code-FDM's fairness model is disjoint color groups with an exact per-group count;
-    the adapter maps max-div constraints onto that model (validating disjointness and
+    the adapter maps max-div constraints onto that model (validating that groups are disjoint and
     deriving per-group counts within each constraint's min/max bounds) and treats
     items outside every constraint as one remainder group.
     """

--- a/benchmarks/adapters/code_fdm.py
+++ b/benchmarks/adapters/code_fdm.py
@@ -1,0 +1,128 @@
+"""code-FDM adapter: fair max-min diversification with per-group counts (Wang et al., Entropy 2023).
+
+code-FDM (github.com/yhwang1990/code-FDM) is unpackaged research code without a license
+grant, so it is never vendored or redistributed: the two modules it consists of are
+fetched at run time from a pinned commit into a local cache and imported from there.
+Scenarios must treat this adapter as optional (network + upstream availability).
+"""
+
+import importlib.util
+import sys
+import urllib.request
+from pathlib import Path
+from types import ModuleType
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div.problem import MaxDivProblem
+
+from ._inputs import problem_vectors
+from .base import SelectionAdapter
+
+_REPO_RAW = "https://raw.githubusercontent.com/yhwang1990/code-FDM"
+_PINNED_COMMIT = "d18758a93f9173e1e888a886e2e0ea10c5639022"
+_MODULES = ("utils.py", "algorithms_offline.py")
+_CACHE_DIR = Path("reports/benchmarks/vendor/code_fdm")
+
+
+class CodeFdmFairFlow(SelectionAdapter):
+    """Fair max-min selection via code-FDM's FairFlow algorithm.
+
+    code-FDM's fairness model is disjoint color groups with an exact per-group count;
+    the adapter maps max-div constraints onto that model (validating disjointness and
+    deriving per-group counts within each constraint's min/max bounds) and treats
+    items outside every constraint as one remainder group.
+    """
+
+    @property
+    def name(self) -> str:
+        """Tool name as it appears in records and figures."""
+        return "code-FDM[FairFlow]"
+
+    @property
+    def supports_constraints(self) -> bool:
+        """code-FDM is the one heuristic competitor that honors group constraints."""
+        return True
+
+    def select(self, problem: MaxDivProblem, seed: int) -> NDArray[np.int64]:
+        """Run FairFlow with colors and counts derived from the problem's constraints."""
+        algorithms, utils = _load_code_fdm()
+        vectors = problem_vectors(problem)
+        colors, counts = _constraints_to_colors(problem)
+
+        elements = [utils.Element(idx=i, color=int(colors[i]), features=vectors[i].tolist()) for i in range(problem.n)]
+        selected, _diversity, _t = algorithms.FairFlow(elements, len(counts), counts, utils.euclidean_dist)
+        return np.asarray(sorted(selected), dtype=np.int64)
+
+
+def _constraints_to_colors(problem: MaxDivProblem) -> tuple[NDArray[np.int64], list[int]]:
+    """Map the problem's constraints onto code-FDM's disjoint-color model.
+
+    Each constraint becomes one color; items outside every constraint share a remainder
+    color. Per-color counts start at each constraint's min_count and the remaining
+    budget is distributed greedily within max_count bounds (largest slack first).
+
+    Returns:
+        Tuple of (per-item color array, per-color count list summing to k).
+
+    Raises:
+        ValueError: If constraints overlap (code-FDM cannot express that) or no
+            count assignment within the bounds sums to k.
+    """
+    if problem.m == 0:
+        raise ValueError("code-FDM comparison requires a constrained problem.")
+
+    colors = np.full(problem.n, problem.m, dtype=np.int64)  # default: remainder color
+    for color, con in enumerate(problem.constraints):
+        indices = np.fromiter(con.int_set, dtype=np.int64)
+        if (colors[indices] != problem.m).any():
+            raise ValueError("Constraints overlap; code-FDM's disjoint-color model cannot express them.")
+        colors[indices] = color
+
+    counts = [con.min_count for con in problem.constraints]
+    n_remainder = int((colors == problem.m).sum())
+    has_remainder = n_remainder > 0
+    if has_remainder:
+        counts.append(0)
+    max_counts = [con.max_count for con in problem.constraints] + ([n_remainder] if has_remainder else [])
+
+    budget = problem.k - sum(counts)
+    if budget < 0:
+        raise ValueError("Sum of constraint min_counts exceeds k; no feasible code-FDM count assignment.")
+    slack_order = sorted(range(len(counts)), key=lambda i: max_counts[i] - counts[i], reverse=True)
+    for i in slack_order:
+        take = min(budget, max_counts[i] - counts[i])
+        counts[i] += take
+        budget -= take
+    if budget > 0:
+        raise ValueError("Constraint max_counts leave no room to reach k; cannot map onto code-FDM.")
+    return colors, counts
+
+
+def _load_code_fdm() -> tuple[ModuleType, ModuleType]:
+    """Fetch (if needed) and import code-FDM's two modules from the pinned commit."""
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    for filename in _MODULES:
+        target = _CACHE_DIR / filename
+        if not target.exists():
+            url = f"{_REPO_RAW}/{_PINNED_COMMIT}/{filename}"
+            with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310 -- pinned https URL
+                target.write_bytes(response.read())
+
+    modules = []
+    for filename in _MODULES:
+        module_name = f"code_fdm_{filename.removesuffix('.py')}"
+        if module_name in sys.modules:
+            modules.append(sys.modules[module_name])
+            continue
+        # code-FDM's modules cross-import each other by their original names
+        alias = filename.removesuffix(".py")
+        spec = importlib.util.spec_from_file_location(alias, _CACHE_DIR / filename)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[alias] = module
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        modules.append(module)
+    utils, algorithms = modules[0], modules[1]
+    return algorithms, utils

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,8 @@ benchmarks = [
     "rdkit>=2025.3",
     "apricot-select>=0.6",
     "kmedoids>=0.5",
+    "networkx>=3.0",       # runtime dependency of the code-FDM research code
+    "scikit-learn>=1.4",   # runtime dependency of the code-FDM research code
 ]
 # GPL-3 competitor kept in its own opt-in group so the default benchmarks group stays GPL-free.
 benchmarks-gpl = [

--- a/uv.lock
+++ b/uv.lock
@@ -1790,7 +1790,9 @@ benchmarks = [
     { name = "fpsample" },
     { name = "kmedoids" },
     { name = "matplotlib" },
+    { name = "networkx" },
     { name = "rdkit" },
+    { name = "scikit-learn" },
     { name = "skmatter" },
 ]
 benchmarks-gpl = [
@@ -1845,7 +1847,9 @@ benchmarks = [
     { name = "fpsample", specifier = ">=1.0" },
     { name = "kmedoids", specifier = ">=0.5" },
     { name = "matplotlib", specifier = ">=3.9" },
+    { name = "networkx", specifier = ">=3.0" },
     { name = "rdkit", specifier = ">=2025.3" },
+    { name = "scikit-learn", specifier = ">=1.4" },
     { name = "skmatter", specifier = ">=0.3" },
 ]
 benchmarks-gpl = [{ name = "qc-selector", specifier = ">=0.1" }]
@@ -2097,6 +2101,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the sole heuristic competitor that honors group constraints: code-FDM's FairFlow (fair max-min, disjoint per-group counts). The research code has no license grant, so nothing is vendored — its two modules are fetched at run time from a pinned upstream commit into a gitignored cache. max-div constraints are mapped onto code-FDM's disjoint-color model (min/max bounds honored, remainder items grouped); overlapping constraints are rejected with a clear error. Verified end-to-end on the constrained C1 generator (all constraints satisfied) and on C3 (correctly rejected as inexpressible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)