### PR TITLE
chore: drive the CI test matrix through the Makefile targets

### DIFF
--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -49,6 +49,10 @@ runs:
         # but removing the committed lock guarantees the matrix leg is never pinned by it.
         run: rm -f uv.lock
 
+      # `make test`, not a bare `uv run`: the interpreter, resolution strategy and dependency
+      # group are defined once, in the Makefile, so this matrix and a developer's local run
+      # cannot drift apart. Only the genuinely CI-side concerns stay here — the JIT toggle, the
+      # coverage flags, and the per-combo data file.
       - name: Run tests
         shell: bash
         env:
@@ -64,7 +68,8 @@ runs:
           COV_FLAG=""
           # --cov-fail-under=0: the gate is cumulative (coverage job), not per-combo
           [ "$COV" = "true" ] && COV_FLAG="--cov --cov-report= --cov-fail-under=0"
-          uv run --python "$PY" --resolution "$RES" --group dev pytest ./tests $COV_FLAG --durations=20
+          # PYTEST_ARGS replaces the Makefile default, so warnings stay visible in CI
+          make test PY="$PY" RESOLUTION="$RES" PYTEST_ARGS="$COV_FLAG"
 
       - name: Dump collected node-ids (for the cross-combo test-count union)
         if: inputs.coverage == 'true'
@@ -74,10 +79,8 @@ runs:
           RES: ${{ inputs.dependency_resolution }}
           JIT: ${{ inputs.jit }}
         run: |
-          # -o addopts="" clears `-n auto`, so collection runs single-process (xdist off);
-          # each combo records its own collected set so the coverage job can union them.
-          uv run --python "$PY" --resolution "$RES" --group dev \
-            pytest ./tests --collect-only -q -o addopts="" \
+          # each combo records its own collected set so the coverage job can union them
+          make collect-test-ids PY="$PY" RESOLUTION="$RES" \
             | grep '::' > "test-ids-${PY}-${RES}-${JIT}.txt"
 
       - name: Upload coverage + node-id data

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,20 @@
 file_path=
 
-.PHONY: help build test coverage test-and-coverage format format-single-file lint dev-setup release splash docs show-coverage show-docs update-internal-benchmarks update-solver-strategies-benchmarks update-all-benchmarks update-solver-benchmark-figures
+# --- how the package suite is installed and run ------------
+# Single definition, shared by every target below AND by the CI test matrix, which calls these
+# targets rather than repeating the command. That is the point: the interpreter, the resolution
+# strategy and the dependency group cannot drift between a developer machine and CI, because
+# there is only one place that names them. CI overrides PY and RESOLUTION per matrix leg; the
+# defaults are the single representative combo to run locally.
+PY ?= 3.13
+RESOLUTION ?= highest
+UV_RUN = uv run --python $(PY) --resolution $(RESOLUTION) --group dev
+
+# Appended to the pytest invocation. Locally this silences the warning summary; CI overrides it
+# to pass coverage flags, and deliberately keeps the warnings visible.
+PYTEST_ARGS ?= --disable-warnings
+
+.PHONY: help build test collect-test-ids coverage test-and-coverage format format-single-file lint dev-setup release splash docs show-coverage show-docs update-internal-benchmarks update-solver-strategies-benchmarks update-all-benchmarks update-solver-benchmark-figures
 
 help:
 	@echo 'Commands:'
@@ -10,6 +24,7 @@ help:
 	@echo '  build                                  (Re)build package using uv.'
 	@echo ''
 	@echo '  test                                   Run pytest unit tests.'
+	@echo '  collect-test-ids                       List collected test node-ids without running them.'
 	@echo '  coverage                               Generate test coverage report. (./reports/coverage)'
 	@echo '  test-and-coverage                      Run unit tests (=with numba) + generate coverage report (=without numba).'
 	@echo ''
@@ -34,15 +49,24 @@ help:
 	@echo 'Options:'
 	@echo ''
 	@echo '  format-single-file             - accepts `file_path=<path>` to pass the relative path of the file to be formatted.'
