### PR TITLE
chore: stagger the dependabot schedules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,20 @@ updates:
       - "/"
       - "/.github/actions/unit_test"
       - "/.github/actions/pre_commit"
+    # Deliberately a different day from the uv entry below: both ecosystems used to
+    # fire in the same minute, and since patch/minor bumps auto-merge, whichever
+    # landed first left its sibling behind main — unmergeable under the
+    # up-to-date-branch rule until someone updated the branch by hand.
+    # Local overnight time (Dependabot applies the timezone incl. DST), so a PR
+    # opens and merges while nothing else is being pushed to main. Treat it as a
+    # preference, not a guarantee: observed firing times have varied by hours and
+    # have landed off the nominal day, so the day separation above is what the
+    # collision fix actually rests on.
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "01:00"
+      timezone: "Europe/Zurich"
     # `chore` prefix makes the PR title (and thus the squash commit on main)
     # follow the repo's `<type>: <summary>` convention, so the preflight
     # title check needs no Dependabot exemption.
@@ -27,8 +39,12 @@ updates:
     # Refreshes uv.lock for the runtime + dev/lint/type tooling the lockfile
     # deliberately pins — those rot without automated updates.
     directory: "/"
+    # Tuesday: see the day/time rationale on the github-actions entry above.
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "01:00"
+      timezone: "Europe/Zurich"
     commit-message:
       prefix: "chore"
     # Never touch pyproject.toml requirement ranges: the per-Python floors are


### PR DESCRIPTION
**Problem**: Both ecosystem entries ran on the same weekly window — in practice within about a minute of each other. Since patch/minor bumps are approved and auto-merged, whichever landed first advanced `main` and left its sibling behind it. The up-to-date-branch protection rule then blocks that sibling, and nothing unblocks it: Dependabot's auto-rebase only triggers on merge *conflicts*, not on a branch merely being behind.

**Solution**: Puts the two ecosystems on different weekdays, so the first bump has long since merged before the second is even created — the second then branches from the already-advanced tip. Each also gets an explicit overnight local time, expressed with a timezone so daylight-saving is handled rather than hardcoded into a UTC offset.

- **Attention:** This removes the systematic weekly collision, not every case. A major bump deliberately waits for a human review, and while it waits it can still be left behind by anything else that lands. Only a merge queue or an explicit branch-update step covers that.
- **Attention:** Dependabot treats the scheduled time as approximate. This repository's own history shows PRs opening several hours after the default window, so the overnight time reduces the chance of a bump landing mid-session but does not guarantee it. The day separation is the part doing the real work.
- **TEST:** Config schema validated by the pre-commit Dependabot-config and YAML hooks.

**Changelog**: None — repository automation only, no effect on the published package.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
