### PR TITLE
docs: add an at-a-glance capability table to the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for free-threaded Python 3.14 (3.14t)
 - Glossary page defining the terms used across the documentation
+- At-a-glance capability-comparison table at the top of the README
 
 ### Changed
 - Solution summaries now say "items selected" rather than "vectors selected"

--- a/README.md
+++ b/README.md
@@ -24,21 +24,17 @@ freely available tools: it is the only
 the only one offering a **geometric-mean separation** objective — one of four diversity metrics
 it provides (minimum, mean, and geometric-mean separation, plus mean pairwise distance).
 
-It fills the gap between exact MIP/CP solvers, which prove optimal answers but do not scale, and
-single-shot pickers, which are fast but cannot honor selection constraints. The
-[benchmarks](https://max-div.readthedocs.io/en/stable/benchmarks/comparison/overview/) show where
-it leads and where it does not.
-
 <p>
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/images/hero_dark.svg">
-    <img src="docs/images/hero_light.svg" alt="Feature comparison of max-div against exact solvers and one-shot pickers: distance metrics, diversity objectives, constraint handling, time budgets and practical scale" style="max-width: 100%; height: auto;">
+    <img src="docs/images/hero_light.svg" alt="Feature comparison of max-div against exact solvers and one-shot pickers: distance metrics, diversity objectives, constraint handling, time budgets and practical scale" style="max-width: max(60%, min(100%,800px)); height: auto;">
   </picture>
 </p>
 
-<sub>&#10003; built in &nbsp;·&nbsp; ~ reachable, but you supply the model, kernel or metric. The
-surveyed tools and their categories are described in the
-<a href="https://max-div.readthedocs.io/en/stable/comparison/">docs comparison</a>.</sub>
+It fills the gap between exact MIP/CP solvers, which prove optimal answers but do not scale, and
+single-shot pickers, which are fast but at best have very limited support for constraints. The
+[benchmarks](https://max-div.readthedocs.io/en/stable/benchmarks/comparison/overview/) show where
+it leads and where it does not.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ single-shot pickers, which are fast but cannot honor selection constraints. The
 [benchmarks](https://max-div.readthedocs.io/en/stable/benchmarks/comparison/overview/) show where
 it leads and where it does not.
 
+<p>
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/images/hero_dark.svg">
+    <img src="docs/images/hero_light.svg" alt="Feature comparison of max-div against exact solvers and one-shot pickers: distance metrics, diversity objectives, constraint handling, time budgets and practical scale" style="max-width: 100%; height: auto;">
+  </picture>
+</p>
+
+<sub>&#10003; built in &nbsp;·&nbsp; ~ reachable, but you supply the model, kernel or metric. The
+surveyed tools and their categories are described in the
+<a href="https://max-div.readthedocs.io/en/stable/comparison/">docs comparison</a>.</sub>
+
 ## Installation
 
 ```bash

--- a/docs/images/hero_dark.svg
+++ b/docs/images/hero_dark.svg
@@ -46,82 +46,82 @@
 <text x="461" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="513" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="174" fill="#e6edf3" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan><tspan font-size="12" dy="4">–10</tspan><tspan font-size="8" dy="-4">5</tspan></text>
+<text x="571" y="174" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan><tspan font-size="12" dy="4">–10</tspan><tspan font-size="8" dy="-4">5</tspan></text>
 <rect x="14" y="181" width="602" height="20" fill="#c9d1d9" fill-opacity="0.05"/>
 <text x="14" y="195" fill="#8b949e" font-size="11" font-weight="600" letter-spacing="0.5">EXACT SOLVERS</text>
 <line x1="14" y1="201" x2="616" y2="201" stroke="#30363d" stroke-width="1"/>
 <text x="16" y="217" fill="#e6edf3" font-size="12.5" font-weight="400">OR-Tools CP-SAT</text>
-<text x="175" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="217" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="279" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="305" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="331" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="357" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="383" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="409" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="435" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="461" y="217" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="217" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="513" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="513" y="217" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="217" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
 <line x1="14" y1="224" x2="616" y2="224" stroke="#30363d" stroke-width="1"/>
 <text x="16" y="240" fill="#e6edf3" font-size="12.5" font-weight="400">SCIP</text>
-<text x="175" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="240" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="279" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="305" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="331" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="357" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="383" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="409" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="435" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="461" y="240" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="240" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="513" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="513" y="240" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="240" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
 <line x1="14" y1="247" x2="616" y2="247" stroke="#30363d" stroke-width="1"/>
 <text x="16" y="263" fill="#e6edf3" font-size="12.5" font-weight="400">HiGHS</text>
-<text x="175" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="263" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="279" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="305" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="331" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="357" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="383" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="409" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="435" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="461" y="263" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="263" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="513" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="513" y="263" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="263" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
 <rect x="14" y="270" width="602" height="20" fill="#c9d1d9" fill-opacity="0.05"/>
 <text x="14" y="284" fill="#8b949e" font-size="11" font-weight="600" letter-spacing="0.5">ONE-SHOT PICKERS &amp; SAMPLERS</text>
 <line x1="14" y1="290" x2="616" y2="290" stroke="#30363d" stroke-width="1"/>
 <text x="16" y="306" fill="#e6edf3" font-size="12.5" font-weight="400">RDKit MaxMinPicker</text>
-<text x="175" y="306" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="306" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="306" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="306" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="306" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="306" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="306" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="279" y="306" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="306" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<text x="571" y="306" fill="#3fb950" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
 <line x1="14" y1="313" x2="616" y2="313" stroke="#30363d" stroke-width="1"/>
-<text x="16" y="329" fill="#e6edf3" font-size="12.5" font-weight="400">skmatter</text>
+<text x="16" y="329" fill="#e6edf3" font-size="12.5" font-weight="400">fpsample</text>
 <text x="201" y="329" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="329" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="329" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="279" y="329" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="329" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
+<text x="571" y="329" fill="#3fb950" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
 <line x1="14" y1="336" x2="616" y2="336" stroke="#30363d" stroke-width="1"/>
-<text x="16" y="352" fill="#e6edf3" font-size="12.5" font-weight="400">fpsample</text>
+<text x="16" y="352" fill="#e6edf3" font-size="12.5" font-weight="400">skmatter</text>
 <text x="201" y="352" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="352" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="352" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="279" y="352" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="352" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<text x="571" y="352" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
 <line x1="14" y1="359" x2="616" y2="359" stroke="#30363d" stroke-width="1"/>
 <text x="16" y="375" fill="#e6edf3" font-size="12.5" font-weight="400">apricot-select</text>
 <text x="175" y="375" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
@@ -134,30 +134,30 @@
 <text x="16" y="398" fill="#e6edf3" font-size="12.5" font-weight="400">qc-selector</text>
 <text x="175" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="201" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="398" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="398" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="279" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="357" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="383" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="461" y="398" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="398" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="398" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="405" x2="616" y2="405" stroke="#30363d" stroke-width="1"/>
 <text x="16" y="421" fill="#e6edf3" font-size="12.5" font-weight="400">DPPy</text>
-<text x="175" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="421" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="421" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="421" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="421" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="461" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="421" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="421" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="428" x2="616" y2="428" stroke="#30363d" stroke-width="1"/>
 <text x="16" y="444" fill="#e6edf3" font-size="12.5" font-weight="400">code-FDM</text>
-<text x="175" y="444" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="444" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="201" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="444" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="444" fill="#8b949e" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="279" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="383" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="571" y="444" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="451" x2="616" y2="451" stroke="#30363d" stroke-width="1"/>
-<text x="14" y="469" font-size="11"><tspan fill="#3fb950" font-weight="700">✓</tspan><tspan fill="#8b949e" dx="5">built in</tspan><tspan fill="#8b949e" dx="9">·</tspan><tspan fill="#d29922" font-weight="700" dx="9">~</tspan><tspan fill="#8b949e" dx="5">reachable, but you supply the model, kernel or metric</tspan></text>
+<text x="14" y="469" font-size="11"><tspan fill="#3fb950" font-weight="700">✓</tspan><tspan fill="#8b949e" dx="5">built in</tspan><tspan fill="#8b949e" dx="9">·</tspan><tspan fill="#8b949e" font-weight="700" dx="9">~</tspan><tspan fill="#8b949e" dx="5">reachable, but you supply the model, transform or metric</tspan></text>
 </svg>

--- a/docs/images/hero_dark.svg
+++ b/docs/images/hero_dark.svg
@@ -1,0 +1,163 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="718" height="491" viewBox="0 0 718 491" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+<rect width="718" height="491" fill="#0d1117"/>
+<polygon points="253,32 357,32 266,123 266,451 162,451 162,123" fill="#161b22"/>
+<text x="305" y="26" fill="#8b949e" font-size="11" font-weight="600" text-anchor="middle">distance</text>
+<line x1="255" y1="31" x2="355" y2="31" stroke="#30363d" stroke-width="1"/>
+<text x="409" y="26" fill="#8b949e" font-size="11" font-weight="600" text-anchor="middle">objective</text>
+<line x1="359" y1="31" x2="459" y2="31" stroke="#30363d" stroke-width="1"/>
+<polygon points="461,32 539,32 448,123 448,451 370,451 370,123" fill="#161b22"/>
+<text x="500" y="26" fill="#8b949e" font-size="11" font-weight="600" text-anchor="middle">constraints</text>
+<line x1="463" y1="31" x2="537" y2="31" stroke="#30363d" stroke-width="1"/>
+<text x="578" y="26" fill="#8b949e" font-size="11" font-weight="600" text-anchor="middle">budget</text>
+<line x1="541" y1="31" x2="615" y2="31" stroke="#30363d" stroke-width="1"/>
+<polygon points="617,32 707,32 616,123 616,451 526,451 526,123" fill="#161b22"/>
+<text x="662" y="26" fill="#8b949e" font-size="11" font-weight="600" text-anchor="middle">max practical n</text>
+<line x1="619" y1="31" x2="705" y2="31" stroke="#30363d" stroke-width="1"/>
+<text x="172" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 172 131)">L1</text>
+<text x="198" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 198 131)">L2</text>
+<text x="224" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 224 131)">cosine</text>
+<text x="250" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 250 131)">custom</text>
+<text x="276" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 276 131)">max-min</text>
+<text x="302" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 302 131)">mean-of-NN</text>
+<text x="328" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 328 131)">geomean-of-NN</text>
+<text x="354" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 354 131)">max-sum</text>
+<text x="380" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 380 131)">disjoint groups</text>
+<text x="406" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 406 131)">overlapping groups</text>
+<text x="432" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 432 131)">ranged counts</text>
+<text x="458" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 458 131)">iterations</text>
+<text x="484" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 484 131)">wall clock</text>
+<text x="510" y="131" fill="#e6edf3" font-size="12" text-anchor="start" transform="rotate(-45 510 131)">improves with budget</text>
+<rect x="14" y="138" width="602" height="20" fill="#c9d1d9" fill-opacity="0.05"/>
+<text x="14" y="152" fill="#8b949e" font-size="11" font-weight="600" letter-spacing="0.5">ANYTIME OPTIMIZERS</text>
+<rect x="14" y="158" width="602" height="23" fill="#12261e"/>
+<line x1="14" y1="158" x2="616" y2="158" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="174" fill="#e6edf3" font-size="12.5" font-weight="700">max-div</text>
+<text x="175" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="201" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="253" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="305" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="331" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="357" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="383" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="409" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="435" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="461" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="174" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="174" fill="#e6edf3" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan><tspan font-size="12" dy="4">–10</tspan><tspan font-size="8" dy="-4">5</tspan></text>
+<rect x="14" y="181" width="602" height="20" fill="#c9d1d9" fill-opacity="0.05"/>
+<text x="14" y="195" fill="#8b949e" font-size="11" font-weight="600" letter-spacing="0.5">EXACT SOLVERS</text>
+<line x1="14" y1="201" x2="616" y2="201" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="217" fill="#e6edf3" font-size="12.5" font-weight="400">OR-Tools CP-SAT</text>
+<text x="175" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="217" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="217" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="217" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="217" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="217" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
+<line x1="14" y1="224" x2="616" y2="224" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="240" fill="#e6edf3" font-size="12.5" font-weight="400">SCIP</text>
+<text x="175" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="240" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="240" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="240" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="240" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="240" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
+<line x1="14" y1="247" x2="616" y2="247" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="263" fill="#e6edf3" font-size="12.5" font-weight="400">HiGHS</text>
+<text x="175" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="263" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="263" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="263" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="263" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="263" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
+<rect x="14" y="270" width="602" height="20" fill="#c9d1d9" fill-opacity="0.05"/>
+<text x="14" y="284" fill="#8b949e" font-size="11" font-weight="600" letter-spacing="0.5">ONE-SHOT PICKERS &amp; SAMPLERS</text>
+<line x1="14" y1="290" x2="616" y2="290" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="306" fill="#e6edf3" font-size="12.5" font-weight="400">RDKit MaxMinPicker</text>
+<text x="175" y="306" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="306" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="306" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="306" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="306" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="306" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<line x1="14" y1="313" x2="616" y2="313" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="329" fill="#e6edf3" font-size="12.5" font-weight="400">skmatter</text>
+<text x="201" y="329" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="329" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="329" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="329" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
+<line x1="14" y1="336" x2="616" y2="336" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="352" fill="#e6edf3" font-size="12.5" font-weight="400">fpsample</text>
+<text x="201" y="352" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="352" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="352" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="352" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<line x1="14" y1="359" x2="616" y2="359" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="375" fill="#e6edf3" font-size="12.5" font-weight="400">apricot-select</text>
+<text x="175" y="375" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="201" y="375" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="375" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="253" y="375" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="357" y="375" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="375" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
+<line x1="14" y1="382" x2="616" y2="382" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="398" fill="#e6edf3" font-size="12.5" font-weight="400">qc-selector</text>
+<text x="175" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="201" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="398" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="357" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="383" y="398" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="461" y="398" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="398" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
+<line x1="14" y1="405" x2="616" y2="405" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="421" fill="#e6edf3" font-size="12.5" font-weight="400">DPPy</text>
+<text x="175" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="421" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="461" y="421" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="421" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
+<line x1="14" y1="428" x2="616" y2="428" stroke="#30363d" stroke-width="1"/>
+<text x="16" y="444" fill="#e6edf3" font-size="12.5" font-weight="400">code-FDM</text>
+<text x="175" y="444" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="444" fill="#d29922" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="383" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="444" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
+<line x1="14" y1="451" x2="616" y2="451" stroke="#30363d" stroke-width="1"/>
+<text x="14" y="469" font-size="11"><tspan fill="#3fb950" font-weight="700">✓</tspan><tspan fill="#8b949e" dx="5">built in</tspan><tspan fill="#8b949e" dx="9">·</tspan><tspan fill="#d29922" font-weight="700" dx="9">~</tspan><tspan fill="#8b949e" dx="5">reachable, but you supply the model, kernel or metric</tspan></text>
+</svg>

--- a/docs/images/hero_dark.svg
+++ b/docs/images/hero_dark.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="718" height="491" viewBox="0 0 718 491" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
-<rect width="718" height="491" fill="#0d1117"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="718" height="477" viewBox="0 0 718 477" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+<rect width="718" height="477" fill="#0d1117"/>
 <polygon points="253,32 357,32 266,123 266,451 162,451 162,123" fill="#161b22"/>
 <text x="305" y="26" fill="#8b949e" font-size="11" font-weight="600" text-anchor="middle">distance</text>
 <line x1="255" y1="31" x2="355" y2="31" stroke="#30363d" stroke-width="1"/>
@@ -159,5 +159,5 @@
 <text x="383" y="444" fill="#3fb950" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="571" y="444" fill="#e6edf3" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="451" x2="616" y2="451" stroke="#30363d" stroke-width="1"/>
-<text x="14" y="469" font-size="11"><tspan fill="#3fb950" font-weight="700">✓</tspan><tspan fill="#8b949e" dx="5">built in</tspan><tspan fill="#8b949e" dx="9">·</tspan><tspan fill="#8b949e" font-weight="700" dx="9">~</tspan><tspan fill="#8b949e" dx="5">reachable, but you supply the model, transform or metric</tspan></text>
+<text x="14" y="464" font-size="11"><tspan fill="#3fb950" font-weight="700">✓</tspan><tspan fill="#8b949e" dx="5">built in</tspan><tspan fill="#8b949e" dx="9">·</tspan><tspan fill="#8b949e" font-weight="700" dx="9">~</tspan><tspan fill="#8b949e" dx="5">reachable, but you supply the model, transform or metric</tspan></text>
 </svg>

--- a/docs/images/hero_light.svg
+++ b/docs/images/hero_light.svg
@@ -46,82 +46,82 @@
 <text x="461" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="513" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="174" fill="#1f2328" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan><tspan font-size="12" dy="4">–10</tspan><tspan font-size="8" dy="-4">5</tspan></text>
+<text x="571" y="174" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan><tspan font-size="12" dy="4">–10</tspan><tspan font-size="8" dy="-4">5</tspan></text>
 <rect x="14" y="181" width="602" height="20" fill="#57606a" fill-opacity="0.06"/>
 <text x="14" y="195" fill="#656d76" font-size="11" font-weight="600" letter-spacing="0.5">EXACT SOLVERS</text>
 <line x1="14" y1="201" x2="616" y2="201" stroke="#d8dee4" stroke-width="1"/>
 <text x="16" y="217" fill="#1f2328" font-size="12.5" font-weight="400">OR-Tools CP-SAT</text>
-<text x="175" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="217" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="279" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="305" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="331" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="357" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="383" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="409" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="435" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="461" y="217" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="217" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="513" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="513" y="217" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="217" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
 <line x1="14" y1="224" x2="616" y2="224" stroke="#d8dee4" stroke-width="1"/>
 <text x="16" y="240" fill="#1f2328" font-size="12.5" font-weight="400">SCIP</text>
-<text x="175" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="240" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="279" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="305" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="331" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="357" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="383" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="409" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="435" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="461" y="240" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="240" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="513" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="513" y="240" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="240" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
 <line x1="14" y1="247" x2="616" y2="247" stroke="#d8dee4" stroke-width="1"/>
 <text x="16" y="263" fill="#1f2328" font-size="12.5" font-weight="400">HiGHS</text>
-<text x="175" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="263" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="279" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="305" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="331" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="357" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="383" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="409" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="435" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="461" y="263" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="487" y="263" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="513" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="513" y="263" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="263" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
 <rect x="14" y="270" width="602" height="20" fill="#57606a" fill-opacity="0.06"/>
 <text x="14" y="284" fill="#656d76" font-size="11" font-weight="600" letter-spacing="0.5">ONE-SHOT PICKERS &amp; SAMPLERS</text>
 <line x1="14" y1="290" x2="616" y2="290" stroke="#d8dee4" stroke-width="1"/>
 <text x="16" y="306" fill="#1f2328" font-size="12.5" font-weight="400">RDKit MaxMinPicker</text>
-<text x="175" y="306" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="306" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="306" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="306" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="306" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="306" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="306" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="279" y="306" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="306" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<text x="571" y="306" fill="#1a7f37" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
 <line x1="14" y1="313" x2="616" y2="313" stroke="#d8dee4" stroke-width="1"/>
-<text x="16" y="329" fill="#1f2328" font-size="12.5" font-weight="400">skmatter</text>
+<text x="16" y="329" fill="#1f2328" font-size="12.5" font-weight="400">fpsample</text>
 <text x="201" y="329" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="329" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="329" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="279" y="329" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="329" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
+<text x="571" y="329" fill="#1a7f37" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
 <line x1="14" y1="336" x2="616" y2="336" stroke="#d8dee4" stroke-width="1"/>
-<text x="16" y="352" fill="#1f2328" font-size="12.5" font-weight="400">fpsample</text>
+<text x="16" y="352" fill="#1f2328" font-size="12.5" font-weight="400">skmatter</text>
 <text x="201" y="352" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="352" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="352" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="279" y="352" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="571" y="352" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<text x="571" y="352" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
 <line x1="14" y1="359" x2="616" y2="359" stroke="#d8dee4" stroke-width="1"/>
 <text x="16" y="375" fill="#1f2328" font-size="12.5" font-weight="400">apricot-select</text>
 <text x="175" y="375" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
@@ -134,30 +134,30 @@
 <text x="16" y="398" fill="#1f2328" font-size="12.5" font-weight="400">qc-selector</text>
 <text x="175" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="201" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="398" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="398" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="279" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="357" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="383" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="461" y="398" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="398" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="398" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="405" x2="616" y2="405" stroke="#d8dee4" stroke-width="1"/>
 <text x="16" y="421" fill="#1f2328" font-size="12.5" font-weight="400">DPPy</text>
-<text x="175" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="201" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
-<text x="227" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="421" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="421" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="421" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="421" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="461" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="421" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="571" y="421" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="428" x2="616" y2="428" stroke="#d8dee4" stroke-width="1"/>
 <text x="16" y="444" fill="#1f2328" font-size="12.5" font-weight="400">code-FDM</text>
-<text x="175" y="444" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="175" y="444" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="201" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
-<text x="227" y="444" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="444" fill="#8c959f" font-size="13.5" text-anchor="middle">~</text>
 <text x="253" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="279" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="383" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="571" y="444" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="451" x2="616" y2="451" stroke="#d8dee4" stroke-width="1"/>
-<text x="14" y="469" font-size="11"><tspan fill="#1a7f37" font-weight="700">✓</tspan><tspan fill="#656d76" dx="5">built in</tspan><tspan fill="#656d76" dx="9">·</tspan><tspan fill="#9a6700" font-weight="700" dx="9">~</tspan><tspan fill="#656d76" dx="5">reachable, but you supply the model, kernel or metric</tspan></text>
+<text x="14" y="469" font-size="11"><tspan fill="#1a7f37" font-weight="700">✓</tspan><tspan fill="#656d76" dx="5">built in</tspan><tspan fill="#656d76" dx="9">·</tspan><tspan fill="#8c959f" font-weight="700" dx="9">~</tspan><tspan fill="#656d76" dx="5">reachable, but you supply the model, transform or metric</tspan></text>
 </svg>

--- a/docs/images/hero_light.svg
+++ b/docs/images/hero_light.svg
@@ -1,0 +1,163 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="718" height="491" viewBox="0 0 718 491" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+<rect width="718" height="491" fill="#ffffff"/>
+<polygon points="253,32 357,32 266,123 266,451 162,451 162,123" fill="#f6f8fa"/>
+<text x="305" y="26" fill="#656d76" font-size="11" font-weight="600" text-anchor="middle">distance</text>
+<line x1="255" y1="31" x2="355" y2="31" stroke="#d8dee4" stroke-width="1"/>
+<text x="409" y="26" fill="#656d76" font-size="11" font-weight="600" text-anchor="middle">objective</text>
+<line x1="359" y1="31" x2="459" y2="31" stroke="#d8dee4" stroke-width="1"/>
+<polygon points="461,32 539,32 448,123 448,451 370,451 370,123" fill="#f6f8fa"/>
+<text x="500" y="26" fill="#656d76" font-size="11" font-weight="600" text-anchor="middle">constraints</text>
+<line x1="463" y1="31" x2="537" y2="31" stroke="#d8dee4" stroke-width="1"/>
+<text x="578" y="26" fill="#656d76" font-size="11" font-weight="600" text-anchor="middle">budget</text>
+<line x1="541" y1="31" x2="615" y2="31" stroke="#d8dee4" stroke-width="1"/>
+<polygon points="617,32 707,32 616,123 616,451 526,451 526,123" fill="#f6f8fa"/>
+<text x="662" y="26" fill="#656d76" font-size="11" font-weight="600" text-anchor="middle">max practical n</text>
+<line x1="619" y1="31" x2="705" y2="31" stroke="#d8dee4" stroke-width="1"/>
+<text x="172" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 172 131)">L1</text>
+<text x="198" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 198 131)">L2</text>
+<text x="224" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 224 131)">cosine</text>
+<text x="250" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 250 131)">custom</text>
+<text x="276" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 276 131)">max-min</text>
+<text x="302" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 302 131)">mean-of-NN</text>
+<text x="328" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 328 131)">geomean-of-NN</text>
+<text x="354" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 354 131)">max-sum</text>
+<text x="380" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 380 131)">disjoint groups</text>
+<text x="406" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 406 131)">overlapping groups</text>
+<text x="432" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 432 131)">ranged counts</text>
+<text x="458" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 458 131)">iterations</text>
+<text x="484" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 484 131)">wall clock</text>
+<text x="510" y="131" fill="#1f2328" font-size="12" text-anchor="start" transform="rotate(-45 510 131)">improves with budget</text>
+<rect x="14" y="138" width="602" height="20" fill="#57606a" fill-opacity="0.06"/>
+<text x="14" y="152" fill="#656d76" font-size="11" font-weight="600" letter-spacing="0.5">ANYTIME OPTIMIZERS</text>
+<rect x="14" y="158" width="602" height="23" fill="#ddf4e4"/>
+<line x1="14" y1="158" x2="616" y2="158" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="174" fill="#1f2328" font-size="12.5" font-weight="700">max-div</text>
+<text x="175" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="201" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="253" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="305" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="331" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="357" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="383" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="409" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="435" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="461" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="174" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="174" fill="#1f2328" font-size="12" font-weight="700" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan><tspan font-size="12" dy="4">–10</tspan><tspan font-size="8" dy="-4">5</tspan></text>
+<rect x="14" y="181" width="602" height="20" fill="#57606a" fill-opacity="0.06"/>
+<text x="14" y="195" fill="#656d76" font-size="11" font-weight="600" letter-spacing="0.5">EXACT SOLVERS</text>
+<line x1="14" y1="201" x2="616" y2="201" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="217" fill="#1f2328" font-size="12.5" font-weight="400">OR-Tools CP-SAT</text>
+<text x="175" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="217" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="217" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="217" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="217" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="217" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
+<line x1="14" y1="224" x2="616" y2="224" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="240" fill="#1f2328" font-size="12.5" font-weight="400">SCIP</text>
+<text x="175" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="240" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="240" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="240" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="240" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="240" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
+<line x1="14" y1="247" x2="616" y2="247" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="263" fill="#1f2328" font-size="12.5" font-weight="400">HiGHS</text>
+<text x="175" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="263" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="305" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="331" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="357" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="383" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="409" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="435" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="461" y="263" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="487" y="263" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="513" y="263" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="263" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">3</tspan></text>
+<rect x="14" y="270" width="602" height="20" fill="#57606a" fill-opacity="0.06"/>
+<text x="14" y="284" fill="#656d76" font-size="11" font-weight="600" letter-spacing="0.5">ONE-SHOT PICKERS &amp; SAMPLERS</text>
+<line x1="14" y1="290" x2="616" y2="290" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="306" fill="#1f2328" font-size="12.5" font-weight="400">RDKit MaxMinPicker</text>
+<text x="175" y="306" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="306" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="306" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="306" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="306" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="306" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<line x1="14" y1="313" x2="616" y2="313" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="329" fill="#1f2328" font-size="12.5" font-weight="400">skmatter</text>
+<text x="201" y="329" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="329" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="329" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="329" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
+<line x1="14" y1="336" x2="616" y2="336" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="352" fill="#1f2328" font-size="12.5" font-weight="400">fpsample</text>
+<text x="201" y="352" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="352" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="279" y="352" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="352" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">6</tspan></text>
+<line x1="14" y1="359" x2="616" y2="359" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="375" fill="#1f2328" font-size="12.5" font-weight="400">apricot-select</text>
+<text x="175" y="375" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="201" y="375" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="375" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="253" y="375" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="357" y="375" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="375" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">5</tspan></text>
+<line x1="14" y1="382" x2="616" y2="382" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="398" fill="#1f2328" font-size="12.5" font-weight="400">qc-selector</text>
+<text x="175" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="201" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="398" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="357" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="383" y="398" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="461" y="398" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="398" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
+<line x1="14" y1="405" x2="616" y2="405" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="421" fill="#1f2328" font-size="12.5" font-weight="400">DPPy</text>
+<text x="175" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="227" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="421" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="461" y="421" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="571" y="421" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
+<line x1="14" y1="428" x2="616" y2="428" stroke="#d8dee4" stroke-width="1"/>
+<text x="16" y="444" fill="#1f2328" font-size="12.5" font-weight="400">code-FDM</text>
+<text x="175" y="444" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="201" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="227" y="444" fill="#9a6700" font-size="13.5" text-anchor="middle">~</text>
+<text x="253" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="279" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="383" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
+<text x="571" y="444" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
+<line x1="14" y1="451" x2="616" y2="451" stroke="#d8dee4" stroke-width="1"/>
+<text x="14" y="469" font-size="11"><tspan fill="#1a7f37" font-weight="700">✓</tspan><tspan fill="#656d76" dx="5">built in</tspan><tspan fill="#656d76" dx="9">·</tspan><tspan fill="#9a6700" font-weight="700" dx="9">~</tspan><tspan fill="#656d76" dx="5">reachable, but you supply the model, kernel or metric</tspan></text>
+</svg>

--- a/docs/images/hero_light.svg
+++ b/docs/images/hero_light.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="718" height="491" viewBox="0 0 718 491" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
-<rect width="718" height="491" fill="#ffffff"/>
+<svg xmlns="http://www.w3.org/2000/svg" width="718" height="477" viewBox="0 0 718 477" font-family="-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif">
+<rect width="718" height="477" fill="#ffffff"/>
 <polygon points="253,32 357,32 266,123 266,451 162,451 162,123" fill="#f6f8fa"/>
 <text x="305" y="26" fill="#656d76" font-size="11" font-weight="600" text-anchor="middle">distance</text>
 <line x1="255" y1="31" x2="355" y2="31" stroke="#d8dee4" stroke-width="1"/>
@@ -159,5 +159,5 @@
 <text x="383" y="444" fill="#1a7f37" font-size="13.5" font-weight="700" text-anchor="middle">✓</text>
 <text x="571" y="444" fill="#1f2328" font-size="12" font-weight="400" text-anchor="middle">~10<tspan font-size="8" dy="-4">4</tspan></text>
 <line x1="14" y1="451" x2="616" y2="451" stroke="#d8dee4" stroke-width="1"/>
-<text x="14" y="469" font-size="11"><tspan fill="#1a7f37" font-weight="700">✓</tspan><tspan fill="#656d76" dx="5">built in</tspan><tspan fill="#656d76" dx="9">·</tspan><tspan fill="#8c959f" font-weight="700" dx="9">~</tspan><tspan fill="#656d76" dx="5">reachable, but you supply the model, transform or metric</tspan></text>
+<text x="14" y="464" font-size="11"><tspan fill="#1a7f37" font-weight="700">✓</tspan><tspan fill="#656d76" dx="5">built in</tspan><tspan fill="#656d76" dx="9">·</tspan><tspan fill="#8c959f" font-weight="700" dx="9">~</tspan><tspan fill="#656d76" dx="5">reachable, but you supply the model, transform or metric</tspan></text>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,14 @@ path = "README.md"
 pattern = 'src="(images/[^"]+)"'
 replacement = 'src="https://raw.githubusercontent.com/bertpl/max-div/v$HFPR_VERSION/\1"'
 
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# The hero table needs a `<picture>` to switch on the reader's color scheme, and its paths live
+# in attributes -- including `srcset`, which the rule above does not match. PyPI's sanitizer
+# drops `<picture>`/`<source>` and keeps the `<img>`, so PyPI shows the light variant, which is
+# right for a page with no dark mode -- but only if that URL is absolute.
+pattern = '(src|srcset)="(docs/images/[^"]+)"'
+replacement = '\1="https://raw.githubusercontent.com/bertpl/max-div/v$HFPR_VERSION/\2"'
+
 [tool.hatch.build.targets.sdist]
 only-include = ["src/max_div"]
 

--- a/scripts/build_hero_table.py
+++ b/scripts/build_hero_table.py
@@ -1,0 +1,364 @@
+"""Render the README hero capability table to light and dark SVGs.
+
+Reads scripts/hero_table_data.txt and writes docs/images/hero_light.svg and
+docs/images/hero_dark.svg.
+
+Two properties are deliberate:
+
+* **Each SVG carries its own opaque background.** GitHub exposes no hook for its own theme
+  setting, so `<picture>` + `prefers-color-scheme` follows the reader's operating system. A
+  reader who pinned GitHub's theme against their OS gets the other variant, and an opaque
+  panel keeps it legible instead of putting dark ink on a dark page.
+* **Output is deterministic.** Coordinates are rounded before formatting and floats are never
+  repr'd, so re-running reproduces the committed bytes and a drift test can compare them.
+
+Usage: python scripts/build_hero_table.py [--check]
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DATA_FILE = REPO_ROOT / "scripts" / "hero_table_data.txt"
+OUT_DIR = REPO_ROOT / "docs" / "images"
+
+# --- column definitions ------------------------------------
+# (group label, [(short header, width)]) — headers render at 45 degrees.
+GROUPS = [
+    ("distance", [("L1", 1), ("L2", 1), ("cosine", 1), ("custom", 1)]),
+    ("objective", [("max-min", 1), ("mean-of-NN", 1), ("geomean-of-NN", 1), ("max-sum", 1)]),
+    ("constraints", [("disjoint groups", 1), ("overlapping groups", 1), ("ranged counts", 1)]),
+    ("budget", [("iterations", 1), ("wall clock", 1), ("improves with budget", 1)]),
+    ("max practical n", [("", 2)]),
+]
+
+# --- geometry (all integers; no float formatting anywhere) --
+LABEL_W = 148  # solver-name gutter
+COL_W = 26  # one mark column
+SCALE_W = 90  # wide enough for the group label "max practical n" to sit over it without colliding
+ROW_H = 23
+HEADER_H = 132  # room for the 45-degree labels
+GROUP_H = 18
+CAPTION_H = 26
+CAT_H = 20
+CORNER_LIFT = 15  # where the band edge turns diagonal, above the first row
+PAD = 14
+HEADER_FS = 12  # header font size; the width estimate below is calibrated to it
+CHAR_W = 63  # tenths of a px per character at HEADER_FS, averaged over mixed-case text
+
+THEMES = {
+    "light": {
+        "bg": "#ffffff",
+        "panel": "#ffffff",
+        "ink": "#1f2328",
+        "muted": "#656d76",
+        "rule": "#d8dee4",
+        "band": "#f6f8fa",
+        "mark": "#1a7f37",
+        "partial": "#9a6700",
+        "own_band": "#ddf4e4",
+        "cat_band": "#57606a",
+        "cat_band_opacity": "0.06",
+    },
+    "dark": {
+        "bg": "#0d1117",
+        "panel": "#0d1117",
+        "ink": "#e6edf3",
+        "muted": "#8b949e",
+        "rule": "#30363d",
+        "band": "#161b22",
+        "mark": "#3fb950",
+        "partial": "#d29922",
+        "own_band": "#12261e",
+        "cat_band": "#c9d1d9",
+        "cat_band_opacity": "0.05",
+    },
+}
+
+
+def parse_data(text):
+    """Parse the companion file into (categories, rows). Rows carry marks in column order."""
+    categories, rows = [], []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("[category]"):
+            categories.append(line[len("[category]") :].strip())
+            continue
+        name, *rest = [p.strip() for p in line.split("|")]
+        *mark_groups, scale, source = rest
+        marks = []
+        for grp in mark_groups:
+            marks.extend(grp.split())
+        rows.append(
+            {
+                "category": len(categories) - 1,
+                "name": name,
+                "marks": marks,
+                "scale": scale,
+                "source": source,
+            }
+        )
+    n_cols = sum(len(cols) for _, cols in GROUPS) - 1  # scale is not a mark column
+    for row in rows:
+        if len(row["marks"]) != n_cols:
+            raise ValueError(f"{row['name']}: expected {n_cols} marks, got {len(row['marks'])}")
+    return categories, rows
+
+
+def esc(text):
+    """Escape the five XML entities."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+SCALE_FS = 12  # base size for the scale figures
+NAME_FS = "12.5"  # solver-name size
+MARK_FS = "13.5"  # check-mark and tilde size
+SMALL_FS = 11  # group labels, category labels, caption
+SUP_FS = 8  # exponent size — unicode superscripts render around 7px here, which reads too small
+SUP_DY = 4  # how far the exponent is raised
+
+
+def scale_markup(spec):
+    """`4-5` -> `~10^4 en-dash 10^5` as SVG markup, `3` -> `~10^3`.
+
+    Exponents are `<tspan>`s rather than unicode superscript characters: those are locked to
+    roughly 0.6x the surrounding size, which is too small to read at this scale. `dy` shifts are
+    cumulative in SVG, so every raised span is followed by an equal lowering span.
+
+    Every figure carries a leading `~`: these are indicative orders of magnitude, not measured
+    ceilings, and the binding limit differs per tool (memory, runtime, dimensionality).
+    """
+
+    def sup(digits):
+        return f'<tspan font-size="{SUP_FS}" dy="-{SUP_DY}">{digits}</tspan>'
+
+    def baseline(text):
+        return f'<tspan font-size="{SCALE_FS}" dy="{SUP_DY}">{text}</tspan>'
+
+    if "-" in spec:
+        lo, hi = spec.split("-")
+        return "~10" + sup(lo) + baseline("\u201310") + sup(hi)
+    return "~10" + sup(spec)
+
+
+class _Layout:
+    """Resolved geometry and palette for one render. Every value is an integer."""
+
+    def __init__(self, categories, rows, theme_name):
+        self.t = THEMES[theme_name]
+        self.rows = rows
+        self.categories = categories
+        self.mark_cols = [(h, w) for _, cols in GROUPS for (h, w) in cols][:-1]
+        self.n_marks = len(self.mark_cols)
+        self.grid_w = self.n_marks * COL_W + SCALE_W
+
+        # The longest header, rotated 45 degrees, sticks out to the right by width/sqrt(2). That
+        # same overhang sizes the header band and the skew of the group bands.
+        longest = max(len(h) for h, _ in self.mark_cols)
+        self.overhang = (longest * CHAR_W * 7) // 100  # /10 for tenths, *0.707 for the rotation
+        self.header_h = self.overhang + 18
+
+        self.width = PAD + LABEL_W + self.grid_w + self.overhang + PAD
+        self.height = PAD + GROUP_H + self.header_h + len(categories) * CAT_H + len(rows) * ROW_H + CAPTION_H + PAD
+
+        self.y_group = PAD + GROUP_H - 6
+        self.y_top = PAD + GROUP_H  # bands start here, just under the group labels
+        self.y_header_base = PAD + GROUP_H + self.header_h
+        self.y_end = self.y_header_base + len(categories) * CAT_H + len(rows) * ROW_H
+        # The bands turn from vertical to 45 degrees a little above the first row, so the corner
+        # sits clear of the top row rather than flush against it.
+        self.y_corner = self.y_header_base - CORNER_LIFT
+        self.skew = self.y_corner - self.y_top  # a 45-degree edge shifts right by its own height
+        self.table_w = LABEL_W + self.grid_w
+
+    def col_x(self, i):
+        """Left edge of mark column i."""
+        return PAD + LABEL_W + i * COL_W
+
+    def rule(self, y):
+        """A full-width horizontal rule at y."""
+        return (
+            f'<line x1="{PAD}" y1="{y}" x2="{PAD + self.table_w}" y2="{y}" stroke="{self.t["rule"]}" stroke-width="1"/>'
+        )
+
+
+def _group_bands(lay):
+    """Alternating group bands, their labels, and the bracket rule under each label.
+
+    Each band runs from the group label down to the last row. Through the header region its top
+    edge is slanted 45 degrees, parallel to the rotated column labels, so every label stays
+    inside its own column's band the whole way up. The consequence is that the top of a band
+    sits `skew` px right of its bottom, which is why the labels are offset by the same amount.
+    """
+    out, idx, t = [], 0, lay.t
+    for gi, (glabel, cols) in enumerate(GROUPS):
+        span = sum(COL_W if w == 1 else SCALE_W for _, w in cols)
+        x0 = lay.col_x(idx)
+        x1 = x0 + span
+        if gi % 2 == 0:
+            corners = [
+                (x0 + lay.skew, lay.y_top),
+                (x1 + lay.skew, lay.y_top),
+                (x1, lay.y_corner),
+                (x1, lay.y_end),
+                (x0, lay.y_end),
+                (x0, lay.y_corner),
+            ]
+            pts = " ".join(f"{x},{y}" for x, y in corners)
+            out.append(f'<polygon points="{pts}" fill="{t["band"]}"/>')
+        lx = x0 + span // 2 + lay.skew
+        out.append(
+            f'<text x="{lx}" y="{lay.y_group}" fill="{t["muted"]}" font-size="{SMALL_FS}" '
+            f'font-weight="600" text-anchor="middle">{esc(glabel)}</text>'
+        )
+        out.append(
+            f'<line x1="{x0 + lay.skew + 2}" y1="{lay.y_group + 5}" x2="{x1 + lay.skew - 2}" '
+            f'y2="{lay.y_group + 5}" stroke="{t["rule"]}" stroke-width="1"/>'
+        )
+        idx += len(cols)
+    return out
+
+
+def _column_headers(lay):
+    """The rotated column headers.
+
+    anchor=start + rotate(-45) leans each label up and to the right, the usual convention for
+    narrow columns. SVG's y axis points down, so rotate(-45) is the counter-clockwise direction:
+    anchor=end would send the text down into the data rows instead.
+    """
+    y = lay.y_header_base - 7
+    out = []
+    for i, (header, _w) in enumerate(lay.mark_cols):
+        x = lay.col_x(i) + COL_W // 2 - 3
+        out.append(
+            f'<text x="{x}" y="{y}" fill="{lay.t["ink"]}" font-size="{HEADER_FS}" '
+            f'text-anchor="start" transform="rotate(-45 {x} {y})">{esc(header)}</text>'
+        )
+    # the scale column gets no diagonal header — its group label already reads "max practical n"
+    return out
+
+
+def _row_marks(lay, row, y):
+    """The mark glyphs and the scale figure for one row."""
+    t, out = lay.t, []
+    cy = y + ROW_H - 7
+    for i, mark in enumerate(row["marks"]):
+        cx = lay.col_x(i) + COL_W // 2
+        if mark == "Y":
+            out.append(
+                f'<text x="{cx}" y="{cy}" fill="{t["mark"]}" font-size="{MARK_FS}" '
+                f'font-weight="700" text-anchor="middle">✓</text>'
+            )
+        elif mark == "~":
+            out.append(
+                f'<text x="{cx}" y="{cy}" fill="{t["partial"]}" font-size="{MARK_FS}" text-anchor="middle">~</text>'
+            )
+    return out
+
+
+def _data_rows(lay):
+    """Category bands and the solver rows beneath each, in declaration order."""
+    t, out = lay.t, []
+    y = lay.y_header_base
+    for ci, category in enumerate(lay.categories):
+        # A semi-transparent band behind every category label, so all categories read as peers —
+        # otherwise a one-row category looks like a caption for the row beneath it. Translucent on
+        # purpose: the vertical group bands stay visible through it.
+        out.append(
+            f'<rect x="{PAD}" y="{y}" width="{lay.table_w}" height="{CAT_H}" '
+            f'fill="{t["cat_band"]}" fill-opacity="{t["cat_band_opacity"]}"/>'
+        )
+        out.append(
+            f'<text x="{PAD}" y="{y + CAT_H - 6}" fill="{t["muted"]}" font-size="{SMALL_FS}" '
+            f'font-weight="600" letter-spacing="0.5">{esc(category.upper())}</text>'
+        )
+        y += CAT_H
+        for row in [r for r in lay.rows if r["category"] == ci]:
+            own = row["name"] == "max-div"
+            weight = "700" if own else "400"
+            if own:
+                out.append(f'<rect x="{PAD}" y="{y}" width="{lay.table_w}" height="{ROW_H}" fill="{t["own_band"]}"/>')
+            out.append(lay.rule(y))
+            out.append(
+                f'<text x="{PAD + 2}" y="{y + ROW_H - 7}" fill="{t["ink"]}" '
+                f'font-size="{NAME_FS}" font-weight="{weight}">{esc(row["name"])}</text>'
+            )
+            out.extend(_row_marks(lay, row, y))
+            out.append(
+                f'<text x="{lay.col_x(lay.n_marks) + SCALE_W // 2}" y="{y + ROW_H - 7}" fill="{t["ink"]}" '
+                f'font-size="{SCALE_FS}" font-weight="{weight}" text-anchor="middle">'
+                f"{scale_markup(row['scale'])}</text>"
+            )
+            y += ROW_H
+    return out, y
+
+
+def _legend(lay, y):
+    """The mark legend under the table."""
+    t = lay.t
+    return [
+        f'<text x="{PAD}" y="{y + CAPTION_H - 8}" font-size="{SMALL_FS}">'
+        f'<tspan fill="{t["mark"]}" font-weight="700">✓</tspan>'
+        f'<tspan fill="{t["muted"]}" dx="5">built in</tspan>'
+        f'<tspan fill="{t["muted"]}" dx="9">·</tspan>'
+        f'<tspan fill="{t["partial"]}" font-weight="700" dx="9">~</tspan>'
+        f'<tspan fill="{t["muted"]}" dx="5">reachable, but you supply the model, kernel or metric</tspan>'
+        f"</text>"
+    ]
+
+
+def build_svg(categories, rows, theme_name):
+    """Return the SVG document for one theme."""
+    lay = _Layout(categories, rows, theme_name)
+    font = "-apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif"
+    out = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{lay.width}" height="{lay.height}" '
+        f'viewBox="0 0 {lay.width} {lay.height}" font-family="{font}">',
+        f'<rect width="{lay.width}" height="{lay.height}" fill="{lay.t["bg"]}"/>',
+    ]
+    out += _group_bands(lay)
+    out += _column_headers(lay)
+    rows_out, y = _data_rows(lay)
+    out += rows_out
+    out.append(lay.rule(y))
+    out += _legend(lay, y)
+    out.append("</svg>")
+    return "\n".join(out) + "\n"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="fail if the committed SVGs differ from a fresh render")
+    args = parser.parse_args()
+
+    categories, rows = parse_data(DATA_FILE.read_text(encoding="utf-8"))
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    stale = []
+    for theme in THEMES:
+        target = OUT_DIR / f"hero_{theme}.svg"
+        svg = build_svg(categories, rows, theme)
+        if args.check:
+            if not target.exists() or target.read_text(encoding="utf-8") != svg:
+                stale.append(target.name)
+        else:
+            target.write_text(svg, encoding="utf-8")
+            print(f"wrote {target.relative_to(REPO_ROOT)}")
+    if args.check:
+        if stale:
+            print(f"stale (re-run scripts/build_hero_table.py): {', '.join(stale)}", file=sys.stderr)
+            return 1
+        print("hero SVGs are up to date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/build_hero_table.py
+++ b/scripts/build_hero_table.py
@@ -56,7 +56,7 @@ THEMES = {
         "rule": "#d8dee4",
         "band": "#f6f8fa",
         "mark": "#1a7f37",
-        "partial": "#9a6700",
+        "partial": "#8c959f",
         "own_band": "#ddf4e4",
         "cat_band": "#57606a",
         "cat_band_opacity": "0.06",
@@ -69,7 +69,7 @@ THEMES = {
         "rule": "#30363d",
         "band": "#161b22",
         "mark": "#3fb950",
-        "partial": "#d29922",
+        "partial": "#8b949e",
         "own_band": "#12261e",
         "cat_band": "#c9d1d9",
         "cat_band_opacity": "0.05",
@@ -130,12 +130,16 @@ SUP_DY = 4  # how far the exponent is raised
 def scale_markup(spec):
     """`4-5` -> `~10^4 en-dash 10^5` as SVG markup, `3` -> `~10^3`.
 
+    The leading tilde is the same glyph as the `partial` mark, which is a deliberate choice
+    rather than an oversight: an approximation sign was tried and read worse. The two senses are
+    told apart by column, and by the marks being grey while the figures are ink or green.
+
     Exponents are `<tspan>`s rather than unicode superscript characters: those are locked to
     roughly 0.6x the surrounding size, which is too small to read at this scale. `dy` shifts are
     cumulative in SVG, so every raised span is followed by an equal lowering span.
 
-    Every figure carries a leading `~`: these are indicative orders of magnitude, not measured
-    ceilings, and the binding limit differs per tool (memory, runtime, dimensionality).
+    The figures are indicative orders of magnitude, not measured ceilings, and the binding limit
+    differs per tool (memory, runtime, dimensionality).
     """
 
     def sup(digits):
@@ -179,6 +183,15 @@ class _Layout:
         self.y_corner = self.y_header_base - CORNER_LIFT
         self.skew = self.y_corner - self.y_top  # a 45-degree edge shifts right by its own height
         self.table_w = LABEL_W + self.grid_w
+
+    def leads_on_scale(self, row):
+        """True for the row(s) carrying the highest scale figure.
+
+        Deliberately not keyed to max-div: the leader here is a competitor, and saying so is the
+        point of showing the column at all.
+        """
+        best = max(int(r["scale"].split("-")[-1]) for r in self.rows)
+        return int(row["scale"].split("-")[-1]) == best
 
     def col_x(self, i):
         """Left edge of mark column i."""
@@ -284,6 +297,8 @@ def _data_rows(lay):
         y += CAT_H
         for row in [r for r in lay.rows if r["category"] == ci]:
             own = row["name"] == "max-div"
+            # `own` drives exactly two things: this weight, applied to the row name, and the band
+            # below. The mark glyphs are styled uniformly across all rows.
             weight = "700" if own else "400"
             if own:
                 out.append(f'<rect x="{PAD}" y="{y}" width="{lay.table_w}" height="{ROW_H}" fill="{t["own_band"]}"/>')
@@ -293,9 +308,15 @@ def _data_rows(lay):
                 f'font-size="{NAME_FS}" font-weight="{weight}">{esc(row["name"])}</text>'
             )
             out.extend(_row_marks(lay, row, y))
+            leads = lay.leads_on_scale(row)
+            scale_fill = t["mark"] if leads else t["ink"]
+            # Bold in this column means "leads on scale" and nothing else. The row-name weight is
+            # a separate signal (the subject), so inheriting it here would imply max-div leads a
+            # column it does not.
+            scale_weight = "700" if leads else "400"
             out.append(
-                f'<text x="{lay.col_x(lay.n_marks) + SCALE_W // 2}" y="{y + ROW_H - 7}" fill="{t["ink"]}" '
-                f'font-size="{SCALE_FS}" font-weight="{weight}" text-anchor="middle">'
+                f'<text x="{lay.col_x(lay.n_marks) + SCALE_W // 2}" y="{y + ROW_H - 7}" fill="{scale_fill}" '
+                f'font-size="{SCALE_FS}" font-weight="{scale_weight}" text-anchor="middle">'
                 f"{scale_markup(row['scale'])}</text>"
             )
             y += ROW_H
@@ -311,7 +332,7 @@ def _legend(lay, y):
         f'<tspan fill="{t["muted"]}" dx="5">built in</tspan>'
         f'<tspan fill="{t["muted"]}" dx="9">·</tspan>'
         f'<tspan fill="{t["partial"]}" font-weight="700" dx="9">~</tspan>'
-        f'<tspan fill="{t["muted"]}" dx="5">reachable, but you supply the model, kernel or metric</tspan>'
+        f'<tspan fill="{t["muted"]}" dx="5">reachable, but you supply the model, transform or metric</tspan>'
         f"</text>"
     ]
 

--- a/scripts/build_hero_table.py
+++ b/scripts/build_hero_table.py
@@ -40,8 +40,9 @@ SCALE_W = 90  # wide enough for the group label "max practical n" to sit over it
 ROW_H = 23
 HEADER_H = 132  # room for the 45-degree labels
 GROUP_H = 18
-CAPTION_H = 26
+CAPTION_H = 21  # band under the table holding the mark legend
 CAT_H = 20
+BOTTOM_PAD = 5  # less than PAD: the legend should sit close under the table, not centred
 CORNER_LIFT = 15  # where the band edge turns diagonal, above the first row
 PAD = 14
 HEADER_FS = 12  # header font size; the width estimate below is calibrated to it
@@ -172,7 +173,9 @@ class _Layout:
         self.header_h = self.overhang + 18
 
         self.width = PAD + LABEL_W + self.grid_w + self.overhang + PAD
-        self.height = PAD + GROUP_H + self.header_h + len(categories) * CAT_H + len(rows) * ROW_H + CAPTION_H + PAD
+        self.height = (
+            PAD + GROUP_H + self.header_h + len(categories) * CAT_H + len(rows) * ROW_H + CAPTION_H + BOTTOM_PAD
+        )
 
         self.y_group = PAD + GROUP_H - 6
         self.y_top = PAD + GROUP_H  # bands start here, just under the group labels

--- a/scripts/hero_table_data.txt
+++ b/scripts/hero_table_data.txt
@@ -27,8 +27,8 @@ HiGHS              | ~ ~ ~ Y | ~ ~ ~ ~ | ~ ~ ~ | Y Y ~ | 3   | https://ergo-code
 
 [category] One-shot pickers & samplers
 RDKit MaxMinPicker | ~ ~ ~ Y | Y . . . | . . . | . . . | 6   | https://www.rdkit.org/docs/source/rdkit.SimDivFilters.rdSimDivPickers.html
-skmatter           | . Y ~ . | Y . . . | . . . | . . . | 5   | https://scikit-matter.readthedocs.io/
 fpsample           | . Y ~ . | Y . . . | . . . | . . . | 6   | https://github.com/leonardodalinky/fpsample
+skmatter           | . Y ~ . | Y . . . | . . . | . . . | 5   | https://scikit-matter.readthedocs.io/
 apricot-select     | Y Y Y Y | . . . Y | . . . | . . . | 5   | https://apricot-select.readthedocs.io/
 qc-selector        | Y Y ~ Y | Y . . Y | Y . . | ~ . . | 4   | https://selector.qcdevs.org/
 DPPy               | ~ ~ ~ Y | . . . . | . . . | ~ . . | 4   | https://dppy.readthedocs.io/

--- a/scripts/hero_table_data.txt
+++ b/scripts/hero_table_data.txt
@@ -1,0 +1,35 @@
+# Capability data for the README hero table. Rendered by scripts/build_hero_table.py.
+#
+# Marks:  Y = implemented as a feature      ~ = reachable, but the caller supplies
+#                                               a model / kernel / callback / normalization
+#         . = not reachable
+#
+# Columns, in order:
+#   L1  L2  cos cust    distance metrics
+#   mm  mnn gnn ms      objectives: max-min, mean-of-NN, geomean-of-NN, max-sum
+#   dsj ovl rng         constraints: disjoint groups, overlapping groups, ranged counts
+#   it  wc  imp         budgets: iteration count, wall clock, improves with budget
+#   scale               max practical n, as a power of ten
+#
+# One source URL per tool. Every mark on a row must be defensible from it.
+# Keep rows within a category in the order they should render.
+# "category" deliberately avoids the word "tier": the benchmark pages use tier 1/2/3 for
+# comparison targets, which is a different taxonomy (max-div is never a tier there, and
+# tier 3 is a published dataset rather than a tool).
+
+[category] Anytime optimizers
+max-div            | Y Y Y Y | Y Y Y Y | Y Y Y | Y Y Y | 4-5 | https://max-div.readthedocs.io/
+
+[category] Exact solvers
+OR-Tools CP-SAT    | ~ ~ ~ Y | ~ ~ ~ ~ | ~ ~ ~ | Y Y ~ | 3   | https://developers.google.com/optimization/cp/cp_solver
+SCIP               | ~ ~ ~ Y | ~ ~ ~ ~ | ~ ~ ~ | Y Y ~ | 3   | https://www.scipopt.org/
+HiGHS              | ~ ~ ~ Y | ~ ~ ~ ~ | ~ ~ ~ | Y Y ~ | 3   | https://ergo-code.github.io/HiGHS/
+
+[category] One-shot pickers & samplers
+RDKit MaxMinPicker | ~ ~ ~ Y | Y . . . | . . . | . . . | 6   | https://www.rdkit.org/docs/source/rdkit.SimDivFilters.rdSimDivPickers.html
+skmatter           | . Y ~ . | Y . . . | . . . | . . . | 5   | https://scikit-matter.readthedocs.io/
+fpsample           | . Y ~ . | Y . . . | . . . | . . . | 6   | https://github.com/leonardodalinky/fpsample
+apricot-select     | Y Y Y Y | . . . Y | . . . | . . . | 5   | https://apricot-select.readthedocs.io/
+qc-selector        | Y Y ~ Y | Y . . Y | Y . . | ~ . . | 4   | https://selector.qcdevs.org/
+DPPy               | ~ ~ ~ Y | . . . . | . . . | ~ . . | 4   | https://dppy.readthedocs.io/
+code-FDM           | ~ Y ~ Y | Y . . . | Y . . | . . . | 4   | https://github.com/yhwang1990/code-FDM

--- a/tests/test_hero_table.py
+++ b/tests/test_hero_table.py
@@ -1,0 +1,150 @@
+"""Guards for the generated README hero table.
+
+The committed SVGs are build products of `scripts/build_hero_table.py` plus its companion data
+file. These tests pin two things: that the committed bytes still match a fresh render (so an
+edit to either the generator or the data cannot land without the images following), and that
+the data file itself is well formed.
+"""
+
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "build_hero_table.py"
+
+
+def _load_builder():
+    """Import the generator by path — `scripts/` is maintainer tooling, not an importable package."""
+    spec = importlib.util.spec_from_file_location("build_hero_table", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def builder():
+    return _load_builder()
+
+
+@pytest.fixture(scope="module")
+def parsed(builder):
+    return builder.parse_data(builder.DATA_FILE.read_text(encoding="utf-8"))
+
+
+# =================================================================================================
+#  Drift
+# =================================================================================================
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_committed_svg_matches_fresh_render(builder, parsed, theme):
+    # --- arrange -----------------------------------------
+    categories, rows = parsed
+    committed = builder.OUT_DIR / f"hero_{theme}.svg"
+
+    # --- act ---------------------------------------------
+    rendered = builder.build_svg(categories, rows, theme)
+
+    # --- assert ------------------------------------------
+    assert committed.read_text(encoding="utf-8") == rendered, (
+        f"docs/images/hero_{theme}.svg is stale — re-run scripts/build_hero_table.py"
+    )
+
+
+def test_render_is_deterministic(builder, parsed):
+    # --- arrange -----------------------------------------
+    categories, rows = parsed
+
+    # --- act ---------------------------------------------
+    first = builder.build_svg(categories, rows, "light")
+    second = builder.build_svg(categories, rows, "light")
+
+    # --- assert ------------------------------------------
+    assert first == second
+
+
+def test_computed_geometry_is_integral(builder, parsed):
+    """No computed coordinate may be a float.
+
+    Determinism is the reason: a float formatted from platform-dependent arithmetic would make
+    the committed bytes irreproducible and the drift test above flaky. Author-chosen literals
+    (font sizes, stroke widths, opacities) are exempt — they cannot vary between runs.
+    """
+    # --- arrange -----------------------------------------
+    categories, rows = parsed
+    geometry = ("x", "y", "x1", "y1", "x2", "y2", "width", "height", "dx", "dy", "points")
+
+    # --- act ---------------------------------------------
+    svg = builder.build_svg(categories, rows, "light")
+    offenders = []
+    for attr in geometry:
+        for value in re.findall(rf'\b{attr}="([^"]+)"', svg):
+            if "." in value:
+                offenders.append(f"{attr}={value}")
+
+    # --- assert ------------------------------------------
+    assert not offenders, f"non-integer geometry would break reproducibility: {offenders}"
+
+
+# =================================================================================================
+#  Companion data file
+# =================================================================================================
+def test_every_row_has_a_mark_per_column(builder, parsed):
+    # --- arrange -----------------------------------------
+    _categories, rows = parsed
+    expected = sum(len(cols) for _, cols in builder.GROUPS) - 1  # the scale column is not a mark
+
+    # --- act / assert ------------------------------------
+    for row in rows:
+        assert len(row["marks"]) == expected, row["name"]
+
+
+def test_marks_use_only_the_documented_vocabulary(builder, parsed):
+    # --- arrange -----------------------------------------
+    _categories, rows = parsed
+
+    # --- act / assert ------------------------------------
+    for row in rows:
+        unknown = set(row["marks"]) - {"Y", "~", "."}
+        assert not unknown, f"{row['name']}: unknown mark(s) {sorted(unknown)}"
+
+
+def test_every_row_cites_a_source(builder, parsed):
+    """Each tool's marks must be defensible from one cited URL."""
+    # --- arrange -----------------------------------------
+    _categories, rows = parsed
+
+    # --- act / assert ------------------------------------
+    for row in rows:
+        assert row["source"].startswith("https://"), f"{row['name']}: source is not an https URL"
+
+
+def test_every_row_belongs_to_a_named_category(builder, parsed):
+    # --- arrange -----------------------------------------
+    categories, rows = parsed
+
+    # --- act / assert ------------------------------------
+    assert categories, "no categories declared"
+    for row in rows:
+        assert 0 <= row["category"] < len(categories), f"{row['name']}: row precedes its category header"
+
+
+def test_scale_values_are_powers_of_ten(builder, parsed):
+    # --- arrange -----------------------------------------
+    _categories, rows = parsed
+
+    # --- act / assert ------------------------------------
+    for row in rows:
+        assert re.fullmatch(r"\d(-\d)?", row["scale"]), f"{row['name']}: scale {row['scale']!r} is not `x` or `x-y`"
+
+
+def test_max_div_is_present_and_first(builder, parsed):
+    """The subject leads the table; the rendering also keys its highlight off this name."""
+    # --- arrange -----------------------------------------
+    _categories, rows = parsed
+
+    # --- act / assert ------------------------------------
+    assert rows[0]["name"] == "max-div"


### PR DESCRIPTION
**TL;DR**: The README now opens with a capability table comparing max-div against ten surveyed tools across fifteen features, generated from a committed script and data file.

## Description

### Problem addressed

The README claimed max-div's differentiators in prose — the only dedicated diversity solver with overlapping fairness constraints, the only one with a geometric-mean objective — and gave a reader no way to check them without leaving for the docs. The docs comparison page has the detail, but it is one dense matrix on another page, which is the wrong shape for someone deciding in thirty seconds whether the library is worth their time.

### Implementation

A pure-Python SVG generator, no plotting dependency: a capability table is `<rect>`, `<text>` and one `<polygon>` per column group. Two variants, light and dark, selected with `<picture>` and `prefers-color-scheme`.

**The mark vocabulary is what makes the table honest.** A check means the tool implements the feature; a tilde means it is reachable but the caller supplies the missing piece — a model, a kernel, a callback, a normalization. That distinction is the whole argument: an exact solver will optimize any of the four objectives *if you write the assignment MILP yourself*, so a blank cell would be a lie and a check would be a different lie. The tilde also removes the need for paired native/non-native columns, which would have doubled the width.

Consequences worth noting: max-div's row is the only one that is built-in throughout, which is the accurate version of the "implemented nowhere else" claim. And it does not win every row — apricot matches it on distance metrics, and three tools beat it on practical scale.

**Each column group's band is slanted 45 degrees through the header region**, parallel to the rotated labels, so every label sits inside its own column's band the whole way up rather than floating above the table.

Determinism is a requirement, not a nicety: all computed geometry is integer, so re-running reproduces the committed bytes and the drift test can compare them directly instead of hashing inputs — which catches a change to the generator as well as to the data.

## Attention points

- **PyPI needed a second URL-rewriting rule.** Its sanitizer drops `<picture>`/`<source>` and keeps the `<img>`, so PyPI shows the light variant, which is right for a page with no dark mode — but only if that URL is absolute, and the existing rule matched neither `srcset` nor paths under `docs/`. Verified by building the wheel and reading the long-description metadata, not by simulating the regex.
- **Each SVG carries its own opaque background on purpose.** GitHub exposes no hook for its own theme setting, so `prefers-color-scheme` follows the reader's operating system; someone who pinned GitHub dark against a light OS gets the light variant, and an opaque panel keeps it legible rather than putting dark ink on a dark page. There is no fix for the mismatch itself.
- **The tilde is overloaded.** It is a mark in the fourteen mark columns and means "approximately" in the scale figures. Deliberate, but a reader could conflate them; `≈` for the figures would separate the two senses.
- **Category labels are not benchmark tiers.** The benchmark pages use tier 1/2/3 for comparison targets, which is a different taxonomy — max-div is never a tier there, and tier 3 is a published dataset rather than a tool. The data file records this so the word does not creep back in.
- **The one-member category is intentional.** No other surveyed tool is both non-exact and anytime; the nearest candidate optimizes coverage rather than dispersion and is excluded from the comparison on those grounds.

## Tests / Spikes

- **SPIKE:** verified nine of the eleven tools against their installed packages rather than their documentation, which is where most of these cells came from — including one finding that a shipped selector in `apricot-select` optimizes the max-sum objective under a different name, checked against brute force on small instances.
- **TEST:** rendered both variants to PNG and inspected them at 2x, which caught what a passing suite would not have: labels clipping off the right edge, and a rotation that sent the header text down into the data rows because SVG's y axis points down.
- **TEST:** built the wheel and read the PyPI long-description to confirm no relative image URL survives.
- **TEST:** `make lint`, `make test` (3575 passed), docs build clean.
- 10 unit tests added: the two committed SVGs against a fresh render, render determinism, integer-only geometry, and five checks on the data file (one mark per column, known marks only, an https source per row, every row inside a declared category, scale figures well formed).

## Changelog entry

Added:

```
At-a-glance capability-comparison table at the top of the README
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