+	@echo '  test / collect-test-ids / coverage'
+	@echo '                                 - accept `PY=<version>` and `RESOLUTION=highest|lowest-direct` to pick the'
+	@echo '                                   interpreter and uv resolution strategy, and `PYTEST_ARGS=<flags>` to replace'
+	@echo '                                   the default pytest flags. The CI matrix drives these targets that way.'
 
 build:
 	uv build;
 
 test:
-	# run all tests - with numba & just 1 python version
-	# --group dev, NOT --all-extras: the same install surface the CI matrix uses, so a test that
-	# reaches for an optional dependency (e.g. anything in the docs extra) fails here too
-	uv run --group dev --python 3.13 pytest ./tests --durations=20 --disable-warnings
+	# run all tests - with numba & one interpreter (see PY / RESOLUTION above)
+	$(UV_RUN) pytest ./tests --durations=20 $(PYTEST_ARGS)
+
+# Collected node-ids, one per line. CI unions these across matrix legs to count the suite, so this
+# target's stdout is data: it is written with `@` and its commentary lives here rather than in the
+# recipe, since an echoed recipe line would land in whatever consumes the list.
+# -o addopts="" clears `-n auto`, so collection runs in-process instead of under xdist.
+collect-test-ids:
+	@$(UV_RUN) pytest ./tests --collect-only -q -o addopts=""
 
 test-benchmarks:
 	# comparison-benchmark harness tests - separate from the package suite (needs the benchmarks deps groups)
@@ -52,8 +76,8 @@ coverage:
 	# NOTE: NUMBA_DISABLE_JIT ensure coverage collects detailed line-by-line coverage info, also for numba-compiled functions
     #       NUMBA_JIT_COVERAGE is another option, but would incorrectly emit coverage info for ALL compiled lines, when a function is triggered.
 	mkdir -p ./reports
-	# run tests on the same install surface as the CI coverage legs (see the note under `test`)
-	NUMBA_DISABLE_JIT=1 COVERAGE_FILE=./reports/.coverage uv run --group dev --python 3.13 pytest ./tests --cov --cov-report=html:./reports/coverage --durations=20 --disable-warnings
+	# same install surface as `test` and as the CI coverage legs (see PY / RESOLUTION above)
+	NUMBA_DISABLE_JIT=1 COVERAGE_FILE=./reports/.coverage $(UV_RUN) pytest ./tests --cov --cov-report=html:./reports/coverage --durations=20 $(PYTEST_ARGS)
 
 test-and-coverage:
 	$(MAKE) test;


### PR DESCRIPTION
**Problem**: The interpreter, resolution strategy and dependency group were spelled out **twice** — once in the Makefile, once in the test workflow. Re-aligning them fixes today's mismatch but leaves the mechanism that produced it.

**Solution**: The Makefile names that install surface **once** and accepts `PY`, `RESOLUTION` and `PYTEST_ARGS` overrides. The workflow passes the matrix values into `make test`, keeping only what is genuinely CI-side: the JIT toggle, the coverage flags, and the per-combo coverage data file. Test collection for the cross-leg test count becomes a target on the same footing.

- **Attention:** Deleting the checked-out lock so each leg re-resolves **stays in the workflow**, deliberately. A Makefile target that silently removed a developer's lock file would be a genuinely nasty surprise, and re-resolving is a CI concern rather than a local one.
- **Attention:** The collection target writes its output with `@` and keeps its commentary above the recipe rather than inside it. Its stdout is consumed as data, and an echoed recipe line would land in the consumer.
- **Attention:** Warnings stay visible in CI. The Makefile default silences the summary locally; passing `PYTEST_ARGS` replaces that default rather than adding to it, which preserves current workflow behavior.
- **TEST:** ran the workflow's exact invocations locally — the coverage-leg form (JIT disabled, coverage flags, 3584 passed) and an interpreter override to confirm `PY` really switches interpreters (3520 passed, 64 skipped, matching the known single-interpreter fingerprint on those cases). Also checked that the collection target emits only node-ids on stdout, and ran the lint suite so the workflow linters saw the change.

**Changelog** (none): tooling only, with no effect on the published package.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
