### PR TITLE
chore: add SCIP exact mean/geomean-of-NN reference to the benchmark harness

### DIFF
--- a/benchmarks/exact/__init__.py
+++ b/benchmarks/exact/__init__.py
@@ -1,8 +1,11 @@
 """Exact-solver references: formulations that prove optimality at small problem sizes."""
 
 from .cpsat_maxmin import CpsatMaxMinResult, solve_maxmin_cpsat
+from .scip_nn_separation import ScipNnSeparationResult, solve_nn_separation_scip
 
 __all__ = [
     "CpsatMaxMinResult",
+    "ScipNnSeparationResult",
     "solve_maxmin_cpsat",
+    "solve_nn_separation_scip",
 ]

--- a/benchmarks/exact/scip_nn_separation.py
+++ b/benchmarks/exact/scip_nn_separation.py
@@ -1,0 +1,126 @@
+"""Exact mean/geomean-of-NN reference via a nearest-neighbor assignment MILP (SCIP).
+
+Model (Lei & Church-style): binary x_j = "item j selected", binary y_ij = "j is i's
+nearest selected neighbor". Each selected item is assigned exactly one neighbor, and
+closest-assignment constraints force that neighbor to be the *nearest* selected one.
+Maximizing sum(d_ij * y_ij) then solves mean-of-NN separation exactly; running the same
+model on log-distances solves geomean-of-NN (the geometric mean is the arithmetic mean
+after a log transform). Group min/max-count constraints bolt on directly. O(n^2)
+binaries: practical only at small n — that is the point of an exact reference.
+"""
+
+import math
+import time
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy.spatial.distance import squareform
+
+from max_div.metrics import DiversityMetric
+from max_div.problem import MaxDivProblem
+
+SUPPORTED_METRICS = (DiversityMetric.MEAN_SEPARATION, DiversityMetric.GEOMEAN_SEPARATION)
+
+
+@dataclass
+class ScipNnSeparationResult:
+    """Outcome of the assignment-MILP solve."""
+
+    i_selected: NDArray[np.int64]
+    objective_value: float  # mean of NN separations (geomean for the geomean objective)
+    proven_optimal: bool
+    measured_sec: float
+
+
+def solve_nn_separation_scip(
+    problem: MaxDivProblem,
+    metric: DiversityMetric,
+    time_limit_sec: float = 120.0,
+) -> ScipNnSeparationResult:
+    """Solve mean- or geomean-of-NN selection (with group constraints) via SCIP.
+
+    Args:
+        problem: Problem to solve; its constraints are encoded directly.
+        metric: MEAN_SEPARATION or GEOMEAN_SEPARATION.
+        time_limit_sec: SCIP wall-clock limit.
+
+    Returns:
+        Best selection found, its objective value, and whether optimality was proven.
+
+    Raises:
+        ValueError: For unsupported metrics.
+        RuntimeError: If SCIP finds no feasible selection within the limit.
+    """
+    from pyscipopt import Model, quicksum
+
+    if metric not in SUPPORTED_METRICS:
+        raise ValueError(f"Unsupported metric for the NN-assignment MILP: {metric}.")
+
+    t_start = time.perf_counter()
+    distances = squareform(problem.condensed_distances().astype(np.float64))
+    n, k = problem.n, problem.k
+    weights = np.log(np.maximum(distances, 1e-12)) if metric == DiversityMetric.GEOMEAN_SEPARATION else distances
+
+    model = Model("nn-separation")
+    model.hideOutput()
+    model.setParam("limits/time", time_limit_sec)
+
+    x = [model.addVar(vtype="B", name=f"x{j}") for j in range(n)]
+    y = {(i, j): model.addVar(vtype="B", name=f"y{i}_{j}") for i in range(n) for j in range(n) if i != j}
+
+    model.addCons(quicksum(x) == k)
+    _add_assignment_constraints(model, x, y, n)
+    _add_closest_assignment_constraints(model, x, y, distances)
+    for con in problem.constraints:
+        group_sum = quicksum(x[i] for i in con.int_set)
+        model.addCons(group_sum >= con.min_count)
+        model.addCons(group_sum <= con.max_count)
+
+    model.setObjective(quicksum(weights[i, j] * y[i, j] for (i, j) in y), "maximize")
+    model.optimize()
+
+    if model.getNSols() == 0:
+        raise RuntimeError("SCIP found no feasible selection within the time limit.")
+
+    selection = np.asarray([j for j in range(n) if model.getVal(x[j]) > 0.5], dtype=np.int64)
+    obj = model.getObjVal() / k  # mean of NN contributions (log-domain for geomean)
+    if metric == DiversityMetric.GEOMEAN_SEPARATION:
+        obj = math.exp(obj)
+
+    return ScipNnSeparationResult(
+        i_selected=np.sort(selection),
+        objective_value=float(obj),
+        proven_optimal=model.getStatus() == "optimal",
+        measured_sec=time.perf_counter() - t_start,
+    )
+
+
+def _add_assignment_constraints(model, x, y, n) -> None:  # noqa: ANN001 -- pyscipopt types are dynamic
+    """Each selected item gets exactly one NN assignment, and only to a selected neighbor."""
+    from pyscipopt import quicksum
+
+    for i in range(n):
+        model.addCons(quicksum(y[i, j] for j in range(n) if j != i) == x[i])
+        for j in range(n):
+            if i != j:
+                model.addCons(y[i, j] <= x[j])
+
+
+def _add_closest_assignment_constraints(model, x, y, distances) -> None:  # noqa: ANN001 -- pyscipopt types are dynamic
+    """Force each assignment to the *nearest* selected neighbor.
+
+    If i and j are both selected, i must be assigned to some neighbor at least as
+    close as j; walking neighbors in distance order accumulates the "closer" set.
+    """
+    from pyscipopt import quicksum
+
+    order = np.argsort(distances, axis=1)
+    for i in range(distances.shape[0]):
+        closer: list = []
+        for j_raw in order[i]:
+            j = int(j_raw)
+            if j == i:
+                continue
+            model.addCons(quicksum(y[i, ll] for ll in closer) + y[i, j] >= x[j] + x[i] - 1)
+            closer.append(j)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ benchmarks = [
     "networkx>=3.0",       # runtime dependency of the code-FDM research code
     "scikit-learn>=1.4",   # runtime dependency of the code-FDM research code
     "ortools>=9.10",       # CP-SAT: exact max-min reference
+    "pyscipopt>=5.0",      # SCIP: exact mean/geomean-of-NN reference
 ]
 # GPL-3 competitor kept in its own opt-in group so the default benchmarks group stays GPL-free.
 benchmarks-gpl = [

--- a/uv.lock
+++ b/uv.lock
@@ -1031,7 +1031,7 @@ name = "icc-rt"
 version = "2020.0.133"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "intel-openmp" },
