### PR TITLE
chore: add harness test suite with a dedicated CI job

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,9 +80,10 @@ jobs:
     uses: ./.github/workflows/_unit_tests.yml
 
   # Comparison-benchmark harness tests: single leg (py3.13, numba on) with the
-  # `benchmarks` dependency group — deliberately outside the package test matrix.
-  # Network-dependent tests (MDPLIB fetch, code-FDM fetch) skip on fetch failure,
-  # so upstream availability can never block a merge.
+  # `benchmarks` dependency groups (incl. the GPL one: running GPL software in CI
+  # carries no obligations; only distributing it would) — deliberately outside the
+  # package test matrix. Network-dependent tests (MDPLIB fetch, code-FDM fetch)
+  # skip on fetch failure, so upstream availability can never block a merge.
   benchmarks-harness:
     needs: [preflight]
     runs-on: ubuntu-latest

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -84,7 +84,7 @@ jobs:
   # carries no obligations; only distributing it would) — deliberately outside the
   # package test matrix. Network-dependent tests (MDPLIB fetch, code-FDM fetch)
   # skip on fetch failure, so upstream availability can never block a merge.
-  benchmarks-harness:
+  test-benchmarks-harness:
     needs: [preflight]
     runs-on: ubuntu-latest
     steps:
@@ -137,7 +137,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, benchmarks-harness, package, pip-audit]
+    needs: [preflight, pre-commit, test, test-benchmarks-harness, package, pip-audit]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -79,6 +79,24 @@ jobs:
     needs: [preflight]
     uses: ./.github/workflows/_unit_tests.yml
 
+  # Comparison-benchmark harness tests: single leg (py3.13, numba on) with the
+  # `benchmarks` dependency group — deliberately outside the package test matrix.
+  # Network-dependent tests (MDPLIB fetch, code-FDM fetch) skip on fetch failure,
+  # so upstream availability can never block a merge.
+  benchmarks-harness:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
+        with:
+          version: ${{ vars.UV_VERSION }}
+      - name: Run harness tests
+        run: make test-benchmarks
+
   # Package-integrity gate: build once, verify the wheel statically, then
   # blind-install the artifact and test against it — catches packaging holes
   # (empty wheel, missing modules) that editable-install runs cannot see.
@@ -118,7 +136,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, package, pip-audit]
+    needs: [preflight, pre-commit, test, benchmarks-harness, package, pip-audit]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ test:
 	# run all tests - with numba & just 1 python version
 	uv run --all-extras --python 3.13 pytest ./tests --durations=20 --disable-warnings
 
+test-benchmarks:
+	# comparison-benchmark harness tests - separate from the package suite (needs the benchmarks deps group)
+	uv run --group benchmarks --python 3.13 pytest ./benchmarks/tests --durations=20 --disable-warnings
+
 coverage:
 	# NOTE: NUMBA_DISABLE_JIT ensure coverage collects detailed line-by-line coverage info, also for numba-compiled functions
     #       NUMBA_JIT_COVERAGE is another option, but would incorrectly emit coverage info for ALL compiled lines, when a function is triggered.

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,8 @@ test:
 	uv run --all-extras --python 3.13 pytest ./tests --durations=20 --disable-warnings
 
 test-benchmarks:
-	# comparison-benchmark harness tests - separate from the package suite (needs the benchmarks deps group)
-	uv run --group benchmarks --python 3.13 pytest ./benchmarks/tests --durations=20 --disable-warnings
+	# comparison-benchmark harness tests - separate from the package suite (needs the benchmarks deps groups)
+	uv run --group benchmarks --group benchmarks-gpl --python 3.13 pytest ./benchmarks/tests --durations=20 --disable-warnings
 
 coverage:
 	# NOTE: NUMBA_DISABLE_JIT ensure coverage collects detailed line-by-line coverage info, also for numba-compiled functions

--- a/benchmarks/tests/__init__.py
+++ b/benchmarks/tests/__init__.py
@@ -1,0 +1,6 @@
+"""Tests for the comparison-benchmark harness.
+
+Deliberately outside the package test suite (tests/): these need the `benchmarks`
+dependency group and run as their own CI job (single Python, numba on) via
+`make test-benchmarks`, never inside the package test matrix.
+"""

