### PR TITLE
refactor: give provisional state changes an explicit savepoint scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Solver iterations run more than 2× faster on separation-based metrics, so time-budgeted runs reach better selections
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Solver iterations run more than 2× faster on separation-based metrics, so time-budgeted runs reach better selections
+- Due to internal optimizations, solver iterations run more than 2× faster on separation-based metrics, so time-budgeted runs reach better selections
 
 ### Deprecated
 

--- a/src/max_div/_core/solver/_diversity_contribution/_base.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_base.py
@@ -24,8 +24,9 @@ class DiversityContributionTracker(ABC):
 
     Mutations mirror the solver-state mutators (`add`, `remove`, `..._many`) and must be called
     with the same indices, in the same order.  Snapshot methods mirror the solver-state snapshot
-    life cycle: `set_snapshot` overwrites any previous snapshot; `restore_snapshot` restores and
-    invalidates it.  Numba kernels are only ever handed bare numpy arrays, never tracker objects.
+    life cycle, which is a *stack*: `push_snapshot` saves the current contributions on top of any
+    already saved, and `pop_snapshot` discards the top entry, restoring from it or not.  Numba
+    kernels are only ever handed bare numpy arrays, never tracker objects.
     """
 
     # -------------------------------------------------------------------------
@@ -89,13 +90,17 @@ class DiversityContributionTracker(ABC):
     #  Snapshot & copy
     # -------------------------------------------------------------------------
     @abstractmethod
-    def set_snapshot(self) -> None:
-        """Internally save the current contribution state, overwriting any previous snapshot."""
+    def push_snapshot(self) -> None:
+        """Save the current contribution state on top of the snapshot stack."""
         raise NotImplementedError
 
     @abstractmethod
-    def restore_snapshot(self) -> None:
-        """Restore the contribution state saved by the last `set_snapshot` call and invalidate it."""
+    def pop_snapshot(self, restore: bool) -> None:
+        """Discard the top snapshot, first restoring the contribution state from it if `restore`.
+
+        :param restore: (bool) True to roll back to the snapshotted state, False to keep the
+                        current state and drop the snapshot.
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/src/max_div/_core/solver/_diversity_contribution/_base.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_base.py
@@ -98,7 +98,7 @@ class DiversityContributionTracker(ABC):
     def pop_snapshot(self, restore: bool) -> None:
         """Discard the top snapshot, first restoring the contribution state from it if `restore`.
 
-        :param restore: (bool) True to roll back to the snapshotted state, False to keep the
+        :param restore: (bool) True to restore the snapshotted state, False to keep the
                         current state and drop the snapshot.
         """
         raise NotImplementedError

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
@@ -99,7 +99,8 @@ class MeanDistanceTracker(DiversityContributionTracker):
         else:
             self._contribution_wrt_dataset = (compute_distance_sums(pdist, n) / max(int(n) - 1, 1)).astype(np.float32)
         self._dist_sums = dist_sums if dist_sums is not None else np.zeros(n, dtype=np.float64)
-        self._snapshot_dist_sums: NDArray[np.float64] = _EMPTY_NP_ARRAY_FLOAT64
+        # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
+        self._snapshot_dist_sums: list[NDArray[np.float64]] = []
 
     def copy(self) -> MeanDistanceTracker:
         """Return a deep copy of this tracker (without recomputing the global contribution)."""
@@ -141,16 +142,13 @@ class MeanDistanceTracker(DiversityContributionTracker):
     # -------------------------------------------------------------------------
     #  Snapshot
     # -------------------------------------------------------------------------
-    def set_snapshot(self) -> None:
-        """Save a copy of the current distance sums, overwriting any previous snapshot."""
-        self._snapshot_dist_sums = self._dist_sums.copy()
+    def push_snapshot(self) -> None:
+        """Save a copy of the current distance sums on top of the snapshot stack."""
+        self._snapshot_dist_sums.append(self._dist_sums.copy())
 
-    def restore_snapshot(self) -> None:
-        """Restore the distance sums saved by the last `set_snapshot` call and invalidate the snapshot."""
-        # no copy needed: the snapshot slot is cleared, so the restored array cannot alias a live snapshot
-        self._dist_sums = self._snapshot_dist_sums
-        self._snapshot_dist_sums = _EMPTY_NP_ARRAY_FLOAT64
-
-
-# singleton to avoid repeated, unnecessary allocations for the invalid-snapshot placeholder
-_EMPTY_NP_ARRAY_FLOAT64 = np.array([], dtype=np.float64)
+    def pop_snapshot(self, restore: bool) -> None:
+        """Discard the top snapshot, first restoring the distance sums from it if `restore`."""
+        # no copy needed: the entry leaves the stack, so the restored array cannot alias a live snapshot
+        snapshot = self._snapshot_dist_sums.pop()
+        if restore:
+            self._dist_sums = snapshot

--- a/src/max_div/_core/solver/_diversity_contribution/_separation.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_separation.py
@@ -99,7 +99,8 @@ class SeparationTracker(DiversityContributionTracker):
         self._n = n  # READ-ONLY
         self._sep_global = sep_global if sep_global is not None else compute_separation(pdist, n)  # READ-ONLY
         self._sep_selected = sep_selected if sep_selected is not None else np.full(n, np.inf, dtype=np.float32)
-        self._snapshot_sep_selected: NDArray[np.float32] = _EMPTY_NP_ARRAY_FLOAT32
+        # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
+        self._snapshot_sep_selected: list[NDArray[np.float32]] = []
 
     def copy(self) -> SeparationTracker:
         """Return a deep copy of this tracker (without recomputing global separations)."""
@@ -136,16 +137,13 @@ class SeparationTracker(DiversityContributionTracker):
     # -------------------------------------------------------------------------
     #  Snapshot
     # -------------------------------------------------------------------------
-    def set_snapshot(self) -> None:
-        """Save a copy of the current separations, overwriting any previous snapshot."""
-        self._snapshot_sep_selected = self._sep_selected.copy()
+    def push_snapshot(self) -> None:
+        """Save a copy of the current separations on top of the snapshot stack."""
+        self._snapshot_sep_selected.append(self._sep_selected.copy())
 
