### PR TITLE
chore: run the test matrix on ARM

### DIFF
--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -51,14 +51,13 @@ jobs:
           python_version: ${{ matrix.python }}
           dependency_resolution: ${{ matrix.resolution }}
           jit: ${{ matrix.jit }}
-          # Declared per combo rather than derived from the jit axis, which stopped being
-          # the same statement once a single leg carried coverage.
+          # Only combos that opt in upload coverage data; the jit setting does not imply it.
           coverage: ${{ matrix.coverage && 'true' || 'false' }}
 
   coverage:
     name: coverage
-    # Combine-then-gate rather than gating in the leg: the floor belongs to the matrix as a
-    # whole, so a second coverage leg can be added back without moving where it is enforced.
+    # The coverage floor is checked here, on the combined data, rather than inside a test
+    # job — so it stays one gate over the matrix however many legs feed it.
     needs: [core]
     # always() so a cancelled/failed combo makes this job FAIL explicitly rather than
     # skip — GitHub doesn't reliably propagate a cancelled leg through needs.

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -9,7 +9,10 @@ permissions:
 jobs:
   core:
     name: py${{ matrix.python }} / ${{ matrix.resolution }} / jit-${{ matrix.jit }}
-    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    # ARM, which runs this suite about twice as fast as the x64 runner for the same work.
+    # Standardized rather than mixed: the matrix does not set out to test architectures, and
+    # picking x64 for some legs would be the old default dressed up as a decision.
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:
@@ -26,12 +29,8 @@ jobs:
           - { python: "3.14", resolution: highest,       jit: "on"  }
           - { python: "3.11", resolution: lowest-direct, jit: "on"  }
           - { python: "3.14", resolution: lowest-direct, jit: "on"  }
-          # The coverage legs run on ARM, which is roughly twice as fast for the same work.
-          # Safe for these two specifically because they run JIT-disabled, so the kernels are
-          # plain Python; the jit-on legs stay on x64, where the compilation target is part of
-          # what is under test.
-          - { python: "3.11", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }  # coverage leg
-          - { python: "3.14", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }  # coverage leg
+          - { python: "3.11", resolution: highest,       jit: "off" }  # coverage leg
+          - { python: "3.14", resolution: highest,       jit: "off" }  # coverage leg
           # Free-threaded build. `highest` only, deliberately: the numba floor for 3.14 is 0.63,
           # which predates numba's free-threaded wheels (first shipped in 0.65), and no PEP 508
           # marker can raise that floor for free-threaded builds alone — so a lowest-direct leg

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -20,12 +20,9 @@ jobs:
         # interpreted execution, and line coverage of njit functions is only possible with
         # the JIT disabled.
         #
-        # One jit-off leg, not one per Python version. A second was carried on the
-        # assumption that versions cover divergent lines; measured, they do not — nothing
-        # in the package branches on the Python version, and both legs reported an
-        # identical 99.96% over 2 missed statements. 3.14 is the one kept because it is
-        # markedly the cheaper: coverage traces through `sys.monitoring` from 3.12 onward,
-        # where 3.11 still pays for `sys.settrace`.
+        # One jit-off leg suffices: nothing in the package branches on the Python version,
+        # so a second covers no extra lines. 3.14 because coverage traces through
+        # `sys.monitoring` there, far cheaper than the `sys.settrace` 3.11 still uses.
         include:
           - { python: "3.11", resolution: highest,       jit: "on"  }
           - { python: "3.12", resolution: highest,       jit: "on"  }
@@ -33,12 +30,9 @@ jobs:
           - { python: "3.14", resolution: highest,       jit: "on"  }
           - { python: "3.11", resolution: lowest-direct, jit: "on"  }
           - { python: "3.14", resolution: lowest-direct, jit: "on"  }
-          # On ARM, where the same work measured 2m46s against 5m04s on the x64 runner in a
-          # single side-by-side run. Safe for this leg specifically because it runs with the
-          # JIT disabled: the kernels are plain Python there, so nothing architecture-
-          # dependent is being exercised. The jit-on legs stay on x64 for the opposite
-          # reason — those do compile through LLVM, where the target is part of what is
-          # under test, so moving them is a separate question rather than a free win.
+          # ARM is roughly twice as fast here, and safe because this leg runs JIT-disabled,
+          # so the kernels are plain Python. The jit-on legs stay on x64, where the
+          # compilation target is part of what is under test.
           - { python: "3.14", resolution: highest,       jit: "off", coverage: true, runner: ubuntu-24.04-arm }
           # Free-threaded build. `highest` only, deliberately: the numba floor for 3.14 is 0.63,
           # which predates numba's free-threaded wheels (first shipped in 0.65), and no PEP 508
