### PR TITLE
chore: narrow the benchmark-problem sweep when the JIT is off

### DIFF
--- a/tests/_core/_cli/test_cli_benchmark_solver.py
+++ b/tests/_core/_cli/test_cli_benchmark_solver.py
@@ -5,6 +5,7 @@ from max_div._core._cli import benchmark
 from max_div._core._cli._cmd_benchmark_solver_presets import resolve_presets, resolve_problems
 from max_div._core.benchmark_problems import BenchmarkProblemFactory
 from max_div._core.solver import SolverPreset
+from tests.helpers import swept_benchmark_problems
 
 
 # =================================================================================================
@@ -31,7 +32,7 @@ def test_cli_benchmark_solver_list_problems():
         ["--turbo", "--initialization-only"],
     ],
 )
-@pytest.mark.parametrize("test_problem", [*list(BenchmarkProblemFactory.get_all_benchmark_names()), "all"])
+@pytest.mark.parametrize("test_problem", [*swept_benchmark_problems(), "all"])
 def test_cli_benchmark_solver_strategies(options: list[str], test_problem: str):
     # --- arrange -----------------------------------------
     runner = CliRunner()
@@ -57,7 +58,7 @@ def test_cli_benchmark_solver_strategies(options: list[str], test_problem: str):
         ["--size=1", "--json-file", "--preset=random", "--speed=1.0"],
     ],
 )
-@pytest.mark.parametrize("test_problem", [*BenchmarkProblemFactory.get_all_benchmark_names(), "all"])
+@pytest.mark.parametrize("test_problem", [*swept_benchmark_problems(), "all"])
 def test_cli_benchmark_solver_presets(options: list[str], test_problem: str):
     # --- arrange -----------------------------------------
     runner = CliRunner()

--- a/tests/_core/_cli/test_cli_solve.py
+++ b/tests/_core/_cli/test_cli_solve.py
@@ -2,7 +2,7 @@ import pytest
 from click.testing import CliRunner
 
 from max_div._core._cli import solve
-from max_div._core.benchmark_problems import BenchmarkProblemFactory
+from tests.helpers import swept_benchmark_problems
 
 
 # =================================================================================================
@@ -18,7 +18,7 @@ from max_div._core.benchmark_problems import BenchmarkProblemFactory
         (["--seconds=0.001", "--iterations=1000"], 2),
     ],
 )
-@pytest.mark.parametrize("test_problem", list(BenchmarkProblemFactory.get_all_benchmark_names()))
+@pytest.mark.parametrize("test_problem", swept_benchmark_problems())
 def test_cli_solve(options: list[str], test_problem: str, expected_exit_code: int):
     # --- arrange -----------------------------------------
     runner = CliRunner()

--- a/tests/_core/solver/_strategies/_optimization/test_optim_guided_swaps.py
+++ b/tests/_core/solver/_strategies/_optimization/test_optim_guided_swaps.py
@@ -10,6 +10,7 @@ from max_div._core.solver._solver_step import InitializationStep
 from max_div._core.solver._strategies._initialization import InitializationStrategy
 from max_div._core.solver._strategies._optimization import OptimizationStrategy
 from max_div._core.solver._strategies._optimization._optim_guided_swaps import OptimGuidedSwaps
+from tests.helpers import swept_benchmark_problems
 
 if TYPE_CHECKING:
     from max_div._core.problem import MaxDivProblem
@@ -38,7 +39,7 @@ if TYPE_CHECKING:
     ],
 )
 @pytest.mark.parametrize("size", [5])
