### PR TITLE
docs: say items rather than vectors where the docs mean selectable entities

### DIFF
--- a/docs/concepts/constraints.md
+++ b/docs/concepts/constraints.md
@@ -2,18 +2,18 @@
 
 ## What Are Constraints?
 
-Constraints enforce that the selected subset includes a minimum and/or maximum number of vectors
-from specific groups. Each constraint is defined by:
+Constraints enforce that the selected subset includes a minimum and/or maximum number of
+[items](glossary.md#item) from specific groups. Each constraint is defined by:
 
-- **`int_set`** -- a set of vector indices that form the group
-- **`min_count`** -- minimum number of vectors to select from this group
-- **`max_count`** -- maximum number of vectors to select from this group
+- **`int_set`** -- a set of item indices that form the group
+- **`min_count`** -- minimum number of items to select from this group
+- **`max_count`** -- maximum number of items to select from this group
 - **`weight`** -- how strongly this constraint counts toward feasibility (default `1`, must be `> 0`)
 
 ```python
 from max_div import Constraint
 
-# At least 3 and at most 7 vectors from indices 0-49
+# At least 3 and at most 7 items from indices 0-49
 Constraint(int_set=set(range(50)), min_count=3, max_count=7)
 ```
 
@@ -56,7 +56,8 @@ This is a single global setting for the whole solve, independent of any per-cons
 
 ## Overlapping Constraints
 
-A single vector can belong to multiple constraint groups. This is useful for modeling
+A single item can belong to multiple [constraint groups](glossary.md#overlapping-constraints).
+This is useful for modeling
 multi-dimensional fairness requirements.
 
 For example, you might have demographic groups and geographic groups:
@@ -72,7 +73,7 @@ constraints = [
 ]
 ```
 
-A vector can be in both `group_a_indices` and `region_north`, and both constraints will
+An item can be in both `group_a_indices` and `region_north`, and both constraints will
 be tracked independently.
 
 ## Infeasible Constraints
@@ -94,8 +95,8 @@ numba-compiled solver code. For each constraint, the solver tracks how many *add
 selections are needed (`min_remaining`) and how many more are *allowed* (`max_remaining`):
 
 - A constraint is **satisfied** when `min_remaining <= 0` and `max_remaining >= 0`
-- Adding a vector from a constraint group decreases both counters by 1
-- Removing a vector increases both counters by 1
+- Adding an item from a constraint group decreases both counters by 1
+- Removing an item increases both counters by 1
 
 This incremental tracking avoids recomputing constraint satisfaction from scratch after each
 swap, keeping the per-iteration cost constant regardless of constraint complexity.

--- a/docs/concepts/diversity.md
+++ b/docs/concepts/diversity.md
@@ -1,27 +1,27 @@
 # Diversity & Distance
 
-## From Vectors to Diversity
+## From Items to Diversity
 
 The solver evaluates how diverse a selection is through a three-step process:
 
 ```
-Vectors  ──>  Pairwise Distances  ──>  Contributions  ──>  Diversity Score
- (n x d)        (n*(n-1)/2)               (k x 1)                (scalar)
+Items  ──>  Pairwise Distances  ──>  Contributions  ──>  Diversity Score
+  (n)         (n*(n-1)/2)               (k x 1)              (scalar)
 ```
 
-1. **Pairwise distances** are computed once upfront between all `n` vectors using the chosen
+1. **Pairwise distances** are computed once upfront between all `n` [items](glossary.md#item) using the chosen
    distance metric. These are stored as a condensed distance vector (like scipy's `pdist`).
 
-2. A **diversity contribution** is computed for each selected vector -- a per-vector quantity where
+2. A **diversity contribution** is computed for each selected item -- a per-item quantity where
    higher means "contributes more diversity". Which quantity that is depends on the diversity metric's
    family:
 
-    - **Separation family** (all `*_SEPARATION` metrics): the distance to the vector's
-      *nearest neighbor* within the current selection. A vector with high separation is
-      well-spread from the rest of the selection; a vector with low separation is close to at
-      least one other selected vector.
-    - **Mean-distance family** (`MEAN_PAIRWISE_DISTANCE`): the vector's *mean distance to the
-      other selected vectors* -- exactly how much the vector contributes to the total spread
+    - **Separation family** (all `*_SEPARATION` metrics): the distance to the item's
+      *nearest neighbor* within the current selection. An item with high separation is
+      well-spread from the rest of the selection; an item with low separation is close to at
+      least one other selected item.
+    - **Mean-distance family** (`MEAN_PAIRWISE_DISTANCE`): the item's *mean distance to the
+      other selected items* -- exactly how much the item contributes to the total spread
       of the selection.
 
 3. The **diversity score** aggregates the `k` contribution values into a single scalar using the
@@ -40,7 +40,8 @@ The distance metric determines how the distance between two vectors is measured.
 
 ## Separation
 
-The **separation** of a selected vector is its minimum distance to any other selected vector:
+The **[separation](glossary.md#separation)** of a selected item is its minimum distance to any
+other selected item:
 
 $$\text{sep}(v) = \min_{u \in S,\; u \neq v} \; d(v, u)$$
 
@@ -48,22 +49,22 @@ where $S$ is the current selection and $d$ is the chosen distance metric.
 
 Separation is maintained incrementally during optimization:
 
-- **Adding** a vector only requires checking its distances to all other vectors and
+- **Adding** an item only requires checking its distances to all other items and
   updating any separations that decrease.
-- **Removing** a vector requires recomputing separation only for vectors whose nearest
-  neighbor was the removed vector.
+- **Removing** an item requires recomputing separation only for items whose nearest
+  neighbor was the removed one.
 
 This incremental update is much cheaper than recomputing all separations from scratch after
 each swap.
 
 ## Mean Distance
 
-The **mean distance** of a selected vector is its mean distance to the other selected vectors:
+The **mean distance** of a selected item is its mean distance to the other selected items:
 
 $$\text{md}(v) = \frac{1}{k - 1} \sum_{u \in S,\; u \neq v} d(v, u)$$
 
-It is maintained incrementally as well, and even more cheaply than separation: adding a vector
-adds one distance to every vector's running sum, and removing one subtracts it exactly -- no
+It is maintained incrementally as well, and even more cheaply than separation: adding an item
+adds one distance to every item's running sum, and removing one subtracts it exactly -- no
 rescan of the selection is ever needed.
 
 ## Diversity Metrics
@@ -74,8 +75,8 @@ see [Objectives & the Diversity-Problem Landscape](objectives.md).)
 
 | Metric | Formula | Characteristics |
 |--------|---------|-----------------|
-| `GEOMEAN_SEPARATION` | $$\exp\!\left(\frac{1}{k}\sum_{v \in S} \ln(\text{sep}(v))\right)$$ | **Default.** Balances all separations. Sensitive to any vector with low separation -- a single poorly-placed vector drags down the score. |
-| `MIN_SEPARATION` | $$\min_{v \in S} \text{sep}(v)$$ | Only considers the worst-off vector (the closest pair). Equivalent to the *p-dispersion* problem. Many swaps produce tied scores. |
+| `GEOMEAN_SEPARATION` | $$\exp\!\left(\frac{1}{k}\sum_{v \in S} \ln(\text{sep}(v))\right)$$ | **Default.** Balances all separations. Sensitive to any item with low separation -- a single poorly-placed item drags down the score. |
+| `MIN_SEPARATION` | $$\min_{v \in S} \text{sep}(v)$$ | Only considers the worst-off item (the closest pair). Equivalent to the *p-dispersion* problem. Many swaps produce tied scores. |
 | `MEAN_SEPARATION` | $$\frac{1}{k}\sum_{v \in S} \text{sep}(v)$$ | Averages all separations. Less sensitive to individual outliers than geomean, but can be dominated by a few very high separations. |
 | `APPROX_GEOMEAN_SEPARATION` | Same as geomean but using fast log/exp approximations | Slightly less accurate but faster per iteration. Useful for large-scale problems where iteration speed matters more than per-iteration precision. |
 | `MEAN_PAIRWISE_DISTANCE` | $$\frac{2}{k(k-1)}\sum_{\{u,v\} \subseteq S} d(u, v)$$ | Mean distance over all selected *pairs* -- the classical **max-sum diversity** objective (MaxSum MDP, also known as *remote-clique*). Maximizes total spread: selections gravitate to the outer regions of the data, and near-duplicates are tolerated if both sit far from everything else. |
@@ -88,14 +89,14 @@ see [Objectives & the Diversity-Problem Landscape](objectives.md).)
   neighbor distance (e.g., facility placement where minimum coverage radius matters).
   Expect slower convergence due to many tied scores.
 - **`MEAN_SEPARATION`** maximizes total spread. It may tolerate some clustering as long as
-  other vectors compensate with large separations.
+  other items compensate with large separations.
 - **`APPROX_GEOMEAN_SEPARATION`** is a drop-in replacement for `GEOMEAN_SEPARATION` when
   you want to trade a small amount of precision for more iterations per second.
 - **`MEAN_PAIRWISE_DISTANCE`** is the objective to pick when you want classical max-sum
   diversity semantics ("maximize total spread") or want results comparable with the MaxSum
   MDP literature. Unlike every separation metric it does *not* penalize near-duplicates per
-  se -- two nearly identical vectors at the data's boundary can both be kept. Note that the
+  se -- two nearly identical items at the data's boundary can both be kept. Note that the
   solver's swap heuristics were originally designed and tuned around separation contributions; they
-  are correct for this metric (its per-vector contribution is the vector's exact marginal
+  are correct for this metric (its per-item contribution is the item's exact marginal
   contribution to the objective), but the separation metrics remain the most battle-tested
   choice.

--- a/docs/concepts/scoring.md
+++ b/docs/concepts/scoring.md
@@ -7,7 +7,7 @@ Every selection (intermediate or final) is evaluated by a `Score` with four comp
 
 | Component | Range | Meaning |
 |-----------|-------|---------|
-| `size` | 0 to 1 | 1.0 when exactly `k` vectors are selected. Used internally during initialization; always 1.0 in a final solution. |
+| `size` | 0 to 1 | 1.0 when exactly `k` [items](glossary.md#item) are selected. Used internally during initialization; always 1.0 in a final solution. |
 | `constraints` | 0 to 1 | 1.0 when all fairness constraints are satisfied. Lower values indicate more constraint violations. |
 | `diversity` | 0+ | The main diversity metric value (higher is better). |
 | `div_tie_breakers` | 0+ | Secondary diversity metrics, used to break ties. |
@@ -35,8 +35,8 @@ The solver automatically selects appropriate tie-breakers based on your chosen d
 
 | Primary Metric | Default Tie-Breakers | Why |
 |---------------|---------------------|-----|
-| `MIN_SEPARATION` | `APPROX_GEOMEAN_SEPARATION`, `NON_ZERO_SEPARATION_FRAC` | Min-separation only depends on the closest pair. Swapping any other vector doesn't change the score, causing many ties. The geomean tie-breaker guides the solver towards improving the overall spread. |
-| `GEOMEAN_SEPARATION` | `NON_ZERO_SEPARATION_FRAC` | Geomean is zero if any separation is zero. When multiple separations are zero, single swaps can't improve the score. The non-zero fraction tie-breaker guides the solver towards eliminating zero-distance vectors. |
+| `MIN_SEPARATION` | `APPROX_GEOMEAN_SEPARATION`, `NON_ZERO_SEPARATION_FRAC` | Min-separation only depends on the closest pair. Swapping any other item doesn't change the score, causing many ties. The geomean tie-breaker guides the solver towards improving the overall spread. |
+| `GEOMEAN_SEPARATION` | `NON_ZERO_SEPARATION_FRAC` | Geomean is zero if any separation is zero. When multiple separations are zero, single swaps can't improve the score. The non-zero fraction tie-breaker guides the solver towards eliminating zero-distance items. |
 | `MEAN_SEPARATION` | *(none)* | Mean separation rarely produces ties. |
 
 You can override the defaults via `MaxDivSolverBuilder.with_diversity_tie_breakers()`.

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -4,7 +4,8 @@
 
 When you call `solver.solve()`, the solver executes a pipeline of **steps**:
 
-1. **Initialization step** -- builds the initial selection of `k` vectors
+1. **Initialization step** -- builds the initial [selection](glossary.md#selection) of `k`
+   [items](glossary.md#item)
 2. **One or more optimization steps** -- iteratively improves the selection
 
 Each step runs for a configured duration (wall-clock time or iteration count) and operates
@@ -20,26 +21,26 @@ satisfaction.
 
 ## Initialization Strategies
 
-The initialization step selects the initial `k` vectors. Different strategies trade off
+The initialization step selects the initial `k` items. Different strategies trade off
 speed vs quality of the starting point:
 
 | Strategy | How it works |
 |----------|-------------|
-| `random_one_shot` | Selects all `k` vectors in one batch, with probabilities biased by global separation. **Default for all presets.** |
+| `random_one_shot` | Selects all `k` items in one batch, with probabilities biased by global separation. **Default for all presets.** |
 | `random_batched` | Selects in batches of `b`, re-evaluating separations between batches. |
 | `eager` | Evaluates `nc` random candidates per step, picks the best. Slower but higher quality. |
-| `fast` | Deterministic greedy: always picks the vector maximizing separation. Fast but seed-independent. |
+| `fast` | Deterministic greedy: always picks the item maximizing separation. Fast but seed-independent. |
 
 ## Optimization Strategies
 
-Optimization steps iteratively improve the selection through **swap operations**: in each
-iteration, the strategy removes one or more vectors from the current selection and replaces
+Optimization steps iteratively improve the selection through [**swap operations**](glossary.md#swap): in each
+iteration, the strategy removes one or more items from the current selection and replaces
 them with new ones. The swap is kept only if it improves the score.
 
 | Strategy | How it works |
 |----------|-------------|
-| `random_swaps` | Randomly selects vectors to remove and add. Simple baseline. |
-| `guided_swaps` | Biased towards removing low-separation vectors and adding high-separation ones. |
+| `random_swaps` | Randomly selects items to remove and add. Simple baseline. |
+| `guided_swaps` | Biased towards removing low-separation items and adding high-separation ones. |
 | `smart_swaps` | Adaptively learns which swap sizes and candidate selection strategies work best during the run. |
 
 ## Presets vs Custom Configuration

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -22,8 +22,8 @@ itself is single-threaded.
 
 ### 1. Define a problem
 
-A Maximum Diversity Problem consists of a set of `n` vectors in `d` dimensions, from which you want
-to select `k` that are as diverse as possible.
+A Maximum Diversity Problem consists of a set of `n` [items](concepts/glossary.md#item) -- here,
+vectors in `d` dimensions -- from which you want to select `k` that are as diverse as possible.
 
 ```python
 import numpy as np
@@ -59,7 +59,7 @@ The solver will print progress as it runs. Pass `verbosity=0` for silent operati
 print(solution)
 # MaxDivSolution: 20 vectors selected | diversity=0.7792 | 5.17s (39_008 iterations)
 
-# Indices of the selected vectors
+# Indices of the selected items
 print(solution.i_selected)       # e.g. array([ 3,  7, 14, ...], dtype=int32)
 
 # The selected vectors themselves
@@ -77,7 +77,7 @@ The `score` has three main components, shown in strict priority order.
 In a final solution, `size` is always 1.0. For an unconstrained problem, `constraints` is also
 always 1.0:
 
-- **`size`** -- 1.0 when exactly `k` vectors are selected
+- **`size`** -- 1.0 when exactly `k` items are selected
 - **`constraints`** -- 1.0 when all fairness constraints are satisfied
 - **`diversity`** -- the main diversity score (higher is better)
 
@@ -87,13 +87,13 @@ preferred over solutions with higher diversity.
 
 ## Adding Fairness Constraints
 
-Constraints let you enforce that a minimum and/or maximum number of selected vectors come from
+Constraints let you enforce that a minimum and/or maximum number of selected items come from
 specific subsets. This is useful for ensuring fair representation across groups.
 
 ```python
 from max_div import Constraint
 
-# Vectors 0-99 are "group A", vectors 100-199 are "group B"
+# Items 0-99 are "group A", items 100-199 are "group B"
 # Require at least 8 and at most 12 from each group
 constraints = [
     Constraint(int_set=set(range(0, 100)),   min_count=8, max_count=12),
@@ -111,7 +111,7 @@ print(solution)
 Note that the diversity is slightly lower than the unconstrained solution (0.7702 vs 0.7792) --
 this is expected, since satisfying constraints restricts the search space.
 
-Constraints can overlap -- a single vector can belong to multiple constraint groups.
+Constraints can overlap -- a single item can belong to multiple constraint groups.
 
 If constraints are infeasible (or jointly infeasible), the solver will not fail. Instead, it
 gracefully finds the *least infeasible* solution -- the one that violates constraints as little as
@@ -161,9 +161,9 @@ both problem flavors.
 ### Diversity metrics
 
 The diversity metric defines what "diverse" means for the selected subset. It operates on the
-*separation* of each selected vector -- its distance to its nearest neighbor in the selection.
-A well-spread selection will have high separations across all vectors; a clustered selection will
-have low separations for the vectors that are close together.
+*separation* of each selected item -- its distance to its nearest neighbor in the selection.
+A well-spread selection will have high separations across all items; a clustered selection will
+have low separations for the items that are close together.
 
 ```python
 from max_div import DiversityMetric
@@ -179,7 +179,7 @@ problem = MaxDivProblem.new(
 
 | Metric | Description | Best for |
 |--------|-------------|----------|
-| `GEOMEAN_SEPARATION` | Geometric mean of all separations (default) | General use -- balances spread across all selected vectors |
+| `GEOMEAN_SEPARATION` | Geometric mean of all separations (default) | General use -- balances spread across all selected items |
 | `MIN_SEPARATION` | Minimum separation (= p-dispersion) | When the closest pair matters most |
 | `MEAN_SEPARATION` | Arithmetic mean of all separations | When total spread is the objective |
 | `APPROX_GEOMEAN_SEPARATION` | Fast approximation of `GEOMEAN_SEPARATION` | Large-scale problems where speed matters |
@@ -212,7 +212,7 @@ solver = (
 | Preset | Description |
 |--------|-------------|
 | `RANDOM` | Baseline -- random initialization + random swap optimization. Fast but lower quality. |
-| `GUIDED` | Distance-guided swaps -- biased towards removing low-separation vectors and adding high-separation ones. |
+| `GUIDED` | Distance-guided swaps -- biased towards removing low-separation items and adding high-separation ones. |
 | `SMART` | **Default.** Adaptive swap-based optimization that learns which swap sizes and candidate selection strategies work best. |
 | `THOROUGH` | Like `SMART` but with wider parameter ranges, exploring more of the search space at the cost of slower convergence. Best for long runs. |
 


### PR DESCRIPTION
**TL;DR**: Applies the item-versus-vector distinction the glossary defines to the concepts pages and the getting-started walkthrough, and links first uses into the glossary.

## Description

### Problem addressed

The documentation called the things being selected *vectors* throughout. That stopped being accurate once a problem could be constructed from precomputed distances — such a problem has no vectors at all, only items and the distances between them, so "select k vectors" misdescribes half the API.

The constraints page showed it most plainly: it described minimum and maximum counts of *vectors* per group, when a constraint group is a set of indices and never touches coordinates. The scoring, solver, and diversity pages had the same pattern wherever they discussed selection, separation, or swaps.

### Implementation

One rule, applied per occurrence rather than by search-and-replace: **item** for the entity being selected, **vector** kept only where coordinates genuinely matter. That leaves the distance-metric definitions, cosine's magnitude invariance, the vector-input walkthrough and its variable names, and scipy's "condensed distance vector" untouched — roughly a third of the occurrences on the diversity page alone.

First uses now link into the glossary, so a reader meeting *item*, *separation*, *selection*, or *swap* for the first time has one click to the definition.

The pipeline heading and diagram on the diversity page also changed: it opened with `Vectors ──> Pairwise Distances`, which only describes one of the two problem flavors. It now starts from items, since the distance stage is what both flavors share.

## Attention points

- **The comparison page was checked and deliberately left alone.** All six of its occurrences sit in the table's *Input* column, describing what each tool accepts — genuinely about coordinate input versus distance matrices.
- **The benchmark description pages are out of scope**, also deliberately: their ~44 occurrences are about *vector density* in the generated problems, which is geometric and correct. Their sibling results files are generated by the benchmark make targets anyway.
- **Two program-output snippets still read "20 vectors selected"** in the getting-started walkthrough. Those are quoted solver output rather than prose, so they change together with the string that produces them.
- **A section heading changed**, so its anchor did too. Nothing linked to it — checked across the docs and the README before renaming, since the docs build is not run in strict mode and a dead anchor would fail silently.

## Tests / Spikes

- **TEST:** Docs build clean, no new warnings; the two pre-existing `mkdocs_autorefs` warnings on the internal-benchmark pages are unrelated and untouched.
- **TEST:** Verified in the built HTML that all 14 new glossary links resolve to an element that exists.
- **TEST:** Full suite green (3565 passed) and lint clean, though neither exercises documentation.
- No unit tests: prose-only change.

## Changelog entry

None: documentation wording, with no user-facing behavior change.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