@@ -57,16 +51,14 @@ jobs:
           python_version: ${{ matrix.python }}
           dependency_resolution: ${{ matrix.resolution }}
           jit: ${{ matrix.jit }}
-          # Declared per combo rather than derived from the jit axis: with a single jit-off
-          # leg the two are no longer the same statement, and a second jit-off combo that
-          # must not upload (the ARM probe) would silently collide on the artifact name.
+          # Declared per combo rather than derived from the jit axis, which stopped being
+          # the same statement once a single leg carried coverage.
           coverage: ${{ matrix.coverage && 'true' || 'false' }}
 
   coverage:
     name: coverage
-    # Kept as a combine-then-gate rather than folded into the leg itself: the gate belongs to
-    # the matrix as a whole, so a second coverage leg can be added back by declaring one,
-    # without moving where the floor is enforced.
+    # Combine-then-gate rather than gating in the leg: the floor belongs to the matrix as a
+    # whole, so a second coverage leg can be added back without moving where it is enforced.
     needs: [core]
     # always() so a cancelled/failed combo makes this job FAIL explicitly rather than
     # skip — GitHub doesn't reliably propagate a cancelled leg through needs.

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   core:
-    name: py${{ matrix.python }} / ${{ matrix.resolution }} / jit-${{ matrix.jit }}${{ matrix.runner && ' / arm' || '' }}
+    name: py${{ matrix.python }} / ${{ matrix.resolution }} / jit-${{ matrix.jit }}
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
@@ -17,12 +17,8 @@ jobs:
         # OS exercises everything. Strategic combos cover every axis (all four Pythons,
         # both resolution ends) rather than their full product. numba is a mandatory
         # dependency; the jit axis distinguishes compiled (representative) from
-        # interpreted execution, and line coverage of njit functions is only possible with
-        # the JIT disabled.
-        #
-        # One jit-off leg suffices: nothing in the package branches on the Python version,
-        # so a second covers no extra lines. 3.14 because coverage traces through
-        # `sys.monitoring` there, far cheaper than the `sys.settrace` 3.11 still uses.
+        # interpreted execution — coverage comes from the two jit-off legs, since numba
+        # only yields line coverage with the JIT disabled.
         include:
           - { python: "3.11", resolution: highest,       jit: "on"  }
           - { python: "3.12", resolution: highest,       jit: "on"  }
@@ -30,10 +26,12 @@ jobs:
           - { python: "3.14", resolution: highest,       jit: "on"  }
           - { python: "3.11", resolution: lowest-direct, jit: "on"  }
           - { python: "3.14", resolution: lowest-direct, jit: "on"  }
-          # ARM is roughly twice as fast here, and safe because this leg runs JIT-disabled,
-          # so the kernels are plain Python. The jit-on legs stay on x64, where the
-          # compilation target is part of what is under test.
-          - { python: "3.14", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }
+          # The coverage legs run on ARM, which is roughly twice as fast for the same work.
+          # Safe for these two specifically because they run JIT-disabled, so the kernels are
+          # plain Python; the jit-on legs stay on x64, where the compilation target is part of
+          # what is under test.
+          - { python: "3.11", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }  # coverage leg
+          - { python: "3.14", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }  # coverage leg
           # Free-threaded build. `highest` only, deliberately: the numba floor for 3.14 is 0.63,
           # which predates numba's free-threaded wheels (first shipped in 0.65), and no PEP 508
           # marker can raise that floor for free-threaded builds alone — so a lowest-direct leg
@@ -51,13 +49,13 @@ jobs:
           python_version: ${{ matrix.python }}
           dependency_resolution: ${{ matrix.resolution }}
           jit: ${{ matrix.jit }}
-          # the jit-off leg uploads its data; the coverage job combines + gates
+          # the jit-off legs upload their data; the coverage job combines + gates
           coverage: ${{ matrix.jit == 'off' && 'true' || 'false' }}
 
   coverage:
     name: coverage
