### PR TITLE
chore: run make test on the same install surface as CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ build:
 
 test:
 	# run all tests - with numba & just 1 python version
-	uv run --all-extras --python 3.13 pytest ./tests --durations=20 --disable-warnings
+	# --group dev, NOT --all-extras: the same install surface the CI matrix uses, so a test that
+	# reaches for an optional dependency (e.g. anything in the docs extra) fails here too
+	uv run --group dev --python 3.13 pytest ./tests --durations=20 --disable-warnings
 
 test-benchmarks:
 	# comparison-benchmark harness tests - separate from the package suite (needs the benchmarks deps groups)
@@ -50,8 +52,8 @@ coverage:
 	# NOTE: NUMBA_DISABLE_JIT ensure coverage collects detailed line-by-line coverage info, also for numba-compiled functions
     #       NUMBA_JIT_COVERAGE is another option, but would incorrectly emit coverage info for ALL compiled lines, when a function is triggered.
 	mkdir -p ./reports
-	# run tests with Python 3.14; WITH ALL optional dependencies & append to report
-	NUMBA_DISABLE_JIT=1 COVERAGE_FILE=./reports/.coverage uv run --all-extras --python 3.13 pytest ./tests --cov --cov-report=html:./reports/coverage --durations=20 --disable-warnings
+	# run tests on the same install surface as the CI coverage legs (see the note under `test`)
+	NUMBA_DISABLE_JIT=1 COVERAGE_FILE=./reports/.coverage uv run --group dev --python 3.13 pytest ./tests --cov --cov-report=html:./reports/coverage --durations=20 --disable-warnings
 
 test-and-coverage:
 	$(MAKE) test;


### PR DESCRIPTION
**Problem**: The local test targets installed **all optional extras**, while the CI matrix installs **only the dev group**. A test importing an extras-only package therefore passed locally and failed across every matrix leg.

**Solution**: Both `test` and `coverage` now run on the dev group, matching what the matrix and the coverage legs install. The suite passes unchanged on the narrower surface, so nothing in the tests actually needed an extra.

- **Attention:** This closes the gap in one direction only — the flags still live in two places. Making the workflow invoke these targets, so there is a single definition of how the suite runs, is the follow-up that removes the drift rather than re-aligning it.
- **Attention:** The differences that remain between the two are deliberate and stay: CI re-resolves without the lock, sweeps four Python versions plus a free-threaded build, and exercises both resolution ends. Reproducing those on a developer machine would cost minutes per run for a rarer class of break.
- **TEST:** ran the suite on the narrowed surface (3584 passed), the coverage target with the JIT disabled (3584 passed, gate cleared), and the lint suite.

**Changelog** (none): tooling only, with no effect on the published package.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