-    def restore_snapshot(self) -> None:
-        """Restore the separations saved by the last `set_snapshot` call and invalidate the snapshot."""
-        # no copy needed: the snapshot slot is cleared, so the restored array cannot alias a live snapshot
-        self._sep_selected = self._snapshot_sep_selected
-        self._snapshot_sep_selected = _EMPTY_NP_ARRAY_FLOAT32
-
-
-# singleton to avoid repeated, unnecessary allocations for the invalid-snapshot placeholder
-_EMPTY_NP_ARRAY_FLOAT32 = np.array([], dtype=np.float32)
+    def pop_snapshot(self, restore: bool) -> None:
+        """Discard the top snapshot, first restoring the separations from it if `restore`."""
+        # no copy needed: the entry leaves the stack, so the restored array cannot alias a live snapshot
+        snapshot = self._snapshot_sep_selected.pop()
+        if restore:
+            self._sep_selected = snapshot

--- a/src/max_div/_core/solver/_diversity_contribution/_trackers.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_trackers.py
@@ -128,15 +128,15 @@ class DiversityContributionTrackers:
     # -------------------------------------------------------------------------
     #  Snapshot
     # -------------------------------------------------------------------------
-    def set_snapshot(self) -> None:
-        """Save the current contribution state of all trackers, overwriting any previous snapshot."""
+    def push_snapshot(self) -> None:
+        """Save the current contribution state of all trackers on top of their snapshot stacks."""
         for tracker in self._trackers:
-            tracker.set_snapshot()
+            tracker.push_snapshot()
 
-    def restore_snapshot(self) -> None:
-        """Restore all trackers to the state saved by the last `set_snapshot` call and invalidate it."""
+    def pop_snapshot(self, restore: bool) -> None:
+        """Discard every tracker's top snapshot, first restoring from it if `restore`."""
         for tracker in self._trackers:
-            tracker.restore_snapshot()
+            tracker.pop_snapshot(restore)
 
     # -------------------------------------------------------------------------
     #  Scoring reads

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -41,12 +41,12 @@ class SolverState:
                 ...
                 with state.savepoint():  # depth 1 -> 2: state saved into _snapshots[1]
                     ...
-                # inner exit             # depth 2 -> 1: state restored from _snapshots[1]
-                                         #   (rolled back) or left as-is (kept); either way
-                                         #   _snapshots[1] is cleared back to a spare
+                # inner exit             # depth 2 -> 1: state restored from _snapshots[1],
+                                         #   or left as-is (kept); either way _snapshots[1]
+                                         #   is cleared back to a spare
             # outer exit                 # depth 1 -> 0: same, against _snapshots[0]
 
-        Keeping and rolling back thus leave the lists themselves identical — they differ only in
+        Keeping and restoring thus leave the lists themselves identical — they differ only in
         whether the state was first restored from the top entry before that entry was cleared.
     """
 
@@ -138,14 +138,14 @@ class SolverState:
     def savepoint(self) -> Savepoint:
         """Open a scope in which every change to this state is provisional.
 
-        On leaving the scope the changes are rolled back, unless the scope was explicitly kept:
+        On leaving the scope the pre-scope state is restored, unless the scope was explicitly kept:
 
             with state.savepoint() as sp:   # everything in here is provisional
                 state.remove(i)
                 if state.score > best:
                     sp.keep()               # ... unless we say otherwise
 
-        Rollback is the default, so a trial reads as nothing more than a `with` block, and an
+        Restoring is the default, so a trial reads as nothing more than a `with` block, and an
         exception inside the scope leaves the state untouched.  Scopes nest: the solver evaluates
         candidates provisionally inside a swap that is itself provisional.
         """
@@ -436,7 +436,7 @@ class Savepoint:
         self._keep = False
 
     def keep(self) -> None:
-        """Keep the changes made inside this scope instead of rolling them back on exit."""
+        """Keep the changes made inside this scope instead of restoring the pre-scope state on exit."""
         self._keep = True
 
     def __enter__(self) -> Savepoint:
@@ -446,7 +446,7 @@ class Savepoint:
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> bool:  # noqa: ANN001 -- standard context-manager signature
-        """Roll back unless the scope was kept; an exception always rolls back and always propagates."""
+        """Restore the pre-scope state unless the scope was kept; an exception always restores and always propagates."""
         self._state._pop_snapshot(restore=not self._keep or exc_type is not None)  # noqa: SLF001 -- as above
         return False  # never swallow an exception
 

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -22,7 +22,33 @@ if TYPE_CHECKING:
 #  Solver State
 # =================================================================================================
 class SolverState:
-    """Abstract base class for solver state management."""
+    """Mutable state of a solver run: selection, constraint status, diversity contributions, and score.
+
+    Savepoint mechanics:
+
+        Provisional changes are managed by three fields that always move together:
+
+            _depth       number of currently open scopes
+            _snapshots   entries 0.._depth-1 hold the state saved at each open scope, innermost
+                         last; entries at _depth and above are cleared spares kept for reuse
+            _savepoints  the scope object handed out at each depth, one per depth ever reached
+
+        Both lists only ever grow: reaching a depth for the first time appends its entry, every
+        later visit reuses it, so steady-state operation allocates nothing.  A nested trial
+        evolves like this:
+
+            with state.savepoint():      # depth 0 -> 1: state saved into _snapshots[0]
+                ...
+                with state.savepoint():  # depth 1 -> 2: state saved into _snapshots[1]
+                    ...
+                # inner exit             # depth 2 -> 1: state restored from _snapshots[1]
+                                         #   (rolled back) or left as-is (kept); either way
+                                         #   _snapshots[1] is cleared back to a spare
+            # outer exit                 # depth 1 -> 0: same, against _snapshots[0]
+
+        Keeping and rolling back thus leave the lists themselves identical — they differ only in
+        whether the state was first restored from the top entry before that entry was cleared.
+    """
 
     # -------------------------------------------------------------------------
     #  Construction & Configuration
@@ -82,9 +108,9 @@ class SolverState:
         self._con_indices = con_indices  # READ-ONLY
         self._con_membership = con_membership  # READ-ONLY
 
-        # snapshots — a stack, so provisional changes can nest (see savepoint())
-        self._snapshots: list[Snapshot] = []  # entries 0.._depth-1 are live, the rest are reusable spares
-        self._savepoints: list[Savepoint] = []  # one reusable scope object per depth, so entry allocates nothing
+        # snapshots — a stack, so provisional changes can nest ("Savepoint mechanics" in the class docstring)
+        self._snapshots: list[Snapshot] = []
+        self._savepoints: list[Savepoint] = []
         self._depth: int = 0
 
         # finalize
@@ -125,6 +151,7 @@ class SolverState:
         """
         depth = self._depth
         if depth == len(self._savepoints):