-    # The coverage floor is checked here, on the combined data, rather than inside a test
-    # job — so it stays one gate over the matrix however many legs feed it.
+    # Cumulative gate: combine the coverage legs' data into one picture before checking
+    # the floor, so version-divergent code paths don't read as uncovered.
     needs: [core]
     # always() so a cancelled/failed combo makes this job FAIL explicitly rather than
     # skip — GitHub doesn't reliably propagate a cancelled leg through needs.

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
           # ARM is roughly twice as fast here, and safe because this leg runs JIT-disabled,
           # so the kernels are plain Python. The jit-on legs stay on x64, where the
           # compilation target is part of what is under test.
-          - { python: "3.14", resolution: highest,       jit: "off", coverage: true, runner: ubuntu-24.04-arm }
+          - { python: "3.14", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }
           # Free-threaded build. `highest` only, deliberately: the numba floor for 3.14 is 0.63,
           # which predates numba's free-threaded wheels (first shipped in 0.65), and no PEP 508
           # marker can raise that floor for free-threaded builds alone — so a lowest-direct leg
@@ -51,8 +51,8 @@ jobs:
           python_version: ${{ matrix.python }}
           dependency_resolution: ${{ matrix.resolution }}
           jit: ${{ matrix.jit }}
-          # Only combos that opt in upload coverage data; the jit setting does not imply it.
-          coverage: ${{ matrix.coverage && 'true' || 'false' }}
+          # the jit-off leg uploads its data; the coverage job combines + gates
+          coverage: ${{ matrix.jit == 'off' && 'true' || 'false' }}
 
   coverage:
     name: coverage

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -10,9 +10,6 @@ jobs:
   core:
     name: py${{ matrix.python }} / ${{ matrix.resolution }} / jit-${{ matrix.jit }}${{ matrix.runner && ' / arm' || '' }}
     runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