+    { name = "intel-openmp", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/2d/3a308249f7e9d322a8858af3930670c8de7ebb131090a6e62473db844fdd/icc_rt-2020.0.133-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:17a173e65cee0c516358172b9cc96fe297dd54f4d6b23d57f79c62d9e105e3cf", size = 11241236, upload-time = "2019-11-13T12:01:50.643Z" },
@@ -1818,6 +1818,7 @@ benchmarks = [
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "ortools" },
+    { name = "pyscipopt" },
     { name = "rdkit" },
     { name = "scikit-learn" },
     { name = "skmatter" },
@@ -1876,6 +1877,7 @@ benchmarks = [
     { name = "matplotlib", specifier = ">=3.9" },
     { name = "networkx", specifier = ">=3.0" },
     { name = "ortools", specifier = ">=9.10" },
+    { name = "pyscipopt", specifier = ">=5.0" },
     { name = "rdkit", specifier = ">=2025.3" },
     { name = "scikit-learn", specifier = ">=1.4" },
     { name = "skmatter", specifier = ">=0.3" },
@@ -2889,6 +2891,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pyscipopt"
+version = "6.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/b9/ef40e260c3e722d9d4617dd70548c1e3c51b065decd341cf9b9031957bf1/pyscipopt-6.2.1.tar.gz", hash = "sha256:3da1634ff341c8665fcf100486f7968ddbbf160dc56d83e99338717d2245ef6a", size = 1683168, upload-time = "2026-05-16T15:06:54.486Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/48/0aba04be54a4525a3a0672fcc178de1d8bf7228c4642dc50d7b6cf0790f5/pyscipopt-6.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3ff3ca831e5b13ec6e5d67d61c6dffbc9016952bab6891f1e94910082ab92005", size = 8446138, upload-time = "2026-05-16T15:04:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1b/c434f3d0bc31d2e433abc819ac76aa8deef2df4409e8672278656762a5a3/pyscipopt-6.2.1-cp311-cp311-macosx_11_0_x86_64.whl", hash = "sha256:337f5fe1129bfdd918c04bfbc94ecc4c524bd23faf41a37649132fe52a01f750", size = 12298893, upload-time = "2026-05-16T15:04:46.876Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ba/55af4289c550290f3452758c35e9d9b42b69dfc3c7d5976c88f51c942f0f/pyscipopt-6.2.1-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a379c6c038f68d98a21ca5a5a855acba94fbbd53baa70fbcd85e3af2545969e6", size = 16388156, upload-time = "2026-05-16T15:04:49.754Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/24/0384848cf14c69ba5db6e315716fcf3d84e9c1704c70062943f261a33829/pyscipopt-6.2.1-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2463128979ab81d2f99533fefa555c44008bd6aea5e67a19dfc09ddd3a43b3b4", size = 17704107, upload-time = "2026-05-16T15:04:52.786Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/65efa84aea17f68a0a7c4d4de67c9185b0fd9effd8b2a9bd7bbf60568766/pyscipopt-6.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:abc496fee8704f7d975cc7b860c30dd5bbe057478c4c19048eee247cdfcb8138", size = 48290571, upload-time = "2026-05-16T15:04:57.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/dc/347f5b1a30972fb86759d6975acab3cb0fcbd1df6ea0f26873a8a46ddc32/pyscipopt-6.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fbfbc9fce11f8ee0383e64fcfef4bb1e7b5ae6a1063dd964008cf20f906fdd4d", size = 8411318, upload-time = "2026-05-16T15:05:01.205Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/319ef747c8b639165e78a5013c65eae9fa265f364abd6d85cb932719aa30/pyscipopt-6.2.1-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:df9581445061a58c8681e884b4f00801f4ee1dc150d9e5d30faa3cd05f6f5c7c", size = 12259796, upload-time = "2026-05-16T15:05:03.887Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/d9/cdecac650bbab6c8d5fcf9577b77bda53d8bbe972b6285e12530b4782d77/pyscipopt-6.2.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7839074b1dff5cd6e243ea86c0f43cd9f7e9e19257b1fdc5549cf9c9cff0fa6d", size = 16214522, upload-time = "2026-05-16T15:05:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/5b/3ce96f3ed012d3f17556748b27d49ba42b3662283ecb02ae45c70ed19de1/pyscipopt-6.2.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faf86357d83772508c5b1925570ee7e08385fa1a736e0ee33bf0e5c421dd845f", size = 17566755, upload-time = "2026-05-16T15:05:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/50/9fceeb125674c0e955b2175cbba24f2b32ba5f8b635c3484648eb802d090/pyscipopt-6.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:784d8fbee8134c7c1cf590a60972008159033938a5044d9ed28cde9abf4f86be", size = 48216285, upload-time = "2026-05-16T15:05:17.131Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ac/251c595d0eddd4e5480717298118bd252c3d8e5c169d2d95efc862e259ab/pyscipopt-6.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:353725a8f65c86299502aadca12c3a1c7622a64746ea12251906ae0165c843ae", size = 8405270, upload-time = "2026-05-16T15:05:20.386Z" },
+    { url = "https://files.pythonhosted.org/packages/95/34/28ae4af84b6d372404da9d5ff636f1341826f80b793d98f86cac03bd0aa4/pyscipopt-6.2.1-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:fdba06632975280df18e684aa4b9867b1167cb3a6aa9a201e7ee3b108985af51", size = 12257430, upload-time = "2026-05-16T15:05:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/6f/5173067773b5e650566f90c3356bd3a71c02349e6644222a8971c0196687/pyscipopt-6.2.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8860afb9d43c93b653c7295ef674ad1ba156c731591fb7e33b5991c1136b0dc6", size = 16207762, upload-time = "2026-05-16T15:05:26.883Z" },
+    { url = "https://files.pythonhosted.org/packages/57/76/59288c92b7ee914c351c6003b63249e0702d990d1fdd9ff97e65ffc1c57b/pyscipopt-6.2.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:725503ea90fd0962f1111a5b46ee3e271b7375e1b0dfda708ce223dbebaeff5e", size = 17560629, upload-time = "2026-05-16T15:05:30.298Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/42/2b1d48d11311c2fda215c8da83f8f8cabec3b5a82936a7229919ad9141e5/pyscipopt-6.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:a5621ddcb59f7816e87c3deeb1bf52f8693e016a1a29148201b712adb84956e3", size = 48215647, upload-time = "2026-05-16T15:05:36.5Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/af/4ddfd3802ff69ad58f44e6d96878265c4ea55cac2313aae1994611b0d6aa/pyscipopt-6.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:299dbff65d60853d545788457d02720e3693df19ade4aaba1bbe8b575239ff4b", size = 8418209, upload-time = "2026-05-16T15:05:40.166Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/53/61ab5575a6e29547b6d13c37d7005b3f348897b48dd6cbcd4261196f2e25/pyscipopt-6.2.1-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:8bd6fb0f2a6c8bf4ef49e524d4c022b7b539098193ce312e94d29c6254658ff6", size = 12267358, upload-time = "2026-05-16T15:05:43.17Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/fd/851dedcabdb6d6168eae0e2c31008d02f20cf018b05d091a5bda6f5da6a1/pyscipopt-6.2.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb7858ceececa09658c3bfa58476862255353fea52d4f512ff97160f138f92cd", size = 16171696, upload-time = "2026-05-16T15:05:46.851Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/ac663246709e6ab94b225c40e9dac863a91b1b86e12c2ea65c951f944bea/pyscipopt-6.2.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cdf0e460b834f06ea68a13e59f581f7ecbec5a466a76bbf1267ac5b4573bb52", size = 17430536, upload-time = "2026-05-16T15:05:50.267Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ca/05d80040767d1d2443ea6cd6cc42985cdd532feeaecfcc19f103c8b45a1b/pyscipopt-6.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:6aed03b621decb09b38f399773bf8cf2c707e965990b778a24d28c8cc90a0756", size = 49375214, upload-time = "2026-05-16T15:05:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d4/caa18165a2faf876d8d482b0b92bd75abf284af2b51b64ebee62c1b47065/pyscipopt-6.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:18c6283b8fc47929787a043204e7bb26f41e414d1e8597d394057bcc60fc3ee0", size = 8528074, upload-time = "2026-05-16T15:05:59.776Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/3c/f6593bf4459e788f2302878369c5eb65ec5b04fd6e18524296fe05365c6b/pyscipopt-6.2.1-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:622e9640cdfc22632079ed4f73d88653d6170ee89ca6bdb6459d0db334fa7a87", size = 12341833, upload-time = "2026-05-16T15:06:02.402Z" },
+    { url = "https://files.pythonhosted.org/packages/49/db/bc80dfa03ef13701b818aca26428fe05c389a71a8ec5654e1e4ea60ef3a4/pyscipopt-6.2.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a85fb7f73fd06fad9a0358b2eb47d94dbe94ee52baf85e045beb5e216022b6c7", size = 16735540, upload-time = "2026-05-16T15:06:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/58/ee/97cd080513efdedea2fcd1f9b71d02e775f5e445ab39f8f012c14e4b4c5e/pyscipopt-6.2.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d323fa83b855308587794cd0ab04ae6dd341c227202d0ddaec2761917034e972", size = 17628571, upload-time = "2026-05-16T15:06:09.608Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/75/e280c162ae55a5db7f9031c4b92774964a8eebef94d2d463a389c9f6294b/pyscipopt-6.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:138e312cd692b7c853e7eab572986bc6d2dd28acd6e16347d73c96c225613056", size = 49551043, upload-time = "2026-05-16T15:06:15.368Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the tier-1 exact reference for the NN-separation objectives: a nearest-neighbor assignment MILP (binary selection + assignment variables with closest-assignment constraints), solved by SCIP via PySCIPOpt. GEOMEAN_SEPARATION reuses the identical model on log-distances. Group min/max-count constraints are encoded directly. Smoke test at n=40 with two constraints: both objectives proven optimal (~10-13s), with the MILP objective value matching the harness's independent quality evaluation exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)