+            # first time this nesting depth is reached: allocate its scope object; later visits reuse it
             self._savepoints.append(Savepoint(self))
         return self._savepoints[depth]
 
@@ -132,6 +159,7 @@ class SolverState:
         """Save the current state on top of the snapshot stack."""
         depth = self._depth
         if depth == len(self._snapshots):
+            # first time this nesting depth is reached: allocate its entry; later visits refill the spare in place
             self._snapshots.append(Snapshot.empty())
         snapshot = self._snapshots[depth]
 
@@ -461,7 +489,7 @@ class Snapshot:
 
 
 # singletons to avoid repeated, unnecessary allocations
-# (a cleared snapshot's fields are never read — the depth counter delimits the live stack entries)
+# (a cleared snapshot's fields are never read — SolverState._depth delimits the live stack entries)
 _EMPTY_NP_ARRAY_BOOL = np.array([], dtype=np.bool)
 _EMPTY_NP_ARRAY_INT32 = np.array([], dtype=np.int32)
 _PLACEHOLDER_SCORE = Score(size=0.0, constraints=0.0, diversity=0.0, div_tie_breakers=())

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -82,8 +82,10 @@ class SolverState:
         self._con_indices = con_indices  # READ-ONLY
         self._con_membership = con_membership  # READ-ONLY
 
-        # snapshot
-        self._snapshot: Snapshot = Snapshot.empty()
+        # snapshots — a stack, so provisional changes can nest (see savepoint())
+        self._snapshots: list[Snapshot] = []  # entries 0.._depth-1 are live, the rest are reusable spares
+        self._savepoints: list[Savepoint] = []  # one reusable scope object per depth, so entry allocates nothing
+        self._depth: int = 0
 
         # finalize
         self._update_score()
@@ -107,44 +109,61 @@ class SolverState:
     # -------------------------------------------------------------------------
     #  Main API - used by solver strategies to modify state
     # -------------------------------------------------------------------------
-    def set_snapshot(self) -> None:
-        """Internally saves the current state as a snapshot (possibly overwriting any previous snapshot).
+    def savepoint(self) -> Savepoint:
+        """Open a scope in which every change to this state is provisional.
 
-        Such a snapshot can be restored using the restore_snapshot() method, with any actions that happened
-        in between (add, remove) being undone.
+        On leaving the scope the changes are rolled back, unless the scope was explicitly kept:
+
+            with state.savepoint() as sp:   # everything in here is provisional
+                state.remove(i)
+                if state.score > best:
+                    sp.keep()               # ... unless we say otherwise
+
+        Rollback is the default, so a trial reads as nothing more than a `with` block, and an
+        exception inside the scope leaves the state untouched.  Scopes nest: the solver evaluates
+        candidates provisionally inside a swap that is itself provisional.
         """
+        depth = self._depth
+        if depth == len(self._savepoints):
+            self._savepoints.append(Savepoint(self))
+        return self._savepoints[depth]
+
+    def _push_snapshot(self) -> None:
+        """Save the current state on top of the snapshot stack."""
+        depth = self._depth
+        if depth == len(self._snapshots):
+            self._snapshots.append(Snapshot.empty())
+        snapshot = self._snapshots[depth]
+
         # NOTE: we create copies, such that add(.) and remove(.) cannot influence the snapshot after it was taken
-        self._snapshot.selected = self._selected.copy()
-        self._snapshot.n_selected = self._n_selected
-        self._snapshot.con_values = self._con_values.copy()
-        self._contribution_trackers.set_snapshot()
+        snapshot.selected = self._selected.copy()
+        snapshot.n_selected = self._n_selected
+        snapshot.con_values = self._con_values.copy()
+        self._contribution_trackers.push_snapshot()
         # NOTE: Score is immutable and mutators reassign self._score (never modify in place),
         #       so storing the reference is safe — no copy needed.
-        self._snapshot.score = self.score
-        self._snapshot.is_valid = True
+        snapshot.score = self.score
 
-    def restore_snapshot(self) -> None:
-        """Restores the state of this object to the state saved in the last call to set_snapshot().
+        self._depth = depth + 1
 
-        Any actions that happened in between (add, remove) are undone.  If set_snapshot() hasn't been called before,
-        a ValueError is raised.  After restoring the snapshot, it gets cleared, such that subsequent calls to
-        restore_snapshot() without an intermediate call to set_snapshot() will again raise a ValueError.
-        """
-        if not self._snapshot.is_valid:
-            raise ValueError("Cannot restore snapshot: set_snapshot() not called before.")
+    def _pop_snapshot(self, restore: bool) -> None:
+        """Discard the top snapshot, first restoring this state from it if `restore`."""
+        depth = self._depth - 1
+        snapshot = self._snapshots[depth]
+        self._contribution_trackers.pop_snapshot(restore)
 
-        # restore snapshot (no copy needed; we will clear the snapshot)
-        self._selected = self._snapshot.selected
-        self._n_selected = self._snapshot.n_selected
-        self._con_values = self._snapshot.con_values
-        self._contribution_trackers.restore_snapshot()
+        if restore:
+            # no copy needed; the snapshot is cleared below, so the restored arrays cannot alias a live snapshot
+            self._selected = snapshot.selected
+            self._n_selected = snapshot.n_selected
+            self._con_values = snapshot.con_values
 
-        # restore score (cached at set_snapshot time; avoids a full recompute)
-        self._score = self._snapshot.score
-        self._score_dirty = False
+            # restore score (cached at push time; avoids a full recompute)
+            self._score = snapshot.score
+            self._score_dirty = False
 
-        # clear snapshot after restoring
-        self._snapshot.clear()
+        snapshot.clear()
+        self._depth = depth
 
     def add(self, index: int | np.int32) -> None:
         # --- validation ----------------------------------
@@ -372,6 +391,38 @@ class SolverState:
 # =================================================================================================
 #  Helper Classes
 # =================================================================================================
+class Savepoint:
+    """Scope over provisional changes to a SolverState; see SolverState.savepoint().
+
+    Written as a class with __enter__/__exit__ rather than a @contextmanager generator: the solver
+    enters one of these tens of times per iteration, and generator-based context managers cost
+    noticeably more per entry.  One instance is reused per nesting depth, so entering a scope
+    allocates nothing.
+    """
+
+    __slots__ = ("_keep", "_state")
+
+    def __init__(self, state: SolverState) -> None:
+        """Bind the scope to its state.  Not intended to be constructed directly."""
+        self._state = state
+        self._keep = False
+
+    def keep(self) -> None:
+        """Keep the changes made inside this scope instead of rolling them back on exit."""
+        self._keep = True
+
+    def __enter__(self) -> Savepoint:
+        """Snapshot the state, so everything until __exit__ can be undone."""
+        self._keep = False  # this object is reused across scopes; never inherit the previous outcome
+        self._state._push_snapshot()  # noqa: SLF001 -- Savepoint is SolverState's own scope object
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:  # noqa: ANN001 -- standard context-manager signature
+        """Roll back unless the scope was kept; an exception always rolls back and always propagates."""
+        self._state._pop_snapshot(restore=not self._keep or exc_type is not None)  # noqa: SLF001 -- as above
+        return False  # never swallow an exception
+
+
 @dataclass(slots=True)
 class Snapshot:
     """Class internally used by SolverState to store snapshots of its state.
