### PR TITLE
chore: make the docs target runnable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,9 +83,8 @@ splash:
 	./images/splash/create_splash_with_version.sh "$$(uv version --short)-dev";
 
 docs:
-	mkdir -p ./reports
-	uv sync --extra docs;
-	mkdocs build;
+	# output dir comes from mkdocs.yml (site_dir: ./reports/docs)
+	uv run --extra docs mkdocs build;
 
 show-coverage:
 	# trigger browser to open coverage report


### PR DESCRIPTION
**Problem**: `make docs` failed with `mkdocs: command not found`. The target invoked a bare `mkdocs`, which is only on `PATH` inside an activated virtualenv — so it broke for anyone driving the project through `uv`, the way every other target in the Makefile already does.

**Solution**: Routes the build through `uv run --extra docs`. That also makes the preceding `uv sync --extra docs` redundant, since `uv run` resolves the extra itself, and the `mkdir` was never needed — the output directory comes from the mkdocs config, which creates it.

- **Attention:** The output location is unchanged. It was already set by `site_dir` in the mkdocs config rather than by the Makefile, which is why only the invocation needed fixing.
- **TEST:** Removed the existing output directory, ran `make docs`, confirmed the site rebuilt in the configured location and that no stray default output directory was created.

**Changelog**: None — local developer tooling, no effect on the published package or the built site.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