-@pytest.mark.parametrize("problem_name", BenchmarkProblemFactory.get_all_benchmark_names())
+@pytest.mark.parametrize("problem_name", swept_benchmark_problems())
 def test_optim_guided_swaps(
     problem_name: str,
     size: int,

--- a/tests/_core/solver/_strategies/_optimization/test_optim_random_swaps.py
+++ b/tests/_core/solver/_strategies/_optimization/test_optim_random_swaps.py
@@ -8,13 +8,14 @@ from max_div._core.solver._solver_state import SolverState
 from max_div._core.solver._solver_step import InitializationStep
 from max_div._core.solver._strategies._initialization import InitializationStrategy
 from max_div._core.solver._strategies._optimization import OptimizationStrategy
+from tests.helpers import swept_benchmark_problems
 
 if TYPE_CHECKING:
     from max_div._core.problem import MaxDivProblem
 
 
 @pytest.mark.parametrize("size", [1, 2, 10])
-@pytest.mark.parametrize("problem_name", BenchmarkProblemFactory.get_all_benchmark_names())
+@pytest.mark.parametrize("problem_name", swept_benchmark_problems())
 def test_optim_random_swaps(problem_name: str, size: int):
     """
     Test OptimRandomSwaps strategy on reference problems, with very rudimentary initialization,

--- a/tests/_core/solver/test_solver_builder.py
+++ b/tests/_core/solver/test_solver_builder.py
@@ -15,6 +15,7 @@ from max_div._core.solver import (
 )
 from max_div._core.solver._solver_step import InitializationStep, OptimizationStep
 from max_div._core.solver._strategies import InitializationStrategy, OptimizationStrategy
+from tests.helpers import swept_benchmark_problems
 
 
 # =================================================================================================
@@ -232,7 +233,7 @@ def test_max_div_solver_quadratic_penalty_end_to_end():
 #  Presets
 # =================================================================================================
 @pytest.mark.parametrize("size", [1, 5])
-@pytest.mark.parametrize("problem_name", BenchmarkProblemFactory.get_all_benchmark_names())
+@pytest.mark.parametrize("problem_name", swept_benchmark_problems())
 @pytest.mark.parametrize("preset", list(SolverPreset))
 def test_max_div_solver_builder_preset(problem_name: str, size: int, preset: SolverPreset):
     """

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,13 +1,4 @@
-"""Helpers shared across the test suite.
-
-The suite runs in two modes, and one of them is far more expensive per test. With
-`NUMBA_DISABLE_JIT=1` every `@njit` kernel runs as plain Python — the only way `coverage.py`
-can see inside them, and the mode CI measures coverage in. The same work then costs roughly
-twenty times what the compiled path does.
-
-That cost is not spread evenly. It concentrates in the suites that sweep a real solver run
-across every benchmark problem, which is the axis narrowed below.
-"""
+"""Helpers shared across the test suite."""
 
 import numba
 
@@ -17,18 +8,12 @@ from max_div._core.benchmark_problems import BenchmarkProblemFactory
 def swept_benchmark_problems() -> list[str]:
     """The benchmark problems a solver-level test should sweep in the current mode.
 
-    Compiled, that is all of them: the sweep is cheap and the breadth is the point. Interpreted,
-    it narrows to one constrained and one unconstrained problem — the distinction the solver
-    actually branches on, since the rest of a problem's identity is its data rather than a code
-    path through the solver.
+    All of them when compiled. With the JIT disabled — where every kernel runs as plain Python
+    and a solver sweep costs roughly twenty times more — one constrained and one unconstrained,
+    which is the distinction the solver branches on; the rest of a problem's identity is data.
 
-    Deliberately not a skip. Skipping these suites outright leaves the swap strategies' inner
-    branches and the CLI's solve path uncovered, which is exactly what the interpreted run
-    exists to measure; narrowing the sweep keeps every one of those lines while dropping the
-    repetitions that only re-walk them.
-
-    Keys on `numba.config.DISABLE_JIT` — numba's own parse of the environment variable — so the
-    decision always matches what numba is actually doing.
+    Narrowed rather than skipped: skipping these suites leaves the swap strategies' inner
+    branches and the CLI solve path uncovered, which is what the interpreted run measures.
     """
     names = list(BenchmarkProblemFactory.get_all_benchmark_names())
     if not numba.config.DISABLE_JIT:
@@ -37,6 +22,6 @@ def swept_benchmark_problems() -> list[str]:
 
 
 def _first_with_prefix(names: list[str], prefix: str) -> str:
-    """Pick a representative by family, so renaming or reordering the problems cannot silently
-    turn the narrowed sweep into two problems of the same kind."""
+    """Pick a representative by family, so reordering the problems cannot collapse the narrowed
+    sweep into two of the same kind."""
     return next(name for name in names if name.startswith(prefix))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,42 @@
+"""Helpers shared across the test suite.
+
+The suite runs in two modes, and one of them is far more expensive per test. With
+`NUMBA_DISABLE_JIT=1` every `@njit` kernel runs as plain Python — the only way `coverage.py`
+can see inside them, and the mode CI measures coverage in. The same work then costs roughly
+twenty times what the compiled path does.
+
+That cost is not spread evenly. It concentrates in the suites that sweep a real solver run
+across every benchmark problem, which is the axis narrowed below.
+"""
+
+import numba
+
+from max_div._core.benchmark_problems import BenchmarkProblemFactory
+
+
+def swept_benchmark_problems() -> list[str]:
+    """The benchmark problems a solver-level test should sweep in the current mode.
+
+    Compiled, that is all of them: the sweep is cheap and the breadth is the point. Interpreted,
+    it narrows to one constrained and one unconstrained problem — the distinction the solver
+    actually branches on, since the rest of a problem's identity is its data rather than a code
+    path through the solver.
+
+    Deliberately not a skip. Skipping these suites outright leaves the swap strategies' inner
+    branches and the CLI's solve path uncovered, which is exactly what the interpreted run
+    exists to measure; narrowing the sweep keeps every one of those lines while dropping the
+    repetitions that only re-walk them.
+
+    Keys on `numba.config.DISABLE_JIT` — numba's own parse of the environment variable — so the
+    decision always matches what numba is actually doing.
+    """
+    names = list(BenchmarkProblemFactory.get_all_benchmark_names())
+    if not numba.config.DISABLE_JIT:
+        return names
+    return [_first_with_prefix(names, "C"), _first_with_prefix(names, "U")]
+
+
+def _first_with_prefix(names: list[str], prefix: str) -> str:
+    """Pick a representative by family, so renaming or reordering the problems cannot silently
+    turn the narrowed sweep into two problems of the same kind."""
+    return next(name for name in names if name.startswith(prefix))


### PR DESCRIPTION
**Problem**: Five suites sweep a real solver run across all eight benchmark problems. Interpreted — the mode coverage is measured in — that costs roughly twenty times what the compiled path does, and those five accounted for **86% of the interpreted run's CPU time**.

**Solution**: With the JIT disabled the sweep narrows to one constrained and one unconstrained problem, which is the distinction the solver actually branches on; the rest of a problem's identity is its data, not a code path. The compiled run still sweeps everything.

- **Attention:** **narrowed, not skipped.** Removing these suites under the JIT-off run is cheaper still, but leaves the swap strategies' inner branches and the CLI solve path uncovered — exactly what that run exists to measure. It would have taken coverage to 99.49%, passing the 98% floor while quietly abandoning the 100% target.
- **Attention:** the representative problems are picked **by family prefix rather than by name**, so reordering or renaming the benchmark problems cannot silently collapse the narrowed sweep into two of the same kind.
- **TEST:** interpreted run, before and after: **36.2s → 13.9s**, at an unchanged **99.96%** over the same two missed statements. That equality is the whole point of the change and is the thing to re-check if the sweep is narrowed further.
- **TEST:** compiled run unchanged — 3637 passed, full eight-problem sweep intact.

**Changelog** (none): test-suite change with no user-facing effect.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