@@ -380,8 +431,6 @@ class Snapshot:
     modified after construction.  Diversity-contribution state is snapshotted by the contribution trackers
     themselves, in lockstep with this snapshot's life cycle.
     """
-
-    is_valid: bool
 
     selected: NDArray[np.bool]  # boolean array representing the selection
     n_selected: np.int32  # number of True values in 'selected'
@@ -394,8 +443,7 @@ class Snapshot:
     #  Modification / Factory
     # -------------------------------------------------------------------------
     def clear(self) -> None:
-        """Clear the snapshot, making it invalid."""
-        self.is_valid = False
+        """Release the state held by this snapshot, returning it to the spare pool."""
         self.selected = _EMPTY_NP_ARRAY_BOOL
         self.n_selected = np.int32(0)
         self.con_values = _EMPTY_NP_ARRAY_INT32
@@ -403,9 +451,8 @@ class Snapshot:
 
     @classmethod
     def empty(cls) -> Snapshot:
-        """Create and return an empty/invalid snapshot."""
+        """Create and return a cleared snapshot, ready to be filled by a push."""
         return Snapshot(
-            is_valid=False,
             selected=_EMPTY_NP_ARRAY_BOOL,
             n_selected=np.int32(0),
             con_values=_EMPTY_NP_ARRAY_INT32,
@@ -414,7 +461,7 @@ class Snapshot:
 
 
 # singletons to avoid repeated, unnecessary allocations
-# (an invalid snapshot's score is never read — restore_snapshot guards on is_valid)
+# (a cleared snapshot's fields are never read — the depth counter delimits the live stack entries)
 _EMPTY_NP_ARRAY_BOOL = np.array([], dtype=np.bool)
 _EMPTY_NP_ARRAY_INT32 = np.array([], dtype=np.int32)
 _PLACEHOLDER_SCORE = Score(size=0.0, constraints=0.0, diversity=0.0, div_tie_breakers=())

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
@@ -83,11 +83,10 @@ class InitEager(InitializationStrategy):
         best_score_tuple: tuple | None = None
 
         for sample in candidates:
-            # take snapshot -> add and remember score -> revert
-            state.set_snapshot()
-            state.add(sample)
-            score = state.score
-            state.restore_snapshot()
+            # provisionally add and remember the score; leaving the scope reverts it
+            with state.savepoint():
+                state.add(sample)
+                score = state.score
 
             # see if sample is better
             # soft=1.0 ignores the constraint score; otherwise consider the full score, including constraints

--- a/src/max_div/_core/solver/_strategies/_optimization/_base.py
+++ b/src/max_div/_core/solver/_strategies/_optimization/_base.py
@@ -345,36 +345,34 @@ class SwapBasedOptimizationStrategy(OptimizationStrategy, ABC):
         # just-removed ones to be selected to be added again immediately.
         candidate_samples_to_add = state.not_selected_index_array
 
-        # --- take snapshot & remove n samples ---
+        # --- the whole swap is provisional until it proves itself ---
 
-        # score before
-        state.set_snapshot()
-        score_before = state.score
-        score_tuple_before = score_before.as_tuple(
-            soft=self.constraint_softness,
-            ignore_infeasible_diversity=self.ignore_infeasible_diversity,
-        )
+        with state.savepoint() as swap:
+            # score before
+            score_before = state.score
+            score_tuple_before = score_before.as_tuple(
+                soft=self.constraint_softness,
+                ignore_infeasible_diversity=self.ignore_infeasible_diversity,
+            )
 
-        # remove
-        _ = self._remove_samples(state, n_swap)
+            # remove
+            _ = self._remove_samples(state, n_swap)
 
-        # add
-        _ = self._add_samples(state, n_swap, candidate_samples_to_add)
+            # add
+            _ = self._add_samples(state, n_swap, candidate_samples_to_add)
 
-        # evaluate
-        score_after = state.score
-        score_tuple_after = score_after.as_tuple(
-            soft=self.constraint_softness,
-            ignore_infeasible_diversity=self.ignore_infeasible_diversity,
-        )
-        if score_tuple_after < score_tuple_before:
-            # score deteriorated -> revert; failure
-            state.restore_snapshot()
-            success = False
-        else:
-            # score did improve or stayed equal -> do not revert; success
+            # evaluate
+            score_after = state.score
+            score_tuple_after = score_after.as_tuple(
+                soft=self.constraint_softness,
+                ignore_infeasible_diversity=self.ignore_infeasible_diversity,
+            )
+
+            # score improved or stayed equal -> keep the swap; otherwise the scope reverts it on exit
             # NOTE: for the sake of exploring the search space, swaps with equal score are not reverted.
-            success = True
+            success = score_tuple_after >= score_tuple_before
+            if success:
+                swap.keep()
 
         # --- update fail/success history ---
         _update_success_rate_state(self._success_rate_state, success)

--- a/src/max_div/_core/solver/_strategies/_optimization/_optim_smart_swaps.py
+++ b/src/max_div/_core/solver/_strategies/_optimization/_optim_smart_swaps.py
@@ -170,24 +170,22 @@ class OptimSmartSwaps(SwapBasedOptimizationStrategy):
             best_sample: np.int32 = np.int32(-1)
             best_score_tuple: tuple | None = None
             for i_cand in candidates_for_removal:
-                # temporarily remove candidate from selection
-                state.remove(i_cand)
+                # trial removal: provisional, so leaving the scope undoes it
+                with state.savepoint():
+                    state.remove(i_cand)
 
-                # compute new score
-                cand_score = state.score
+                    # compute new score
+                    cand_score = state.score
+                    cand_score_tuple = cand_score.as_tuple(
+                        soft=self.constraint_softness,
+                        ignore_infeasible_diversity=self.ignore_infeasible_diversity,
+                    )
 
                 # if best score so far, remember candidate
-                cand_score_tuple = cand_score.as_tuple(
-                    soft=self.constraint_softness,
-                    ignore_infeasible_diversity=self.ignore_infeasible_diversity,
-                )
                 if (best_score_tuple is None) or (cand_score_tuple >= best_score_tuple):
                     # NOTE: also accept equal candidates, to encourage diversity in selections and hence exploration
                     best_score_tuple = cand_score_tuple
                     best_sample = i_cand
-
-                # re-add candidate to selection
-                state.add(i_cand)
 
             # 3) now actually remove best sample from selection
             state.remove(best_sample)
@@ -228,21 +226,21 @@ class OptimSmartSwaps(SwapBasedOptimizationStrategy):
             )
 
             # 2) evaluate this candidate group of samples
-            #  --> temporarily add all samples
-            state.add_many(candidate_samples_to_add)
+            #  --> provisionally add all samples; leaving the scope undoes them
+            with state.savepoint():
+                state.add_many(candidate_samples_to_add)
 
-            #  --> compute new score & update best score/samples
-            cand_score_tuple = state.score.as_tuple(
-                soft=self.constraint_softness,
-                ignore_infeasible_diversity=self.ignore_infeasible_diversity,
-            )
+                #  --> compute new score
+                cand_score_tuple = state.score.as_tuple(
+                    soft=self.constraint_softness,
+                    ignore_infeasible_diversity=self.ignore_infeasible_diversity,
+                )
+
+            #  --> update best score/samples
             if (best_score_tuple is None) or (cand_score_tuple >= best_score_tuple):
                 # NOTE: also accept equal candidates, to encourage diversity in selections and hence exploration
                 best_score_tuple = cand_score_tuple
                 best_samples = candidate_samples_to_add
-
-            #  --> re-remove all samples
-            state.remove_many(candidate_samples_to_add)
 
         # b) now actually add best sample set to selection
         state.add_many(best_samples)

--- a/tests/_core/solver/_diversity_contribution/test_base.py
+++ b/tests/_core/solver/_diversity_contribution/test_base.py
@@ -27,10 +27,10 @@ class _CallRecordingTracker(DiversityContributionTracker):
     def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
         self.calls.append(("remove", int(index), list(new_selection)))
 
-    def set_snapshot(self) -> None:
+    def push_snapshot(self) -> None:
         pass  # pragma: no cover - not exercised by these tests
 
-    def restore_snapshot(self) -> None:
+    def pop_snapshot(self, restore: bool) -> None:
         pass  # pragma: no cover - not exercised by these tests
 
     def copy(self) -> DiversityContributionTracker:

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -130,12 +130,11 @@ def test_invariant_random_operations_match_recompute(tracker: MeanDistanceTracke
     # --- arrange -----------------------------------------
     rng = random.default_rng(seed=7)
     selection: list[int] = []
-    snapshot_selection: list[int] | None = None
+    snapshot_selections: list[list[int]] = []  # mirrors the tracker's snapshot stack
 
     # --- act / assert ------------------------------------
     for _ in range(200):
-        can_restore = snapshot_selection is not None
-        options = ["add", "remove", "set_snapshot"] + (["restore_snapshot"] if can_restore else [])
+        options = ["add", "remove", "push_snapshot"] + (["pop_restore", "pop_keep"] if snapshot_selections else [])
         match rng.choice(options):
             case "add" if len(selection) < N:
                 index = int(rng.choice([i for i in range(N) if i not in selection]))
@@ -145,13 +144,15 @@ def test_invariant_random_operations_match_recompute(tracker: MeanDistanceTracke
                 index = int(rng.choice(selection))
                 selection.remove(index)
                 tracker.remove(np.int32(index), new_selection=np.array(selection, dtype=np.int32))
-            case "set_snapshot":
-                tracker.set_snapshot()
-                snapshot_selection = selection.copy()
-            case "restore_snapshot":
-                tracker.restore_snapshot()
-                selection = snapshot_selection.copy()  # ty: ignore[possibly-unbound-attribute]  # gated by can_restore
-                snapshot_selection = None
+            case "push_snapshot":
+                tracker.push_snapshot()
+                snapshot_selections.append(selection.copy())
+            case "pop_restore":
+                tracker.pop_snapshot(restore=True)
+                selection = snapshot_selections.pop()
+            case "pop_keep":
+                tracker.pop_snapshot(restore=False)
+                snapshot_selections.pop()
 
         selected, n_selected = _selection_args(selection)
         np.testing.assert_allclose(

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -115,19 +115,28 @@ def test_copy_is_independent(tracker: SeparationTracker):
     assert clone.contribution_wrt_dataset is not tracker.contribution_wrt_dataset
 
 
-def test_snapshot_restore(tracker: SeparationTracker):
+def test_snapshot_stack(tracker: SeparationTracker):
     # --- arrange -----------------------------------------
     tracker.add(np.int32(0))
-    selected, n_selected = _selection_args([0], 5)
-    contribution_before = tracker.contribution_wrt_selection(selected, n_selected).copy()
 
-    # --- act ---------------------------------------------
-    tracker.set_snapshot()
+    # --- act & assert ------------------------------------
+    # two nested snapshots: pop the inner one restoring, the outer one keeping
+    tracker.push_snapshot()
     tracker.add(np.int32(3))
-    tracker.restore_snapshot()
+    selected_inner, n_selected_inner = _selection_args([0, 3], 5)
+    contribution_inner = tracker.contribution_wrt_selection(selected_inner, n_selected_inner).copy()
 
-    # --- assert ------------------------------------------
-    np.testing.assert_array_equal(tracker.contribution_wrt_selection(selected, n_selected), contribution_before)
+    tracker.push_snapshot()
+    tracker.add(np.int32(4))
+    tracker.pop_snapshot(restore=True)  # roll back to the inner snapshot ({0, 3})
+    np.testing.assert_array_equal(
+        tracker.contribution_wrt_selection(selected_inner, n_selected_inner), contribution_inner
+    )
+
+    tracker.pop_snapshot(restore=False)  # keep {0, 3}; the outer snapshot is only discarded
+    np.testing.assert_array_equal(
+        tracker.contribution_wrt_selection(selected_inner, n_selected_inner), contribution_inner
+    )
 
 
 # =================================================================================================

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -128,7 +128,7 @@ def test_snapshot_stack(tracker: SeparationTracker):
 
     tracker.push_snapshot()
     tracker.add(np.int32(4))
-    tracker.pop_snapshot(restore=True)  # roll back to the inner snapshot ({0, 3})
+    tracker.pop_snapshot(restore=True)  # restore to the inner snapshot ({0, 3})
     np.testing.assert_array_equal(
         tracker.contribution_wrt_selection(selected_inner, n_selected_inner), contribution_inner
     )

--- a/tests/_core/solver/_diversity_contribution/test_trackers.py
+++ b/tests/_core/solver/_diversity_contribution/test_trackers.py
@@ -74,9 +74,9 @@ def test_mutations_fan_out_to_all_trackers(pdist: np.ndarray):
     # --- act ---------------------------------------------
     trackers.add(np.int32(0))
     trackers.add_many(np.array([2, 3], dtype=np.int32))
-    trackers.set_snapshot()
+    trackers.push_snapshot()
     trackers.remove_many(np.array([2, 3], dtype=np.int32), new_selection=np.array([0], dtype=np.int32))
-    trackers.restore_snapshot()
+    trackers.pop_snapshot(restore=True)
     trackers.remove(np.int32(2), new_selection=np.array([0, 3], dtype=np.int32))
 
     for ref in (sep_ref, mean_ref):

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -6,7 +6,7 @@ from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 from max_div._core.metrics._distance import compute_pdist
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker, SeparationTracker
-from max_div._core.solver._solver_state import SolverState, _build_con_membership
+from max_div._core.solver._solver_state import Savepoint, SolverState, _build_con_membership
 
 
 # =================================================================================================
@@ -133,7 +133,7 @@ def test_solver_state_end_to_end(new_solver_state):
     assert state.n_not_selected == 3
 
 
-def test_solver_state_snapshot(new_solver_state):
+def test_savepoint_rolls_back_by_default(new_solver_state):
     # --- arrange -----------------------------------------
     state = new_solver_state
     state.add(0)
@@ -145,23 +145,101 @@ def test_solver_state_snapshot(new_solver_state):
     orig_separation_array = state.selected_contribution_array.copy()
     orig_con_values = state._con_values.copy()
 
-    # --- act & assert ------------------------------------
-    with pytest.raises(ValueError):
-        state.restore_snapshot()  # none taken yet
-
-    # the below should be a no-op
-    state.set_snapshot()
-    state.add(5)
-    state.restore_snapshot()
-
-    with pytest.raises(ValueError):
-        state.restore_snapshot()  # restoring a snapshot invalidates it
+    # --- act ---------------------------------------------
+    # the below should be a no-op: the scope is never kept
+    with state.savepoint():
+        state.add(5)
 
     # --- assert ------------------------------------------
     assert np.array_equal(state.selected_index_array, orig_selected_array)
     assert np.array_equal(state.not_selected_index_array, orig_not_selected_array)
     assert np.allclose(state.selected_contribution_array, orig_separation_array)
     assert np.array_equal(state.con_values, orig_con_values)
+
+
+def test_savepoint_keep(new_solver_state):
+    # --- arrange -----------------------------------------
+    state = new_solver_state
+    state.add(0)
+
+    # --- act ---------------------------------------------
+    with state.savepoint() as sp:
+        state.add(5)
+        sp.keep()
+
+    # --- assert ------------------------------------------
+    assert np.array_equal(state.selected_index_array, [0, 5])
+
+
+def test_savepoint_nesting(new_solver_state):
+    # --- arrange -----------------------------------------
+    state = new_solver_state
+    state.add(0)
+
+    # --- act ---------------------------------------------
+    # kept outer scope, with one rolled-back and one kept scope nested inside it
+    with state.savepoint() as outer:
+        state.add(2)
+        with state.savepoint():
+            state.add(4)  # rolled back
+        with state.savepoint() as inner:
+            state.add(5)
+            inner.keep()
+        outer.keep()
+
+    # --- assert ------------------------------------------
+    assert np.array_equal(state.selected_index_array, [0, 2, 5])
+
+
+def test_savepoint_rolled_back_outer_discards_kept_inner(new_solver_state):
+    # --- arrange -----------------------------------------
+    state = new_solver_state
+    state.add(0)
+
+    # --- act ---------------------------------------------
+    with state.savepoint(), state.savepoint() as inner:
+        state.add(5)
+        inner.keep()
+
+    # --- assert ------------------------------------------
+    # keeping a scope only survives up to its parent; the rolled-back outer scope undoes it all
+    assert np.array_equal(state.selected_index_array, [0])
+
+
+def test_savepoint_exception_rolls_back_and_propagates(new_solver_state):
+    # --- arrange -----------------------------------------
+    state = new_solver_state
+    state.add(0)
+
+    def trial_that_raises() -> None:
+        with state.savepoint() as sp:
+            state.add(5)
+            sp.keep()  # an exception rolls back even a kept scope
+            raise RuntimeError("boom")
+
+    # --- act ---------------------------------------------
+    with pytest.raises(RuntimeError, match="boom"):
+        trial_that_raises()
+
+    # --- assert ------------------------------------------
+    assert np.array_equal(state.selected_index_array, [0])
+
+
+def test_savepoint_restores_cached_score(new_solver_state):
+    # --- arrange -----------------------------------------
+    state = new_solver_state
+    state.add(0)
+    score_before = state.score  # cached, clean
+
+    # --- act ---------------------------------------------
+    with state.savepoint():
+        state.add(5)
+        _ = state.score
+
+    # --- assert ------------------------------------------
+    # rollback reinstates the score cached at scope entry (by reference; Score is immutable), clean
+    assert state._score is score_before
+    assert not state._score_dirty
 
 
 @pytest.mark.parametrize("seed", list(range(1, 100)))
@@ -176,36 +254,35 @@ def test_solver_state_consistency_stress_test(new_solver_state, seed: int):
     # --- act ---------------------------------------------
     random.seed(seed)
     for it in range(n_iters):
-        # take snapshot
-        state.set_snapshot()
+        # every iteration's changes are provisional; roughly half the scopes are kept
+        with state.savepoint() as sp:
+            # add random number of items
+            n_to_add = random.randint(0, len(state.not_selected_index_array) + 1)
+            indices_to_select = state.not_selected_index_array.copy()
+            random.shuffle(indices_to_select)
+            if it % 2 == 0:
+                # use add()
+                for idx in indices_to_select[:n_to_add]:
+                    state.add(idx)
+            else:
+                # use add_many()
+                state.add_many(indices_to_select[:n_to_add])
 
-        # add random number of items
-        n_to_add = random.randint(0, len(state.not_selected_index_array) + 1)
-        indices_to_select = state.not_selected_index_array.copy()
-        random.shuffle(indices_to_select)
-        if it % 2 == 0:
-            # use add()
-            for idx in indices_to_select[:n_to_add]:
-                state.add(idx)
-        else:
-            # use add_many()
-            state.add_many(indices_to_select[:n_to_add])
+            # remove random number of items
+            n_to_remove = random.randint(0, len(state.selected_index_array) + 1)
+            indices_to_remove = state.selected_index_array.copy()
+            random.shuffle(indices_to_remove)
+            if it % 2 == 0:
+                # use remove()
+                for idx in indices_to_remove[:n_to_remove]:
+                    state.remove(idx)
+            else:
+                # use remove_many()
+                state.remove_many(indices_to_remove[:n_to_remove])
 
-        # remove random number of items
-        n_to_remove = random.randint(0, len(state.selected_index_array) + 1)
-        indices_to_remove = state.selected_index_array.copy()
-        random.shuffle(indices_to_remove)
-        if it % 2 == 0:
-            # use remove()
-            for idx in indices_to_remove[:n_to_remove]:
-                state.remove(idx)
-        else:
-            # use remove_many()
-            state.remove_many(indices_to_remove[:n_to_remove])
-
-        # restore snapshot with some probability
-        if random.rand() < 0.5:
-            state.restore_snapshot()
+            # keep the scope with some probability
+            if random.rand() >= 0.5:
+                sp.keep()
 
     # --- assert ------------------------------------------
 
@@ -366,25 +443,36 @@ def _assert_state_matches_fresh_rebuild(state: SolverState) -> None:
     assert np.array_equal(state._con_values, fresh._con_values)
 
 
-def _apply_random_operation(state: SolverState, rng: random.Generator, snapshot_is_valid: bool) -> bool:
-    """Apply one randomly chosen valid operation to 'state'; return whether a snapshot is valid afterwards."""
+def _apply_savepoint_operation(state: SolverState, operation: str, open_savepoints: list[Savepoint]) -> None:
+    """Enter or exit a savepoint on 'state' per 'operation', maintaining the open-savepoint stack.
+
+    Savepoints are entered and exited through their context-manager protocol directly: a random
+    walk opens and closes scopes at arbitrary points, which lexical `with` blocks cannot express.
+    """
+    if operation == "enter_savepoint":
+        open_savepoints.append(state.savepoint().__enter__())
+    else:
+        savepoint = open_savepoints.pop()
+        if operation == "exit_keep":
+            savepoint.keep()
+        savepoint.__exit__(None, None, None)
+
+
+def _apply_random_operation(state: SolverState, rng: random.Generator, open_savepoints: list[Savepoint]) -> None:
+    """Apply one randomly chosen valid operation to 'state', maintaining the open-savepoint stack."""
     selected = state.selected_index_array
     not_selected = state.not_selected_index_array
-    operations = ["set_snapshot"]
-    if snapshot_is_valid:
-        operations.append("restore_snapshot")
+    operations = ["enter_savepoint"]
+    if open_savepoints:
+        operations += ["exit_rollback", "exit_keep"]
     if not_selected.size > 0:
         operations += ["add", "add_many"]
     if selected.size > 0:
         operations += ["remove", "remove_many"]
 
     match rng.choice(operations):
-        case "set_snapshot":
-            state.set_snapshot()
-            return True
-        case "restore_snapshot":
-            state.restore_snapshot()
-            return False
+        case ("enter_savepoint" | "exit_rollback" | "exit_keep") as operation:
+            _apply_savepoint_operation(state, operation, open_savepoints)
         case "add":
             state.add(rng.choice(not_selected))
         case "add_many":
@@ -395,7 +483,6 @@ def _apply_random_operation(state: SolverState, rng: random.Generator, snapshot_
         case "remove_many":
             n_remove = int(rng.integers(1, min(4, selected.size) + 1))
             state.remove_many(rng.choice(selected, size=n_remove, replace=False).astype(np.int32))
-    return snapshot_is_valid
 
 
 @pytest.mark.parametrize("seed", [0, 1, 2])
@@ -404,11 +491,11 @@ def test_solver_state_consistency_invariant(seed: int):
     # --- arrange -----------------------------------------
     state = _make_reference_state()
     rng = random.default_rng(seed=seed)
-    snapshot_is_valid = False
+    open_savepoints: list[Savepoint] = []
 
     # --- act & assert ------------------------------------
     for _ in range(60):
-        snapshot_is_valid = _apply_random_operation(state, rng, snapshot_is_valid)
+        _apply_random_operation(state, rng, open_savepoints)
         _assert_state_matches_fresh_rebuild(state)
 
 

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -133,7 +133,7 @@ def test_solver_state_end_to_end(new_solver_state):
     assert state.n_not_selected == 3
 
 
-def test_savepoint_rolls_back_by_default(new_solver_state):
+def test_savepoint_restores_by_default(new_solver_state):
     # --- arrange -----------------------------------------
     state = new_solver_state
     state.add(0)
@@ -177,11 +177,11 @@ def test_savepoint_nesting(new_solver_state):
     state.add(0)
 
     # --- act ---------------------------------------------
-    # kept outer scope, with one rolled-back and one kept scope nested inside it
+    # kept outer scope, with one restored and one kept scope nested inside it
     with state.savepoint() as outer:
         state.add(2)
         with state.savepoint():
-            state.add(4)  # rolled back
+            state.add(4)  # dropped: this scope is not kept, so its exit restores {0, 2}
         with state.savepoint() as inner:
             state.add(5)
             inner.keep()
@@ -191,7 +191,7 @@ def test_savepoint_nesting(new_solver_state):
     assert np.array_equal(state.selected_index_array, [0, 2, 5])
 
 
-def test_savepoint_rolled_back_outer_discards_kept_inner(new_solver_state):
+def test_savepoint_restoring_outer_discards_kept_inner(new_solver_state):
     # --- arrange -----------------------------------------
     state = new_solver_state
     state.add(0)
@@ -202,11 +202,11 @@ def test_savepoint_rolled_back_outer_discards_kept_inner(new_solver_state):
         inner.keep()
 
     # --- assert ------------------------------------------
-    # keeping a scope only survives up to its parent; the rolled-back outer scope undoes it all
+    # keeping a scope only survives up to its parent; the outer exit restores the state from before it
     assert np.array_equal(state.selected_index_array, [0])
 
 
-def test_savepoint_exception_rolls_back_and_propagates(new_solver_state):
+def test_savepoint_exception_restores_and_propagates(new_solver_state):
     # --- arrange -----------------------------------------
     state = new_solver_state
     state.add(0)
@@ -214,7 +214,7 @@ def test_savepoint_exception_rolls_back_and_propagates(new_solver_state):
     def trial_that_raises() -> None:
         with state.savepoint() as sp:
             state.add(5)
-            sp.keep()  # an exception rolls back even a kept scope
+            sp.keep()  # an exception restores even a kept scope
             raise RuntimeError("boom")
 
     # --- act ---------------------------------------------
@@ -237,7 +237,7 @@ def test_savepoint_restores_cached_score(new_solver_state):
         _ = state.score
 
     # --- assert ------------------------------------------
-    # rollback reinstates the score cached at scope entry (by reference; Score is immutable), clean
+    # the exit restores the score cached at scope entry (by reference; Score is immutable), clean
     assert state._score is score_before
     assert not state._score_dirty
 
@@ -464,14 +464,14 @@ def _apply_random_operation(state: SolverState, rng: random.Generator, open_save
     not_selected = state.not_selected_index_array
     operations = ["enter_savepoint"]
     if open_savepoints:
-        operations += ["exit_rollback", "exit_keep"]
+        operations += ["exit_restore", "exit_keep"]
     if not_selected.size > 0:
         operations += ["add", "add_many"]
     if selected.size > 0:
         operations += ["remove", "remove_many"]
 
     match rng.choice(operations):
-        case ("enter_savepoint" | "exit_rollback" | "exit_keep") as operation:
+        case ("enter_savepoint" | "exit_restore" | "exit_keep") as operation:
             _apply_savepoint_operation(state, operation, open_savepoints)
         case "add":
             state.add(rng.choice(not_selected))


### PR DESCRIPTION
**TL;DR**: Candidate trials now undo themselves by restoring a savepoint instead of running the inverse mutation — ~2.7× faster iterations at n=20000/k=2000, with the search bit-identical.

## Description

### Problem addressed

The solver makes provisional changes at two nesting levels but could only express one: the single snapshot slot is held by the enclosing swap, so `SolverPreset.SMART`'s two candidate loops undo their trials by **inverse mutation** — the removal loop with an `add`, the addition loop with a `remove_many`. Undoing a trial addition rescans the selection for every removed item, and the candidates being undone were chosen for being *far* from the selection, so they own the largest rescan cells. Those two undos measured **62.6% of iteration time** on large problems, the addition loop's alone 57.5%.

### Implementation

The snapshot slot becomes a **stack**, exposed as a scope object:

```python
with state.savepoint() as sp:   # everything in here is provisional
    state.remove(i)
    if state.score > best:
        sp.keep()               # ... unless we say otherwise
```

- **Rollback is the default**, so a trial reads as a plain `with` block and an exception inside the scope leaves the state untouched by construction.
- **All four provisional sites become scopes**: the swap level in the optimization base, both `OptimSmartSwaps` candidate loops, and the eager-initialization candidate loop.
- **The trackers' snapshot contract becomes push/pop** over their own stacks, fanned out by the tracker set as before.
- **The `set_snapshot`/`restore_snapshot` API is removed outright**, making the scope the only path to provisional state — by construction, not convention.
- **One reusable scope object per nesting depth** keeps scope entry allocation-free; savepoints hold full state copies, since a measured ~4 µs round trip displaces an up-to-642 µs inverse mutation.

Nothing about the search changes: mutations, their order, and the RNG draws are untouched, which is why the result is bit-identical.

## Attention points

- **A latent single-slot bug shaped the design**: the optimization base's accept path never restored *or* cleared its snapshot, relying on the next iteration overwriting the slot — correct for one slot, silently wrong for a stack. Scopes always pop on exit, removing that class of error.
- **An exception rolls back even a kept scope**, then propagates — a half-applied trial can never leak out of a failing block.
- **`Snapshot.is_valid` is gone**: the stack depth counter now delimits the live entries, so the flag was written but never read.

## Tests / Spikes

- **SPIKE:** an overnight three-arm comparison established the approach: 2.63× iteration rate at n=20000/k=2000, and 2.42× ± 0.05 sooner to the best third-party solver value on separation-family objectives; every arm crossed reference values at identical iteration counts (search unchanged).
- **TEST:** golden master passed unchanged on all 64 cases, with numba JIT enabled on Python 3.13 — the shipped version reproduces the spike's bit-exact behavior.
- **TEST:** before/after iteration-rate check of this branch against `main` (14000 timed iterations, n=20000/k=2000): **2.70×**.
- Unit tests: 6 new savepoint tests (default rollback, keep, nesting, kept-inner-discarded-by-rolled-back-outer, exception safety, cached-score restore); the randomized state/tracker invariant tests now drive nested snapshot stacks instead of a single slot.

## Changelog entry

Changed:

```
Solver iterations run more than 2× faster on separation-based metrics, so time-budgeted runs reach better selections
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
