### PR TITLE
fix: remove defunct polyfill.io script and repair the docs splash image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `SolverPreset.SMART` no longer crashes on very small problems where an adaptive swap can remove all but one selected item
+- Documentation site: removed the defunct polyfill.io script (which triggered login popups) and fixed the broken splash image on Read the Docs and PyPI
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230)](https://github.com/astral-sh/ruff)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/bertpl/max-div/badge)](https://scorecard.dev/viewer/?uri=github.com/bertpl/max-div)
 <p>
-  <img src="images/splash_with_version.webp" alt="max-div logo" style="max-width: max(60%, min(100%,800px)); height: auto;">
+  <img src="https://raw.githubusercontent.com/bertpl/max-div/v0.8.0/images/splash_with_version.webp" alt="max-div logo" style="max-width: max(60%, min(100%,800px)); height: auto;">
 </p>
 
 # max-div

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: MAX-DIV - Maximum Diversity Solver.
-site_url: https://yourusername.github.io/your-repo-name/
+site_url: https://max-div.readthedocs.io/
 repo_url: https://github.com/bertpl/max-div
 repo_name: bertpl/max-div
 site_dir: ./reports/docs
@@ -9,7 +9,6 @@ extra_css:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 theme:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -305,6 +305,21 @@ def refresh_readme_badges() -> None:
     README.write_text(text)
 
 
+def stamp_readme_splash_url(version: str) -> None:
+    """Pin the README splash image URL to the release tag.
+
+    The README references the splash via a raw.githubusercontent.com URL pinned to a tag,
+    so GitHub, PyPI, and Read the Docs all render the splash belonging to their version.
+    """
+    text = README.read_text()
+    text = re.sub(
+        r"raw\.githubusercontent\.com/bertpl/max-div/v[\d.]+/images/splash_with_version\.webp",
+        f"raw.githubusercontent.com/bertpl/max-div/v{version}/images/splash_with_version.webp",
+        text,
+    )
+    README.write_text(text)
+
+
 def stamp_splash(version: str) -> None:
     """Stamp the release version onto the committed splash webp (needs ImageMagick).
 
@@ -321,6 +336,7 @@ def step_11_commit_release(version: str) -> None:
     """Refresh README badges, stamp the splash, then create the release commit."""
     print_step(11, f"refresh README badges + stamp splash + commit 'release: {version}'")
     refresh_readme_badges()
+    stamp_readme_splash_url(version)
     stamp_splash(version)
     run_command(["git", "add", "pyproject.toml", "uv.lock", "CHANGELOG.md", "README.md", str(SPLASH_WEBP)])
     run_command(["git", "commit", "-m", f"release: {version}"])


### PR DESCRIPTION
The docs site loaded polyfill.io, which was retired after a 2024 supply-chain incident and now triggers login popups on every page; MathJax no longer needs it, so the script is removed. The README splash image was referenced by a repo-relative path that only resolves on GitHub — it now uses a release-tag-pinned raw URL, stamped by the release script alongside the badges, so GitHub, PyPI, and Read the Docs each render the splash matching their version. Also sets the real `site_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)