### PR TITLE
fix: prevent SMART-preset crash when a swap empties the selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+- `SolverPreset.SMART` no longer crashes on very small problems where an adaptive swap can remove all but one selected item
 
 ### Security
 

--- a/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
+++ b/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
@@ -5,7 +5,7 @@ from numpy.typing import NDArray
 from max_div._core._math.fast_log_exp import fast_exp2_f32
 
 
-@njit(fastmath=True, inline="always")
+@njit(inline="always")
 def exponential_selectivity(
     p_in: NDArray[np.float32],
     p_out: NDArray[np.float32],
@@ -46,12 +46,33 @@ def exponential_selectivity(
     p_range = p_max - p_min
 
     # --- corner case ---------------------------
-    if p_range == 0.0:
+    # Degenerate ranges fall back to uniform: all-equal inputs (p_range == 0) and
+    # non-finite inputs (e.g. the +inf contribution of a sole selected item, which
+    # makes p_range inf or nan) — the transform would emit NaNs for those.
+    # NOTE: this guard is why the function is not compiled with fastmath: fastmath
+    # lets LLVM assume no NaN/inf exists and optimize the isfinite check away.
+    if (p_range == 0.0) or (not np.isfinite(p_range)):
         for i in range(n):
             p_out[i] = np.float32(1.0)
         return
 
     # --- actual transformation -----------------
+    _exponential_transform(p_in, p_out, modifier, reverse, low_value, p_min, p_max, p_range)
+
+
+@njit(fastmath=True, inline="always")
+def _exponential_transform(
+    p_in: NDArray[np.float32],
+    p_out: NDArray[np.float32],
+    modifier: np.float32,
+    reverse: bool,
+    low_value: np.float32,
+    p_min: np.float32,
+    p_max: np.float32,
+    p_range: np.float32,
+) -> None:
+    """Apply the exponential transform for finite, non-degenerate p_in (see exponential_selectivity)."""
+    n = p_in.shape[0]
 
     # precompute values
     t = (np.float32(1.0) + modifier) / (np.float32(1.0) - modifier)

--- a/tests/_core/_math/modify_p_selectivity/test_exponential.py
+++ b/tests/_core/_math/modify_p_selectivity/test_exponential.py
@@ -40,3 +40,26 @@ def test_order_based_selectivity_corner_case():
 
     # --- assert ------------------------------------------
     assert np.array_equal(p_out, expected_p_out)
+
+
+@pytest.mark.parametrize(
+    "p_in",
+    [
+        np.array([np.inf], dtype=np.float32),
+        np.array([np.inf, 3.0], dtype=np.float32),
+        np.array([np.inf, np.inf], dtype=np.float32),
+        np.array([np.nan, 1.0], dtype=np.float32),
+    ],
+)
+def test_non_finite_inputs_fall_back_to_uniform(p_in: np.ndarray):
+    # a sole selected item has +inf diversity contribution; the transform must
+    # degrade to uniform probabilities instead of emitting NaNs (solver crash)
+    # --- arrange -----------------------------------------
+    expected_p_out = np.ones_like(p_in)
+
+    # --- act ---------------------------------------------
+    p_out = np.empty_like(p_in)
+    exponential_selectivity(p_in, p_out, np.float32(0.5), reverse=True, low_value=np.float32(0.1))
+
+    # --- assert ------------------------------------------
+    assert np.array_equal(p_out, expected_p_out)

--- a/tests/_core/solver/_strategies/_optimization/test_optim_smart_swaps.py
+++ b/tests/_core/solver/_strategies/_optimization/test_optim_smart_swaps.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+from max_div._core.constraints import Constraint
+from max_div.metrics import DiversityMetric
+from max_div.problem import MaxDivProblem
+from max_div.solver import MaxDivSolverBuilder, SolverPreset, iterations
+
+
+def test_smart_preset_survives_tiny_problem_full_swap():
+    # Regression: on tiny problems, SMART's adaptive swap size can grow to k, so the
+    # removal loop ends up weighing a sole selected item whose contribution is +inf —
+    # which used to NaN the removal probabilities and crash the solver.
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(7)
+    vectors = rng.random((40, 3)).astype(np.float32)
+    constraints = [
+        Constraint(int_set=set(range(20)), min_count=2, max_count=3),
+        Constraint(int_set=set(range(20, 40)), min_count=2, max_count=4),
+    ]
+    problem = MaxDivProblem.new(
+        vectors=vectors, k=6, diversity_metric=DiversityMetric.MEAN_SEPARATION, constraints=constraints
+    )
+    solver = MaxDivSolverBuilder(problem).with_preset(iterations(800), SolverPreset.SMART).with_seed(0).build()
+
+    # --- act ---------------------------------------------
+    solution = solver.solve(verbosity=0)
+
+    # --- assert ------------------------------------------
+    assert len(solution.i_selected) == 6
+    assert solution.n_constraints_satisfied == 2


### PR DESCRIPTION
On small problems, SMART's adaptive swap size can reach k, so the removal loop ends up weighing a single remaining selected item — whose diversity contribution is +inf. exponential_selectivity computed p_range = inf - inf = NaN, slipped past the p_range == 0 guard, and emitted NaN probabilities that crashed choice() with "Sum of probabilities in p must be > 0.0".

Fix: the degenerate-range guard now also catches non-finite ranges and falls back to uniform probabilities (the sensible semantics: no information to discriminate candidates). The guard lives in a non-fastmath wrapper — fastmath flags let LLVM assume no NaN/inf and optimize isfinite checks away, which is exactly how the first version of this fix failed its own tests — while the hot transform loops keep fastmath unchanged. Golden-master determinism tests stay bit-exact; regression test reproduces the original crash (SMART, n=40, k=6, constrained, 800 iterations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)