-    # Only the ARM probe is allowed to fail: it is a measurement, and an unavailable runner
-    # label would otherwise turn the gate red over something nothing depends on.
-    continue-on-error: ${{ matrix.runner != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -36,11 +33,13 @@ jobs:
           - { python: "3.14", resolution: highest,       jit: "on"  }
           - { python: "3.11", resolution: lowest-direct, jit: "on"  }
           - { python: "3.14", resolution: lowest-direct, jit: "on"  }
-          - { python: "3.14", resolution: highest,       jit: "off", coverage: true }
-          # TEMPORARY probe: the same work on an ARM runner, to measure what the
-          # architecture is worth on the leg that sets the critical path. Uploads nothing,
-          # so it cannot collide with the coverage leg's artifact. Remove before merge.
-          - { python: "3.14", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }
+          # On ARM, where the same work measured 2m46s against 5m04s on the x64 runner in a
+          # single side-by-side run. Safe for this leg specifically because it runs with the
+          # JIT disabled: the kernels are plain Python there, so nothing architecture-
+          # dependent is being exercised. The jit-on legs stay on x64 for the opposite
+          # reason — those do compile through LLVM, where the target is part of what is
+          # under test, so moving them is a separate question rather than a free win.
+          - { python: "3.14", resolution: highest,       jit: "off", coverage: true, runner: ubuntu-24.04-arm }
           # Free-threaded build. `highest` only, deliberately: the numba floor for 3.14 is 0.63,
           # which predates numba's free-threaded wheels (first shipped in 0.65), and no PEP 508
           # marker can raise that floor for free-threaded builds alone — so a lowest-direct leg

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -8,8 +8,11 @@ permissions:
 
 jobs:
   core:
-    name: py${{ matrix.python }} / ${{ matrix.resolution }} / jit-${{ matrix.jit }}
-    runs-on: ubuntu-latest
+    name: py${{ matrix.python }} / ${{ matrix.resolution }} / jit-${{ matrix.jit }}${{ matrix.runner && ' / arm' || '' }}
+    runs-on: ${{ matrix.runner || 'ubuntu-latest' }}
+    # Only the ARM probe is allowed to fail: it is a measurement, and an unavailable runner
+    # label would otherwise turn the gate red over something nothing depends on.
+    continue-on-error: ${{ matrix.runner != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -17,8 +20,15 @@ jobs:
         # OS exercises everything. Strategic combos cover every axis (all four Pythons,
         # both resolution ends) rather than their full product. numba is a mandatory
         # dependency; the jit axis distinguishes compiled (representative) from
-        # interpreted execution — coverage comes from the two jit-off legs, since numba
-        # only yields line coverage with the JIT disabled.
+        # interpreted execution, and line coverage of njit functions is only possible with
+        # the JIT disabled.
+        #
+        # One jit-off leg, not one per Python version. A second was carried on the
+        # assumption that versions cover divergent lines; measured, they do not — nothing
+        # in the package branches on the Python version, and both legs reported an
+        # identical 99.96% over 2 missed statements. 3.14 is the one kept because it is
+        # markedly the cheaper: coverage traces through `sys.monitoring` from 3.12 onward,
+        # where 3.11 still pays for `sys.settrace`.
         include:
           - { python: "3.11", resolution: highest,       jit: "on"  }
           - { python: "3.12", resolution: highest,       jit: "on"  }
@@ -26,8 +36,11 @@ jobs:
           - { python: "3.14", resolution: highest,       jit: "on"  }
           - { python: "3.11", resolution: lowest-direct, jit: "on"  }
           - { python: "3.14", resolution: lowest-direct, jit: "on"  }
-          - { python: "3.11", resolution: highest,       jit: "off" }  # coverage leg
-          - { python: "3.14", resolution: highest,       jit: "off" }  # coverage leg
+          - { python: "3.14", resolution: highest,       jit: "off", coverage: true }
+          # TEMPORARY probe: the same work on an ARM runner, to measure what the
+          # architecture is worth on the leg that sets the critical path. Uploads nothing,
+          # so it cannot collide with the coverage leg's artifact. Remove before merge.
+          - { python: "3.14", resolution: highest,       jit: "off", runner: ubuntu-24.04-arm }
           # Free-threaded build. `highest` only, deliberately: the numba floor for 3.14 is 0.63,
           # which predates numba's free-threaded wheels (first shipped in 0.65), and no PEP 508
           # marker can raise that floor for free-threaded builds alone — so a lowest-direct leg
@@ -45,13 +58,16 @@ jobs:
           python_version: ${{ matrix.python }}
           dependency_resolution: ${{ matrix.resolution }}
           jit: ${{ matrix.jit }}
-          # the jit-off legs upload their data; the coverage job combines + gates
-          coverage: ${{ matrix.jit == 'off' && 'true' || 'false' }}
+          # Declared per combo rather than derived from the jit axis: with a single jit-off
+          # leg the two are no longer the same statement, and a second jit-off combo that
+          # must not upload (the ARM probe) would silently collide on the artifact name.
+          coverage: ${{ matrix.coverage && 'true' || 'false' }}
 
   coverage:
     name: coverage
-    # Cumulative gate: combine the coverage legs' data into one picture before checking
-    # the floor, so version-divergent code paths don't read as uncovered.
+    # Kept as a combine-then-gate rather than folded into the leg itself: the gate belongs to
+    # the matrix as a whole, so a second coverage leg can be added back by declaring one,
+    # without moving where the floor is enforced.
     needs: [core]
     # always() so a cancelled/failed combo makes this job FAIL explicitly rather than
     # skip — GitHub doesn't reliably propagate a cancelled leg through needs.


### PR DESCRIPTION
**Problem**: The matrix ran on `ubuntu-latest`, where the two jit-off legs took **8m12s and 5m09s** against roughly 2m for everything else. Those legs run interpreted, so the work is real and a 4-vCPU runner has nowhere to hide it.

**Solution**: Run the whole matrix on `ubuntu-24.04-arm`, which is about twice as fast for the same work. One line, and every leg benefits rather than just the slow two.

- **Attention:** **standardized, not mixed.** An earlier cut kept the jit-on legs on x64 on the grounds that the compilation target is part of what they test. That was the previous default dressed up as a decision — this matrix does not set out to test architectures, and nothing makes x64 the more important one. If architecture coverage is ever wanted, it should be an explicit axis rather than a side effect of which runner label was there first.
- **Attention:** the **golden master validates this**. It asserts bit-exact float equality on jit-compiled output, and its fingerprint keys on Python and numba only — so on a matching fingerprint it compares bits rather than skipping. It ran and passed on ARM against data generated on x64, which says the compiled numerics do not depend on the target here, `fastmath=True` notwithstanding.
- **TEST:** full matrix green on ARM. Timings, before and after: jit-off **8m12s → 4m20s** and **5m09s → 2m57s**; jit-on legs 1m43–2m05 → 1m16–1m28. Critical path **8m12s → 4m20s**.
- **TEST:** the two combos most likely to lack aarch64 wheels both pass — `lowest-direct`, which pins the oldest direct dependencies, and the free-threaded `3.14t` leg.

**Changelog** (none): CI-only change with no user-facing effect.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