--- a/benchmarks/tests/conftest.py
+++ b/benchmarks/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared fixtures: small deterministic problems for harness tests."""
+
+import numpy as np
+import pytest
+
+from max_div._core.constraints import Constraint
+from max_div.metrics import DiversityMetric
+from max_div.problem import MaxDivProblem, VectorMaxDivProblem
+
+
+@pytest.fixture
+def small_problem() -> VectorMaxDivProblem:
+    """Unconstrained problem: 30 random 3-D vectors, select 5."""
+    rng = np.random.default_rng(42)
+    return MaxDivProblem.new(vectors=rng.random((30, 3)).astype(np.float32), k=5)
+
+
+@pytest.fixture
+def small_constrained_problem() -> VectorMaxDivProblem:
+    """Constrained problem: 30 vectors, two disjoint groups, select 6."""
+    rng = np.random.default_rng(43)
+    return MaxDivProblem.new(
+        vectors=rng.random((30, 3)).astype(np.float32),
+        k=6,
+        diversity_metric=DiversityMetric.MIN_SEPARATION,
+        constraints=[
+            Constraint(int_set=set(range(15)), min_count=2, max_count=3),
+            Constraint(int_set=set(range(15, 30)), min_count=2, max_count=4),
+        ],
+    )

--- a/benchmarks/tests/test_adapters.py
+++ b/benchmarks/tests/test_adapters.py
@@ -1,0 +1,97 @@
+import urllib.error
+
+import numpy as np
+import pytest
+
+from benchmarks.adapters import (
+    ApricotFacilityLocation,
+    CodeFdmFairFlow,
+    FpsampleFPS,
+    GreedyMaxSum,
+    KMedoidsFasterPAM,
+    QcSelectorMaxMin,
+    RandomBaseline,
+    RdkitMaxMin,
+    SkmatterFPS,
+)
+from benchmarks.adapters.code_fdm import _constraints_to_colors
+from max_div._core.constraints import Constraint
+from max_div.problem import MaxDivProblem
+
+UNCONSTRAINED_ADAPTERS = [
+    RandomBaseline(),
+    FpsampleFPS(),
+    SkmatterFPS(),
+    RdkitMaxMin(),
+    ApricotFacilityLocation(),
+    KMedoidsFasterPAM(),
+    GreedyMaxSum(),
+]
+
+
+@pytest.mark.parametrize("adapter", UNCONSTRAINED_ADAPTERS, ids=lambda a: a.name)
+def test_adapter_returns_valid_selection(small_problem, adapter):
+    # --- act ---------------------------------------------
+    indices, measured_sec = adapter.timed_select(small_problem, seed=0)
+
+    # --- assert ------------------------------------------
+    assert len(indices) == small_problem.k
+    assert len(np.unique(indices)) == small_problem.k
+    assert indices.min() >= 0
+    assert indices.max() < small_problem.n
+    assert measured_sec > 0.0
+
+
+@pytest.mark.parametrize("adapter", UNCONSTRAINED_ADAPTERS, ids=lambda a: a.name)
+def test_adapter_is_deterministic_given_seed(small_problem, adapter):
+    # --- act ---------------------------------------------
+    first = adapter.select(small_problem, seed=3)
+    second = adapter.select(small_problem, seed=3)
+
+    # --- assert ------------------------------------------
+    assert np.array_equal(first, second)
+
+
+def test_qc_selector_adapter(small_problem):
+    # GPL opt-in dependency group; exercised only where it happens to be installed
+    # --- arrange -----------------------------------------
+    pytest.importorskip("selector")
+
+    # --- act ---------------------------------------------
+    indices, _ = QcSelectorMaxMin().timed_select(small_problem, seed=0)
+
+    # --- assert ------------------------------------------
+    assert len(np.unique(indices)) == small_problem.k
+
+
+def test_code_fdm_adapter_satisfies_constraints(small_constrained_problem):
+    # fetched research code: robustness over blocking — network trouble skips, never fails
+    # --- act ---------------------------------------------
+    try:
+        indices, _ = CodeFdmFairFlow().timed_select(small_constrained_problem, seed=0)
+    except (urllib.error.URLError, OSError) as e:  # pragma: no cover -- network-dependent
+        pytest.skip(f"code-FDM fetch failed: {e}")
+
+    # --- assert ------------------------------------------
+    from benchmarks.common import n_constraints_satisfied
+
+    assert len(np.unique(indices)) == small_constrained_problem.k
+    assert n_constraints_satisfied(small_constrained_problem, indices) == small_constrained_problem.m
+
+
+def test_code_fdm_rejects_overlapping_constraints():
+    # pure mapping logic, no fetch involved
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(0)
+    problem = MaxDivProblem.new(
+        vectors=rng.random((20, 2)).astype(np.float32),
+        k=4,
+        constraints=[
+            Constraint(int_set={0, 1, 2, 3}, min_count=1, max_count=2),
+            Constraint(int_set={3, 4, 5, 6}, min_count=1, max_count=2),  # overlaps on 3
+        ],
+    )
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="overlap"):
+        _constraints_to_colors(problem)

--- a/benchmarks/tests/test_exact.py
+++ b/benchmarks/tests/test_exact.py
@@ -1,0 +1,74 @@
+from itertools import combinations
+
+import numpy as np
+import pytest
+from scipy.spatial.distance import squareform
+
+from benchmarks.common import evaluate_selection
+from benchmarks.exact import solve_maxmin_cpsat, solve_nn_separation_scip
+from max_div._core.constraints import Constraint
+from max_div.metrics import DiversityMetric
+from max_div.problem import MaxDivProblem
+
+
+def _tiny_problem(metric: DiversityMetric) -> MaxDivProblem:
+    """15 vectors, select 4, one group constraint — small enough to brute-force."""
+    rng = np.random.default_rng(11)
+    return MaxDivProblem.new(
+        vectors=rng.random((15, 2)).astype(np.float32),
+        k=4,
+        diversity_metric=metric,
+        constraints=[Constraint(int_set=set(range(8)), min_count=1, max_count=2)],
+    )
+
+
+def _brute_force_optimum(problem: MaxDivProblem, metric_name: str) -> float:
+    """Enumerate all feasible selections and return the true optimum (the test oracle)."""
+    best = -np.inf
+    dist = squareform(problem.condensed_distances().astype(np.float64))
+    group = problem.constraints[0].int_set
+    for selection in combinations(range(problem.n), problem.k):
+        if not 1 <= len(group.intersection(selection)) <= 2:
+            continue
+        value = evaluate_selection(problem, np.asarray(selection, dtype=np.int64))[metric_name]
+        best = max(best, value)
+    assert dist.shape[0] == problem.n  # oracle sanity: distances cover the ground set
+    return best
+
+
+def test_cpsat_maxmin_matches_brute_force():
+    # --- arrange -----------------------------------------
+    problem = _tiny_problem(DiversityMetric.MIN_SEPARATION)
+    oracle = _brute_force_optimum(problem, "MIN_SEPARATION")
+
+    # --- act ---------------------------------------------
+    result = solve_maxmin_cpsat(problem, time_limit_sec=30)
+    achieved = evaluate_selection(problem, result.i_selected)["MIN_SEPARATION"]
+
+    # --- assert ------------------------------------------
+    assert result.proven_optimal
+    assert achieved == pytest.approx(oracle, rel=1e-6)
+
+
+@pytest.mark.parametrize("metric", [DiversityMetric.MEAN_SEPARATION, DiversityMetric.GEOMEAN_SEPARATION])
+def test_scip_nn_separation_matches_brute_force(metric):
+    # --- arrange -----------------------------------------
+    problem = _tiny_problem(metric)
+    oracle = _brute_force_optimum(problem, metric.name)
+
+    # --- act ---------------------------------------------
+    result = solve_nn_separation_scip(problem, metric, time_limit_sec=60)
+    achieved = evaluate_selection(problem, result.i_selected)[metric.name]
+
+    # --- assert ------------------------------------------
+    assert result.proven_optimal
+    assert achieved == pytest.approx(oracle, rel=1e-5)
+
+
+def test_scip_rejects_unsupported_metric():
+    # --- arrange -----------------------------------------
+    problem = _tiny_problem(DiversityMetric.MIN_SEPARATION)
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="Unsupported metric"):
+        solve_nn_separation_scip(problem, DiversityMetric.MIN_SEPARATION)

--- a/benchmarks/tests/test_ladders.py
+++ b/benchmarks/tests/test_ladders.py
@@ -1,0 +1,39 @@
+from itertools import pairwise
+
+import pytest
+
+from benchmarks.common import iteration_ladder, time_ladder
+
+
+def test_time_ladder_covers_ceiling():
+    # --- act ---------------------------------------------
+    rungs = time_ladder(0.001, 1.0, factor=2.0)
+
+    # --- assert ------------------------------------------
+    assert rungs[0] == 0.001
+    assert rungs[-1] >= 1.0
+    assert all(b == pytest.approx(2 * a) for a, b in pairwise(rungs))
+
+
+def test_iteration_ladder_strictly_increases():
+    # --- act ---------------------------------------------
+    rungs = iteration_ladder(1, 1000, factor=1.3)
+
+    # --- assert ------------------------------------------
+    assert rungs[0] == 1
+    assert rungs[-1] >= 1000
+    assert all(b > a for a, b in pairwise(rungs))
+
+
+@pytest.mark.parametrize("kwargs", [{"t_min_sec": 0.0}, {"t_max_sec": 0.0001}, {"factor": 1.0}])
+def test_time_ladder_rejects_bad_arguments(kwargs):
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="Ladder requires"):
+        time_ladder(**{"t_min_sec": 0.001, "t_max_sec": 1.0, "factor": 2.0, **kwargs})
+
+
+@pytest.mark.parametrize("kwargs", [{"i_min": 0}, {"i_max": 5}, {"factor": 0.9}])
+def test_iteration_ladder_rejects_bad_arguments(kwargs):
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="Ladder requires"):
+        iteration_ladder(**{"i_min": 10, "i_max": 1000, "factor": 2.0, **kwargs})

--- a/benchmarks/tests/test_mdplib.py
+++ b/benchmarks/tests/test_mdplib.py
@@ -1,0 +1,51 @@
+import urllib.error
+
+import numpy as np
+import pytest
+
+from benchmarks.mdplib import list_instances, load_instance
+from max_div.problem import DistanceMaxDivProblem, VectorMaxDivProblem
+
+
+@pytest.fixture(scope="module")
+def mdplib_available() -> None:
+    """Skip the module when the MDPLIB archive cannot be fetched (network robustness)."""
+    try:
+        list_instances("Glover")
+    except (urllib.error.URLError, OSError) as e:  # pragma: no cover -- network-dependent
+        pytest.skip(f"MDPLIB archive not fetchable: {e}")
+
+
+def test_families_have_expected_instance_counts(mdplib_available):
+    # --- act / assert ------------------------------------
+    assert len(list_instances("Glover")) == 15
+    assert len(list_instances("Geo")) == 60
+    assert len(list_instances("Ran")) == 60
+
+
+def test_coordinate_instance_loads_as_vector_problem(mdplib_available):
+    # --- act ---------------------------------------------
+    problem = load_instance("Geo", "Geo 100 1.txt", k=10)
+
+    # --- assert ------------------------------------------
+    assert isinstance(problem, VectorMaxDivProblem)
+    assert problem.n == 100
+    assert problem.k == 10
+
+
+def test_edge_list_instance_loads_as_distance_problem(mdplib_available):
+    # --- act ---------------------------------------------
+    problem = load_instance("Ran", "Ran 100 1.txt", k=10)
+
+    # --- assert ------------------------------------------
+    assert isinstance(problem, DistanceMaxDivProblem)
+    assert problem.n == 100
+    condensed = problem.condensed_distances()
+    assert condensed.shape == (100 * 99 // 2,)
+    assert np.all(condensed > 0)
+
+
+def test_unknown_family_is_rejected():
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="Unknown MMDP family"):
+        list_instances("Nope")

--- a/benchmarks/tests/test_quality.py
+++ b/benchmarks/tests/test_quality.py
@@ -1,0 +1,52 @@
+import numpy as np
+import pytest
+from scipy.spatial.distance import squareform
+
+from benchmarks.common import evaluate_selection, n_constraints_satisfied
+
+
+def test_evaluate_selection_matches_squareform_oracle(small_problem):
+    # every published quality number flows through evaluate_selection, so its
+    # condensed-index extraction is verified against scipy's squareform
+    # --- arrange -----------------------------------------
+    i_selected = np.array([0, 7, 13, 21, 29], dtype=np.int64)
+    dist = squareform(small_problem.condensed_distances().astype(np.float64))
+    sub = dist[np.ix_(i_selected, i_selected)]
+    k = len(i_selected)
+    separations = np.where(~np.eye(k, dtype=bool), sub, np.inf).min(axis=1)
+    mean_dists = sub.sum(axis=1) / (k - 1)
+
+    # --- act ---------------------------------------------
+    quality = evaluate_selection(small_problem, i_selected)
+
+    # --- assert ------------------------------------------
+    assert quality["MIN_SEPARATION"] == pytest.approx(separations.min(), rel=1e-6)
+    assert quality["MEAN_SEPARATION"] == pytest.approx(separations.mean(), rel=1e-6)
+    assert quality["GEOMEAN_SEPARATION"] == pytest.approx(np.exp(np.log(separations).mean()), rel=1e-5)
+    assert quality["MEAN_PAIRWISE_DISTANCE"] == pytest.approx(mean_dists.mean(), rel=1e-6)
+
+
+@pytest.mark.parametrize(
+    "i_selected, expected_error",
+    [
+        (np.array([3]), "at least 2 items"),
+        (np.array([3, 3, 5]), "duplicate"),
+    ],
+)
+def test_evaluate_selection_rejects_invalid_selections(small_problem, i_selected, expected_error):
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match=expected_error):
+        evaluate_selection(small_problem, i_selected)
+
+
+def test_n_constraints_satisfied(small_constrained_problem):
+    # groups are {0..14} needing 2-3 picks and {15..29} needing 2-4 picks
+    # --- arrange -----------------------------------------
+    both_ok = np.array([0, 1, 2, 15, 16, 17], dtype=np.int64)
+    first_violated = np.array([0, 1, 2, 3, 15, 16], dtype=np.int64)  # 4 > max_count=3
+    both_violated = np.array([0, 1, 2, 3, 4, 15], dtype=np.int64)  # 5 > 3 and 1 < 2
+
+    # --- act / assert ------------------------------------
+    assert n_constraints_satisfied(small_constrained_problem, both_ok) == 2
+    assert n_constraints_satisfied(small_constrained_problem, first_violated) == 1
+    assert n_constraints_satisfied(small_constrained_problem, both_violated) == 0

--- a/benchmarks/tests/test_records.py
+++ b/benchmarks/tests/test_records.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from benchmarks.common import RunRecord, load_records, save_records
+
+
+def test_records_round_trip(tmp_path: Path):
+    # --- arrange -----------------------------------------
+    records = [
+        RunRecord(
+            tool="max-div[SMART]",
+            problem="U1",
+            size=2,
+            n=200,
+            k=20,
+            diversity_metric="GEOMEAN_SEPARATION",
+            seed=1,
+            budget="time:0.004s",
+            measured_sec=0.0051,
+            n_iterations=123,
+            quality={"MIN_SEPARATION": 0.5, "GEOMEAN_SEPARATION": 0.9},
+            n_constraints=2,
+            n_constraints_satisfied=2,
+        ),
+        RunRecord(
+            tool="fpsample[FPS]",
+            problem="U1",
+            size=2,
+            n=200,
+            k=20,
+            diversity_metric="GEOMEAN_SEPARATION",
+            seed=1,
+            budget="single-shot",
+            measured_sec=0.0002,
+            n_iterations=None,
+            quality={"MIN_SEPARATION": 0.4},
+            proven_optimal=None,
+        ),
+    ]
+
+    # --- act ---------------------------------------------
+    path = tmp_path / "sub" / "records.jsonl"
+    save_records(records, path)
+    loaded = load_records(path)
+
+    # --- assert ------------------------------------------
+    assert loaded == records

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ convention = "google"
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["SLF001", "S101", "S311", "D", "ANN"]  # AAA tests: asserts, private access, random data, no docstring/annotation duty
+"benchmarks/tests/**" = ["SLF001", "S101", "S311", "D", "ANN"]  # harness tests: same carve-outs as the package suite
 "tests/_core/_markdown/test_table.py" = ["E501"]  # expected-output literals: exact rendered table rows
 "__init__.py" = ["F401"]                 # re-export modules: naked imports, no `as` alias
 "scripts/**" = ["INP001", "S", "D", "ANN"]           # maintainer tooling, not the shipped library


### PR DESCRIPTION
Adds tests for the comparison-benchmark harness in `benchmarks/tests/` — deliberately outside the package suite so the test matrix never needs the `benchmarks` dependency group. One dedicated CI job (py3.13, numba on) runs `make test-benchmarks` and joins the CI gate.

Coverage: budget ladders, run-record round-trip, quality evaluation verified against a scipy squareform oracle, adapter contracts (validity + seed-determinism for all seven default adapters), both exact solvers verified against a brute-force enumeration oracle on a 15-point constrained problem, and the MDPLIB loader (family counts, both input flavors). Robustness: the GPL qc-selector test importorskips when absent; MDPLIB/code-FDM fetch failures skip rather than fail, so upstream availability can never block a merge. Local run: 37 passed, 1 skipped, ~4s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)