### PR TITLE
chore: split the dev dependency group by activity

### DIFF
--- a/.github/actions/pre_commit/action.yml
+++ b/.github/actions/pre_commit/action.yml
@@ -24,8 +24,8 @@ runs:
 
       - name: Install dependencies
         shell: bash
-        run: uv sync --group dev
+        run: uv sync --no-default-groups --group lint
 
       - name: Run pre-commit
         shell: bash
-        run: uv run pre-commit run --all-files --show-diff-on-failure
+        run: uv run --no-default-groups --group lint pre-commit run --all-files --show-diff-on-failure

--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -30,7 +30,7 @@ jobs:
       # Static gate: catches structurally broken wheels (empty, missing the
       # declared import package, ...) before the install job spins up.
       - name: Check wheel contents
-        run: uv run --frozen check-wheel-contents dist/*.whl
+        run: uv run --frozen --no-default-groups --group package check-wheel-contents dist/*.whl
 
       - name: Upload distribution artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -57,12 +57,12 @@ jobs:
           name: dist
           path: dist
 
-      # Blind environment: test deps come lockfile-pinned from the dev group
-      # (--no-emit-project keeps the project itself out), and max_div can only
-      # come from the built wheel — never an editable/source install.
+      # Blind environment: test deps come lockfile-pinned from the test group
+      # (--only-group keeps the project and its runtime dependencies out), and
+      # max_div can only come from the built wheel — never an editable/source install.
       - name: Install the built wheel into a bare environment
         run: |
-          uv export --frozen --no-emit-project --only-group dev -o requirements.txt
+          uv export --frozen --no-emit-project --only-group test -o requirements.txt
           uv venv blind-venv
           uv pip install --python blind-venv/bin/python -r requirements.txt
           WHEEL=(dist/*.whl)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,21 +16,21 @@ repos:
     hooks:
       - id: ruff-format
         name: ruff format
-        entry: uv run ruff format
+        entry: uv run --no-default-groups --group lint ruff format
         language: system
         types: [python]
         files: ^(src/max_div|tests|scripts)/|^\.github/scripts/
         pass_filenames: true
       - id: ruff
         name: ruff check
-        entry: uv run ruff check
+        entry: uv run --no-default-groups --group lint ruff check
         language: system
         types: [python]
         files: ^(src/max_div|tests|scripts)/|^\.github/scripts/
         pass_filenames: true
       - id: ty
         name: ty check
-        entry: uv run ty check
+        entry: uv run --no-default-groups --group lint ty check
         language: system
         types: [python]
         # ty is a whole-program checker: a staged-files-only run would miss

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ file_path=
 # strategy and the dependency group cannot drift between a developer machine and CI, because
 # there is only one place that names them. CI overrides PY and RESOLUTION per matrix leg; the
 # defaults are the single representative combo to run locally.
+# --no-default-groups is what makes the narrowing real: `--group test` alone only ADDS to the
+# default set, which still contains `dev`, so the linters would come along anyway. `--only-group`
+# is the wrong tool here — it drops the project and its runtime dependencies too.
 PY ?= 3.13
 RESOLUTION ?= highest
-UV_RUN = uv run --python $(PY) --resolution $(RESOLUTION) --group dev
+UV_RUN = uv run --exact --python $(PY) --resolution $(RESOLUTION) --no-default-groups --group test
 
 # Appended to the pytest invocation. Locally this silences the warning summary; CI overrides it
 # to pass coverage flags, and deliberately keeps the warnings visible.
@@ -83,16 +86,19 @@ test-and-coverage:
 	$(MAKE) test;
 	$(MAKE) coverage;
 
+# The two format targets name the lint group but deliberately do NOT pass --exact: they are wired
+# to editor save actions, and pruning the environment on every keystroke-triggered format would
+# yank packages out from under a docs server or test run in another terminal.
 format:
-	uv run ruff format .;
-	uv run ruff check --fix .;
+	uv run --no-default-groups --group lint ruff format .;
+	uv run --no-default-groups --group lint ruff check --fix .;
 
 format-single-file:
-	uv run ruff format ${file_path};
-	uv run ruff check --fix ${file_path};
+	uv run --no-default-groups --group lint ruff format ${file_path};
+	uv run --no-default-groups --group lint ruff check --fix ${file_path};
 
 lint:
-	uv run pre-commit run --all-files
+	uv run --exact --no-default-groups --group lint pre-commit run --all-files
 
 dev-setup:
 	uv sync --all-extras
@@ -110,7 +116,7 @@ splash:
 
 docs:
 	# output dir comes from mkdocs.yml (site_dir: ./reports/docs)
-	uv run --extra docs mkdocs build;
+	uv run --exact --no-default-groups --extra docs mkdocs build;
 
 show-coverage:
 	# trigger browser to open coverage report

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,13 @@ file_path=
 # strategy and the dependency group cannot drift between a developer machine and CI, because
 # there is only one place that names them. CI overrides PY and RESOLUTION per matrix leg; the
 # defaults are the single representative combo to run locally.
-# --no-default-groups is what makes the narrowing real: `--group test` alone only ADDS to the
-# default set, which still contains `dev`, so the linters would come along anyway. `--only-group`
-# is the wrong tool here — it drops the project and its runtime dependencies too.
+#
+# On the uv flags. Every `uv run` / `uv sync` implicitly activates a set of dependency groups —
+# uv's "default groups", which is `dev` unless a project configures otherwise. `--group` ADDS to
+# that set rather than replacing it, so `--group test` on its own installs test AND dev, and the
+# narrowing would be cosmetic. `--no-default-groups` empties the implicit set, leaving only what
+# is named. `--only-group` narrows as well, but additionally drops the project and its runtime
+# dependencies, which leaves pytest with nothing to import.
 PY ?= 3.13
 RESOLUTION ?= highest
 UV_RUN = uv run --exact --python $(PY) --resolution $(RESOLUTION) --no-default-groups --group test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,16 +75,32 @@ benchmarks = [
 benchmarks-gpl = [
     "qc-selector>=0.1",
 ]
-dev = [
-    "check-wheel-contents>=0.6.2",
-    "pre-commit>=4.0",
+# Split by activity, so what each one needs is a stated fact rather than a shared pile: the test
+# matrix installs no linters, and a test reaching for a lint-only or docs-only package fails as the
+# category error it is.
+test = [
     "pytest>=8.0",
     "pytest-cov>=6.0",
-    "ruff>=0.14.0",
     "pytest-xdist>=3.5.0",
     "pytest-rerunfailures>=14.0",
+]
+# The pre-commit config drives ruff and ty as local `uv run` hooks rather than pinned pre-commit
+# environments, so both tools — and the stubs ty needs to check scipy usage — belong here.
+lint = [
+    "pre-commit>=4.0",
+    "ruff>=0.14.0",
     "scipy-stubs>=1.10.0",
     "ty==0.0.58",  # pre-1.0 type checker — pin exactly; its ruleset is still evolving
+]
+package = [
+    "check-wheel-contents>=0.6.2",
+]
+# Union only — never add a requirement here directly. `dev` is what a developer syncs and what the
+# dependency audit exports, and it stays a derived fact so it cannot disagree with the groups above.
+dev = [
+    { include-group = "test" },
+    { include-group = "lint" },
+    { include-group = "package" },
 ]
 # notebook/analysis tooling — not needed to run the test suite, so kept out of the
 # dev group that CI installs (and out of the lowest-direct resolution surface)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ lint = [
     "pre-commit>=4.0",
     "ruff>=0.14.0",
     "scipy-stubs>=1.10.0",
-    "ty==0.0.58",  # pre-1.0 type checker — pin exactly; its ruleset is still evolving
+    "ty>=0.0.58",  # pre-1.0 type checker — floor only; uv.lock pins the version actually used
 ]
 package = [
     "check-wheel-contents>=0.6.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1907,13 +1907,13 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.5.0" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "scipy-stubs", specifier = ">=1.10.0" },
-    { name = "ty", specifier = "==0.0.58" },
+    { name = "ty", specifier = ">=0.0.58" },
 ]
 lint = [
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "scipy-stubs", specifier = ">=1.10.0" },
-    { name = "ty", specifier = "==0.0.58" },
+    { name = "ty", specifier = ">=0.0.58" },
 ]
 notebooks = [
     { name = "cvxpy", extras = ["ecos", "osqp"], specifier = ">=1.7.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -1837,11 +1837,26 @@ dev = [
     { name = "scipy-stubs" },
     { name = "ty" },
 ]
+lint = [
+    { name = "pre-commit" },
+    { name = "ruff" },
+    { name = "scipy-stubs" },
+    { name = "ty" },
+]
 notebooks = [
     { name = "cvxpy", extra = ["ecos"] },
     { name = "ipywidgets" },
     { name = "jupyter" },
     { name = "matplotlib" },
+]
+package = [
+    { name = "check-wheel-contents" },
+]
+test = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-rerunfailures" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -1894,11 +1909,24 @@ dev = [
     { name = "scipy-stubs", specifier = ">=1.10.0" },
     { name = "ty", specifier = "==0.0.58" },
 ]
+lint = [
+    { name = "pre-commit", specifier = ">=4.0" },
+    { name = "ruff", specifier = ">=0.14.0" },
+    { name = "scipy-stubs", specifier = ">=1.10.0" },
+    { name = "ty", specifier = "==0.0.58" },
+]
 notebooks = [
     { name = "cvxpy", extras = ["ecos", "osqp"], specifier = ">=1.7.1" },
     { name = "ipywidgets", specifier = ">=8.0.0" },
     { name = "jupyter", specifier = ">=1.1.0" },
     { name = "matplotlib", specifier = ">=3.3.0" },
+]
+package = [{ name = "check-wheel-contents", specifier = ">=0.6.2" }]
+test = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=6.0" },
+    { name = "pytest-rerunfailures", specifier = ">=14.0" },
+    { name = "pytest-xdist", specifier = ">=3.5.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
**TL;DR**: `dev` was one pile serving three different activities. It is now a union of `test`, `lint` and `package`, and each consumer installs only what it actually needs.

## Description

### Problem addressed

One group served the test suite, the linters and the packaging check, so **every leg of the test matrix installed linters it never runs**, and nothing recorded which activity needed which tool. That also made a whole class of mistake invisible: a test reaching for a lint-only or docs-only package looked fine, because everything was present everywhere.

### Implementation

Three groups by activity, with `dev` reduced to an `include-group` union of them — so what a developer syncs and what tooling exports stays a **derived fact** that cannot disagree with the parts. A comment marks it union-only; adding a requirement there directly would defeat the point.

Each consumer then names its group. Two details drove the flag choice, both verified rather than assumed:

- **`--group test` alone does not narrow anything.** It *adds* to the default set, which still contains `dev`, so the linters come along regardless. Narrowing needs `--no-default-groups`.
- **`--only-group` is the wrong tool** for running tests: it drops the project and its runtime dependencies too, leaving an environment with pytest and no package. It *is* right for the blind-environment install, where the package deliberately comes from the built wheel instead.

The run targets also pass `--exact`, so the environment is pruned to match rather than merely satisfied. Without it a developer machine keeps whatever was installed earlier and stays laxer than CI, which is the gap this work exists to close.

## Attention points

- **The format targets deliberately omit `--exact`.** They are wired to editor save actions, and pruning on every save would yank packages out from under a docs server or test run in another terminal. The same caution applies to `make test` while a docs server is running — it will prune the docs packages.
- **The dependency audit is unaffected.** It exports runtime dependencies only, so none of this reaches it. Separately confirmed that exporting the union group still resolves *through* the include-groups, which is what the blind-environment install relies on.
- **The blind-environment install narrowed from the whole pile to the test group**, which is what its own comment always claimed it was installing.
- **Alternating between activities costs about a tenth of a second**, since pruning and reinstalling comes from the local cache. This was measured before choosing `--exact`; had it been seconds, the trade would have gone the other way.
- **`make format` covers a wider tree than the lint hooks do** and reports pre-existing findings outside the linted paths. Untouched here — flagging it because it surprised me mid-change, and it is a pre-existing inconsistency rather than anything this introduces.

## Tests / Spikes

- **SPIKE:** probed uv's group semantics in throwaway environments before committing to any flag, inspecting the resulting site-packages directly. That is what established the two points above; an earlier read via a package listing reported the wrong environment and would have sent this the wrong way.
- **TEST:** ran the suite, the coverage target, the collection target, the lint suite, a docs build, and the workflow's exact coverage-leg invocation. Confirmed the docs build still emits correct image paths and that repeated switching between activities leaves every target working.

**Changelog** (none): tooling only, with no effect on the published package.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
