### PR TITLE
refactor: route all distance reads through a pluggable distance store

### DIFF
--- a/src/max_div/_core/metrics/_distance/__init__.py
+++ b/src/max_div/_core/metrics/_distance/__init__.py
@@ -1,6 +1,11 @@
 from ._compute import (
     compute_pdist,
-    get_pdist_el,
     validate_cosine_vectors,
 )
 from ._enum import DistanceMetric
+from ._store import (
+    DISTANCE_STORE_TYPE,
+    DistanceStore,
+    condensed_store,
+    get_distance,
+)

--- a/src/max_div/_core/metrics/_distance/__init__.py
+++ b/src/max_div/_core/metrics/_distance/__init__.py
@@ -6,6 +6,5 @@ from ._enum import DistanceMetric
 from ._store import (
     DISTANCE_STORE_TYPE,
     DistanceStore,
-    condensed_store,
     get_distance,
 )

--- a/src/max_div/_core/metrics/_distance/_compute.py
+++ b/src/max_div/_core/metrics/_distance/_compute.py
@@ -20,7 +20,7 @@ def compute_pdist(vectors: NDArray[np.float32], metric: DistanceMetric) -> NDArr
     :param vectors: (n x d ndarray) A set of n vectors in d dimensions.
     :param metric: (DistanceMetric) The distance metric to use.
     :return: ((n*(n-1))//2 ndarray) condensed pair-wise distance vector, in scipy's layout: the
-                                         (i,j)-distance for i<j sits at the offset given by `_pdist_index`.
+                                         (i,j)-distance for i<j sits at the offset given by `_condensed_index`.
     """
     vectors = np.ascontiguousarray(vectors, dtype=np.float32)
     n = vectors.shape[0]
@@ -133,27 +133,3 @@ def _pdist_cos(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
         for j in range(i + 1, n):
             out[idx] = np.float32(0.5 * _l2sq_pair(normalized, i, j))
             idx += 1
-
-
-# =================================================================================================
-#  Low-level
-# =================================================================================================
-@numba.njit("int64(int32, int32, int32)", inline="always", cache=True)
-def _pdist_index(i_lo: np.int32, i_hi: np.int32, n: np.int32) -> np.int64:
-    """Return the condensed-vector offset of the (i_lo, i_hi) distance, with i_lo < i_hi, for n vectors.
-
-    The offset is evaluated in int64: the intermediate ``n * i_lo`` grows like n² and overflows int32
-    for n above ~46k, so the operands are widened before the multiply even though the final offset fits.
-    """
-    i_lo64 = np.int64(i_lo)
-    return (np.int64(n) * i_lo64) + np.int64(i_hi) - ((i_lo64 + 2) * (i_lo64 + 1)) // 2
-
-
-@numba.njit("float32(float32[::1], int32, int32, int32)", inline="always", cache=True)
-def get_pdist_el(pdist: NDArray[np.float32], i: np.int32, j: np.int32, n: np.int32) -> np.float32:
-    """Return element from 'pdist' array representing distance between vectors i & j, given n vectors in total."""
-    if i == j:
-        return np.float32(0.0)
-    if i < j:
-        return pdist[_pdist_index(i, j, n)]
-    return pdist[_pdist_index(j, i, n)]

--- a/src/max_div/_core/metrics/_distance/_store.py
+++ b/src/max_div/_core/metrics/_distance/_store.py
@@ -1,0 +1,85 @@
+"""Pluggable pairwise-distance storage: the read-only bundle njit kernels read distances from.
+
+The bundle is a namedtuple of numpy arrays and scalars, so it can cross the njit boundary without
+object-mode; fields a backend does not use hold zero-length arrays.  All solver kernels read
+through `get_distance`, which keeps the storage layout out of every call site.
+"""
+
+from typing import NamedTuple
+
+import numba
+import numpy as np
+from numpy.typing import NDArray
+
+# =================================================================================================
+#  DistanceStore
+# =================================================================================================
+# Backend selector values for DistanceStore.kind.
+KIND_CONDENSED = np.int32(0)
+
+
+class DistanceStore(NamedTuple):
+    """Read-only pairwise-distance storage for n items, passable into njit kernels.
+
+    Which field holds the distances is determined by `kind`; unused fields are zero-length
+    arrays (shared module-level singletons, so empty stores cost nothing).  Instances are
+    immutable by construction — kernels can only read, and copies of consuming objects can
+    safely share one store.
+    """
+
+    kind: np.int32
+    n: np.int32
+    condensed: NDArray[np.float32]  # (n*(n-1)/2,) condensed distances (scipy layout), KIND_CONDENSED
+    matrix: NDArray[np.float32]  # placeholder for a full (n, n) distance matrix backend
+    vectors: NDArray[np.float32]  # placeholder for an on-demand (n, d) vector backend
+    metric_kind: np.int32  # pair-kernel selector for the on-demand backend
+
+
+_EMPTY_1D = np.empty(0, dtype=np.float32)
+_EMPTY_2D = np.empty((0, 0), dtype=np.float32)
+
+
+def condensed_store(condensed: NDArray[np.float32], n: int) -> DistanceStore:
+    """Return a DistanceStore reading from a condensed distance vector (scipy layout).
+
+    :param condensed: ((n*(n-1))//2 ndarray) condensed pairwise distances, float32 C-contiguous.
+    :param n: (int) number of items.
+    """
+    return DistanceStore(
+        kind=KIND_CONDENSED,
+        n=np.int32(n),
+        condensed=condensed,
+        matrix=_EMPTY_2D,
+        vectors=_EMPTY_2D,
+        metric_kind=np.int32(0),
+    )
+
+
+# The numba type of every DistanceStore instance (all stores share it: field dtypes are fixed and
+# selectors are runtime values).  Signature strings cannot spell a namedtuple type, so kernels
+# taking a store use signature *objects* built from this constant.
+DISTANCE_STORE_TYPE = numba.typeof(condensed_store(_EMPTY_1D, 0))
+
+
+# =================================================================================================
+#  Distance reads
+# =================================================================================================
+@numba.njit("int64(int32, int32, int32)", inline="always", cache=True)
+def _condensed_index(i_lo: np.int32, i_hi: np.int32, n: np.int32) -> np.int64:
+    """Return the condensed-vector offset of the (i_lo, i_hi) distance, with i_lo < i_hi, for n items.
+
+    The offset is evaluated in int64: the intermediate ``n * i_lo`` grows like n² and overflows int32
+    for n above ~46k, so the operands are widened before the multiply even though the final offset fits.
+    """
+    i_lo64 = np.int64(i_lo)
+    return (np.int64(n) * i_lo64) + np.int64(i_hi) - ((i_lo64 + 2) * (i_lo64 + 1)) // 2
+
+
+@numba.njit(numba.float32(DISTANCE_STORE_TYPE, numba.int32, numba.int32), inline="always", cache=True)
+def get_distance(store: DistanceStore, i: np.int32, j: np.int32) -> np.float32:
+    """Return the distance between items i and j from whichever backend the store holds."""
+    if i == j:
+        return np.float32(0.0)
+    if i < j:
+        return store.condensed[_condensed_index(i, j, store.n)]
+    return store.condensed[_condensed_index(j, i, store.n)]

--- a/src/max_div/_core/metrics/_distance/_store.py
+++ b/src/max_div/_core/metrics/_distance/_store.py
@@ -17,48 +17,51 @@ from numpy.typing import NDArray
 # Backend selector values for DistanceStore.kind.
 KIND_CONDENSED = np.int32(0)
 
+# shared placeholders for the fields a backend does not use, so empty stores cost nothing
+_EMPTY_1D = np.empty(0, dtype=np.float32)
+_EMPTY_2D = np.empty((0, 0), dtype=np.float32)
+
 
 class DistanceStore(NamedTuple):
     """Read-only pairwise-distance storage for n items, passable into njit kernels.
 
     Which field holds the distances is determined by `kind`; unused fields are zero-length
-    arrays (shared module-level singletons, so empty stores cost nothing).  Instances are
-    immutable by construction — kernels can only read, and copies of consuming objects can
-    safely share one store.
+    arrays.  Instances are immutable by construction — kernels can only read, and copies of
+    consuming objects can safely share one store.  Create instances via the factory methods,
+    one per backend.
     """
 
     kind: np.int32
     n: np.int32
-    condensed: NDArray[np.float32]  # (n*(n-1)/2,) condensed distances (scipy layout), KIND_CONDENSED
+    pdist: NDArray[np.float32]  # (n*(n-1)/2,) condensed distances (scipy layout), KIND_CONDENSED
     matrix: NDArray[np.float32]  # placeholder for a full (n, n) distance matrix backend
     vectors: NDArray[np.float32]  # placeholder for an on-demand (n, d) vector backend
     metric_kind: np.int32  # pair-kernel selector for the on-demand backend
 
+    # --------------------------------------------------------------------------
+    #  Factory methods
+    # --------------------------------------------------------------------------
+    @classmethod
+    def condensed(cls, pdist: NDArray[np.float32], n: int) -> "DistanceStore":
+        """Return a DistanceStore reading from a condensed distance vector (scipy layout).
 
-_EMPTY_1D = np.empty(0, dtype=np.float32)
-_EMPTY_2D = np.empty((0, 0), dtype=np.float32)
-
-
-def condensed_store(condensed: NDArray[np.float32], n: int) -> DistanceStore:
-    """Return a DistanceStore reading from a condensed distance vector (scipy layout).
-
-    :param condensed: ((n*(n-1))//2 ndarray) condensed pairwise distances, float32 C-contiguous.
-    :param n: (int) number of items.
-    """
-    return DistanceStore(
-        kind=KIND_CONDENSED,
-        n=np.int32(n),
-        condensed=condensed,
-        matrix=_EMPTY_2D,
-        vectors=_EMPTY_2D,
-        metric_kind=np.int32(0),
-    )
+        :param pdist: ((n*(n-1))//2 ndarray) condensed pairwise distances, float32 C-contiguous.
+        :param n: (int) number of items.
+        """
+        return cls(
+            kind=KIND_CONDENSED,
+            n=np.int32(n),
+            pdist=pdist,
+            matrix=_EMPTY_2D,
+            vectors=_EMPTY_2D,
+            metric_kind=np.int32(0),
+        )
 
 
 # The numba type of every DistanceStore instance (all stores share it: field dtypes are fixed and
 # selectors are runtime values).  Signature strings cannot spell a namedtuple type, so kernels
 # taking a store use signature *objects* built from this constant.
-DISTANCE_STORE_TYPE = numba.typeof(condensed_store(_EMPTY_1D, 0))
+DISTANCE_STORE_TYPE = numba.typeof(DistanceStore.condensed(_EMPTY_1D, 0))
 
 
 # =================================================================================================
@@ -77,9 +80,14 @@ def _condensed_index(i_lo: np.int32, i_hi: np.int32, n: np.int32) -> np.int64:
 
 @numba.njit(numba.float32(DISTANCE_STORE_TYPE, numba.int32, numba.int32), inline="always", cache=True)
 def get_distance(store: DistanceStore, i: np.int32, j: np.int32) -> np.float32:
-    """Return the distance between items i and j from whichever backend the store holds."""
+    """Return the distance between items i and j from whichever backend the store holds.
+
+    Access-pattern note for loops over many pairs: fix one index and sweep the other in ascending
+    order — stored backends then read (mostly) contiguous memory, where sweeping the *fixed* index
+    instead strides ~n elements per step.  The tracker kernels all follow this fix-i-sweep-j shape.
+    """
     if i == j:
         return np.float32(0.0)
     if i < j:
-        return store.condensed[_condensed_index(i, j, store.n)]
-    return store.condensed[_condensed_index(j, i, store.n)]
+        return store.pdist[_condensed_index(i, j, store.n)]
+    return store.pdist[_condensed_index(j, i, store.n)]

--- a/src/max_div/_core/metrics/_distance/_store.py
+++ b/src/max_div/_core/metrics/_distance/_store.py
@@ -82,9 +82,9 @@ def _condensed_index(i_lo: np.int32, i_hi: np.int32, n: np.int32) -> np.int64:
 def get_distance(store: DistanceStore, i: np.int32, j: np.int32) -> np.float32:
     """Return the distance between items i and j from whichever backend the store holds.
 
-    Access-pattern note for loops over many pairs: fix one index and sweep the other in ascending
-    order — stored backends then read (mostly) contiguous memory, where sweeping the *fixed* index
-    instead strides ~n elements per step.  The tracker kernels all follow this fix-i-sweep-j shape.
+    Access-pattern note for loops over many pairs: keep `i` fixed and sweep `j` in ascending
+    order (the shape all tracker kernels follow).  Stored backends then read (mostly) contiguous
+    memory; the swapped nesting — sweeping `i` under a fixed `j` — strides ~n elements per read.
     """
     if i == j:
         return np.float32(0.0)

--- a/src/max_div/_core/solver/_diversity_contribution/_factory.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_factory.py
@@ -8,23 +8,21 @@ from ._mean_distance import MeanDistanceTracker
 from ._separation import SeparationTracker
 
 if TYPE_CHECKING:
-    import numpy as np
-    from numpy.typing import NDArray
+    from max_div._core.metrics._distance import DistanceStore
 
     from ._base import DiversityContributionTracker
 
 
 def build_diversity_contribution_tracker(
-    family: DiversityContributionFamily, pdist: NDArray[np.float32], n: np.int32
+    family: DiversityContributionFamily, store: DistanceStore
 ) -> DiversityContributionTracker:
     """Build a fresh (empty-selection) diversity-contribution tracker for the given contribution family.
 
     :param family: (DiversityContributionFamily) the contribution family to track.
-    :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
-    :param n: (np.int32) number of items
+    :param store: (DistanceStore) pairwise-distance storage the tracker reads from.
     """
     match family:
         case DiversityContributionFamily.SEPARATION:
-            return SeparationTracker(pdist, n)
+            return SeparationTracker(store)
         case DiversityContributionFamily.MEAN_DISTANCE:
-            return MeanDistanceTracker(pdist, n)
+            return MeanDistanceTracker(store)

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import numba
 import numpy as np
 
-from max_div._core.metrics._distance import get_pdist_el
+from max_div._core.metrics._distance import DISTANCE_STORE_TYPE, DistanceStore, get_distance
 
 from ._base import DiversityContributionTracker
 
@@ -21,39 +21,34 @@ if TYPE_CHECKING:
 # iterations, and float32 drift there would change scores with iteration count.  Distances of a
 # point to itself are 0, so a point's own entry never needs special-casing: it always equals the
 # sum of its distances to the *other* selected points.
-@numba.njit("float64[::1](float32[::1], int32)", cache=True)
-def compute_distance_sums(pdist: NDArray[np.float32], n: np.int32) -> NDArray[np.float64]:
-    """Compute sum of distances of each item wrt all others, given pairwise distance array pdist and n items."""
+@numba.njit(numba.float64[::1](DISTANCE_STORE_TYPE), cache=True)
+def compute_distance_sums(store: DistanceStore) -> NDArray[np.float64]:
+    """Compute sum of distances of each item wrt all others, given the distance store."""
+    n = store.n
     dist_sums = np.zeros(n, dtype=np.float64)
-    pdist_idx = 0
-    for i in range(n):
-        for j in range(i + 1, n):
-            # note: the way we iterate over i & j represents the exact order in which pdist stores distances
-            dist_ij = np.float64(pdist[pdist_idx])
-            pdist_idx += 1
-            dist_sums[i] += dist_ij
-            dist_sums[j] += dist_ij
+    # partners are visited in ascending index per item, so each float64 sum accumulates in the
+    # same order however the store lays distances out — sums stay bit-equal across backends
+    for i in np.arange(n, dtype=np.int32):
+        for j in np.arange(n, dtype=np.int32):
+            if j != i:
+                dist_sums[i] += np.float64(get_distance(store, i, j))
     return dist_sums
 
 
-@numba.njit("void(float64[::1], float32[::1], int32, int32)", cache=True)
-def update_distance_sums_add(
-    dist_sums: NDArray[np.float64], pdist: NDArray[np.float32], n: np.int32, i_added: np.int32
-) -> None:
-    """Update distance sums of each item wrt selection, given pdist array and n items, after adding i_added."""
-    for j in np.arange(n, dtype=np.int32):
+@numba.njit(numba.void(numba.float64[::1], DISTANCE_STORE_TYPE, numba.int32), cache=True)
+def update_distance_sums_add(dist_sums: NDArray[np.float64], store: DistanceStore, i_added: np.int32) -> None:
+    """Update distance sums of each item wrt selection, given the distance store, after adding i_added."""
+    for j in np.arange(store.n, dtype=np.int32):
         if j != i_added:
-            dist_sums[j] += np.float64(get_pdist_el(pdist, i_added, j, n))
+            dist_sums[j] += np.float64(get_distance(store, i_added, j))
 
 
-@numba.njit("void(float64[::1], float32[::1], int32, int32)", cache=True)
-def update_distance_sums_remove(
-    dist_sums: NDArray[np.float64], pdist: NDArray[np.float32], n: np.int32, i_removed: np.int32
-) -> None:
-    """Update distance sums of each item wrt selection, given pdist array and n items, after removing i_removed."""
-    for j in np.arange(n, dtype=np.int32):
+@numba.njit(numba.void(numba.float64[::1], DISTANCE_STORE_TYPE, numba.int32), cache=True)
+def update_distance_sums_remove(dist_sums: NDArray[np.float64], store: DistanceStore, i_removed: np.int32) -> None:
+    """Update distance sums of each item wrt selection, given the distance store, after removing i_removed."""
+    for j in np.arange(store.n, dtype=np.int32):
         if j != i_removed:
-            dist_sums[j] -= np.float64(get_pdist_el(pdist, i_removed, j, n))
+            dist_sums[j] -= np.float64(get_distance(store, i_removed, j))
 
 
 # =================================================================================================
@@ -77,37 +72,34 @@ class MeanDistanceTracker(DiversityContributionTracker):
     # -------------------------------------------------------------------------
     def __init__(
         self,
-        pdist: NDArray[np.float32],
-        n: np.int32,
+        store: DistanceStore,
         contribution_wrt_dataset: NDArray[np.float32] | None = None,
         dist_sums: NDArray[np.float64] | None = None,
     ) -> None:
         """Initialize the MeanDistanceTracker for an empty selection.
 
-        :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
-        :param n: (np.int32) number of items
+        :param store: (DistanceStore) pairwise-distance storage; immutable, so shareable across copies.
         :param contribution_wrt_dataset: (np.ndarray[np.float32] | None) precomputed global contribution;
                                     computed if omitted.
         :param dist_sums: (np.ndarray[np.float64] | None) current distance sums wrt selection; fresh (all 0.0,
                           i.e. empty selection) if omitted.  Together with `contribution_wrt_dataset` this
                           enables copies without recomputation.
         """
-        self._pdist = pdist  # READ-ONLY
-        self._n = n  # READ-ONLY
+        self._store = store  # READ-ONLY
         if contribution_wrt_dataset is not None:
             self._contribution_wrt_dataset = contribution_wrt_dataset  # READ-ONLY
         else:
-            self._contribution_wrt_dataset = (compute_distance_sums(pdist, n) / max(int(n) - 1, 1)).astype(np.float32)
-        self._dist_sums = dist_sums if dist_sums is not None else np.zeros(n, dtype=np.float64)
+            n = int(store.n)
+            self._contribution_wrt_dataset = (compute_distance_sums(store) / max(n - 1, 1)).astype(np.float32)
+        self._dist_sums = dist_sums if dist_sums is not None else np.zeros(store.n, dtype=np.float64)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
         self._snapshot_dist_sums: list[NDArray[np.float64]] = []
 
     def copy(self) -> MeanDistanceTracker:
-        """Return a deep copy of this tracker (without recomputing the global contribution)."""
+        """Return an independent copy of this tracker; the immutable store and global contributions are shared."""
         return MeanDistanceTracker(
-            pdist=self._pdist.copy(),
-            n=self._n,
-            contribution_wrt_dataset=self._contribution_wrt_dataset.copy(),
+            store=self._store,
+            contribution_wrt_dataset=self._contribution_wrt_dataset,
             dist_sums=self._dist_sums.copy(),
         )
 
@@ -130,14 +122,14 @@ class MeanDistanceTracker(DiversityContributionTracker):
     # -------------------------------------------------------------------------
     def add(self, index: np.int32) -> None:
         """Update distance sums after adding point `index` to the selection."""
-        update_distance_sums_add(self._dist_sums, self._pdist, self._n, index)
+        update_distance_sums_add(self._dist_sums, self._store, index)
 
     def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
         """Update distance sums after removing point `index`.
 
         `new_selection` is not needed by this tracker: removal is exact subtraction.
         """
-        update_distance_sums_remove(self._dist_sums, self._pdist, self._n, index)
+        update_distance_sums_remove(self._dist_sums, self._store, index)
 
     # -------------------------------------------------------------------------
     #  Snapshot

--- a/src/max_div/_core/solver/_diversity_contribution/_separation.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_separation.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import numba
 import numpy as np
 
-from max_div._core.metrics._distance import get_pdist_el
+from max_div._core.metrics._distance import DISTANCE_STORE_TYPE, DistanceStore, get_distance
 
 from ._base import DiversityContributionTracker
 
@@ -16,50 +16,48 @@ if TYPE_CHECKING:
 # =================================================================================================
 #  Separation kernels
 # =================================================================================================
-@numba.njit("float32[::1](float32[::1], int32)", cache=True)
-def compute_separation(pdist: NDArray[np.float32], n: np.int32) -> NDArray[np.float32]:
-    """Compute separation of each item wrt all others, given pairwise distance array pdist and n items in total."""
+@numba.njit(numba.float32[::1](DISTANCE_STORE_TYPE), cache=True)
+def compute_separation(store: DistanceStore) -> NDArray[np.float32]:
+    """Compute separation of each item wrt all others, given the distance store."""
+    n = store.n
     sep = np.full(n, fill_value=np.inf, dtype=np.float32)
-    pdist_idx = 0
-    for i in range(n):
-        for j in range(i + 1, n):
-            # note: the way we iterate over i & j represents the exact order in which pdist stores distances
-            dist_ij = pdist[pdist_idx]
-            pdist_idx += 1
-            sep[i] = min(sep[i], dist_ij)
-            sep[j] = min(sep[j], dist_ij)
+    for i in np.arange(n, dtype=np.int32):
+        for j in np.arange(n, dtype=np.int32):
+            if j != i:
+                dist_ij = get_distance(store, i, j)
+                if dist_ij < sep[i]:
+                    sep[i] = dist_ij
     return sep
 
 
-@numba.njit("void(float32[::1], float32[::1], int32, int32)", cache=True)
-def update_separation_add(sep: NDArray[np.float32], pdist: NDArray[np.float32], n: np.int32, i_added: np.int32) -> None:
-    """Update separation of each item wrt selection, given pdist array and n items, after adding i_added."""
-    for j in np.arange(n, dtype=np.int32):
+@numba.njit(numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32), cache=True)
+def update_separation_add(sep: NDArray[np.float32], store: DistanceStore, i_added: np.int32) -> None:
+    """Update separation of each item wrt selection, given the distance store, after adding i_added."""
+    for j in np.arange(store.n, dtype=np.int32):
         if j != i_added:
-            dist = get_pdist_el(pdist, i_added, j, n)
+            dist = get_distance(store, i_added, j)
             if dist < sep[j]:
                 sep[j] = dist
 
 
-@numba.njit("void(float32[::1], float32[::1], int32, int32, int32[::1])", cache=True)
+@numba.njit(numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32, numba.int32[::1]), cache=True)
 def update_separation_remove(
     sep: NDArray[np.float32],
-    pdist: NDArray[np.float32],
-    n: np.int32,
+    store: DistanceStore,
     i_removed: np.int32,
     new_selection: NDArray[np.int32],
 ) -> None:
-    """Update separation of each item wrt selection, given pdist array and n items, after removing i_removed."""
-    for j in np.arange(n, dtype=np.int32):
+    """Update separation of each item wrt selection, given the distance store, after removing i_removed."""
+    for j in np.arange(store.n, dtype=np.int32):
         if j != i_removed:
-            dist = get_pdist_el(pdist, i_removed, j, n)
+            dist = get_distance(store, i_removed, j)
             if dist <= sep[j]:
                 # need to recompute sep[j]
                 new_sep_j = np.inf
                 for k in new_selection:
                     # only compute distance to currently selected items
                     if k != j:
-                        dist_jk = get_pdist_el(pdist, j, k, n)
+                        dist_jk = get_distance(store, j, k)
                         if dist_jk < new_sep_j:
                             new_sep_j = dist_jk
                 sep[j] = new_sep_j
@@ -81,33 +79,29 @@ class SeparationTracker(DiversityContributionTracker):
     # -------------------------------------------------------------------------
     def __init__(
         self,
-        pdist: NDArray[np.float32],
-        n: np.int32,
+        store: DistanceStore,
         sep_global: NDArray[np.float32] | None = None,
         sep_selected: NDArray[np.float32] | None = None,
     ) -> None:
         """Initialize the SeparationTracker for an empty selection.
 
-        :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
-        :param n: (np.int32) number of items
+        :param store: (DistanceStore) pairwise-distance storage; immutable, so shareable across copies.
         :param sep_global: (np.ndarray[np.float32] | None) precomputed global separations; computed if omitted.
         :param sep_selected: (np.ndarray[np.float32] | None) current separations wrt selection; fresh (all +inf,
                              i.e. empty selection) if omitted.  Together with `sep_global` this enables copies
                              without recomputation.
         """
-        self._pdist = pdist  # READ-ONLY
-        self._n = n  # READ-ONLY
-        self._sep_global = sep_global if sep_global is not None else compute_separation(pdist, n)  # READ-ONLY
-        self._sep_selected = sep_selected if sep_selected is not None else np.full(n, np.inf, dtype=np.float32)
+        self._store = store  # READ-ONLY
+        self._sep_global = sep_global if sep_global is not None else compute_separation(store)  # READ-ONLY
+        self._sep_selected = sep_selected if sep_selected is not None else np.full(store.n, np.inf, dtype=np.float32)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
         self._snapshot_sep_selected: list[NDArray[np.float32]] = []
 
     def copy(self) -> SeparationTracker:
-        """Return a deep copy of this tracker (without recomputing global separations)."""
+        """Return an independent copy of this tracker; the immutable store and global separations are shared."""
         return SeparationTracker(
-            pdist=self._pdist.copy(),
-            n=self._n,
-            sep_global=self._sep_global.copy(),
+            store=self._store,
+            sep_global=self._sep_global,
             sep_selected=self._sep_selected.copy(),
         )
 
@@ -128,11 +122,11 @@ class SeparationTracker(DiversityContributionTracker):
     # -------------------------------------------------------------------------
     def add(self, index: np.int32) -> None:
         """Update separations after adding point `index` to the selection."""
-        update_separation_add(self._sep_selected, self._pdist, self._n, index)
+        update_separation_add(self._sep_selected, self._store, index)
 
     def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
         """Update separations after removing point `index`, rescanning against `new_selection` where needed."""
-        update_separation_remove(self._sep_selected, self._pdist, self._n, index, new_selection)
+        update_separation_remove(self._sep_selected, self._store, index, new_selection)
 
     # -------------------------------------------------------------------------
     #  Snapshot

--- a/src/max_div/_core/solver/_diversity_contribution/_trackers.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_trackers.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from max_div._core.metrics import DiversityMetric
+    from max_div._core.metrics._distance import DistanceStore
 
     from ._base import DiversityContributionTracker
 
@@ -70,20 +71,18 @@ class DiversityContributionTrackers:
         cls,
         diversity_metric: DiversityMetric,
         diversity_tie_breakers: list[DiversityMetric],
-        pdist: NDArray[np.float32],
-        n: np.int32,
+        store: DistanceStore,
     ) -> DiversityContributionTrackers:
         """Build the tracker set required by the given metrics (main metric's family first).
 
         :param diversity_metric: (DiversityMetric) the main diversity metric.
         :param diversity_tie_breakers: (list[DiversityMetric]) the configured tie-breaker metrics.
-        :param pdist: (np.ndarray[np.float32]) condensed pair-wise distance vector (1D array of size (n*(n-1))//2)
-        :param n: (np.int32) number of items
+        :param store: (DistanceStore) pairwise-distance storage the trackers read from.
         """
         main_family = diversity_metric.contribution_family
         families = dict.fromkeys([main_family, *(tb.contribution_family for tb in diversity_tie_breakers)])
         return cls(
-            trackers_by_family={family: build_diversity_contribution_tracker(family, pdist, n) for family in families},
+            trackers_by_family={family: build_diversity_contribution_tracker(family, store) for family in families},
             main_family=main_family,
         )
 

--- a/src/max_div/_core/solver/_solver.py
+++ b/src/max_div/_core/solver/_solver.py
@@ -1,9 +1,8 @@
-import numpy as np
-
 from max_div._core._utils import Timer, deterministic_hash, ljust_str_list
 from max_div._core.constraints import Constraint
 from max_div._core.constraints._constraints import _np_con_count_satisfied
 from max_div._core.metrics import DiversityMetric
+from max_div._core.metrics._distance import DistanceStore
 
 from ._constraint_penalty import ConstraintPenalty
 from ._duration import Elapsed
@@ -26,7 +25,7 @@ class MaxDivSolver:
     def __init__(
         self,
         n: int,
-        pdist: np.ndarray,
+        store: DistanceStore,
         k: int,
         diversity_metric: DiversityMetric,
         diversity_tie_breakers: list[DiversityMetric],
@@ -38,7 +37,7 @@ class MaxDivSolver:
         """Initialize the MaxDivSolver with the given configuration.
 
         :param n: (int) The number of items in the problem ('universe').
-        :param pdist: ((n*(n-1))//2 ndarray) Condensed pairwise-distance vector (scipy layout).
+        :param store: (DistanceStore) Pairwise-distance storage the solver reads from.
         :param k: (int) The number of items to be selected from the input set ('universe').
         :param diversity_metric: (DiversityMetric) The diversity metric to use.
         :param diversity_tie_breakers: (list[DiversityMetric]) A list of diversity tie-breaker metrics to use.
@@ -51,7 +50,7 @@ class MaxDivSolver:
         """
         # --- problem description -------------------------
         self._n = n
-        self._pdist = pdist
+        self._store = store
         self._k = k
         self._diversity_metric = diversity_metric
         self._constraints = constraints
@@ -113,7 +112,7 @@ class MaxDivSolver:
             progress_reporter.solver_step_started(step_names[0])
             state = SolverState.new(
                 n=self._n,
-                pdist=self._pdist,
+                store=self._store,
                 k=self._k,
                 diversity_metric=self._diversity_metric,
                 diversity_tie_breakers=self._diversity_tie_breakers,

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING, Self
 
 from max_div._core.metrics import DiversityMetric
-from max_div._core.metrics._distance import DistanceStore, condensed_store
+from max_div._core.metrics._distance import DistanceStore
 from max_div._core.problem import MaxDivProblem
 
 from ._constraint_penalty import ConstraintPenalty
@@ -33,7 +33,7 @@ class MaxDivSolverBuilder:
 
         # --- problem properties ----------------
         self._n: int = problem.n
-        self._store: DistanceStore = condensed_store(problem.condensed_distances(), problem.n)
+        self._store: DistanceStore = DistanceStore.condensed(problem.condensed_distances(), problem.n)
         self._k: int = problem.k
         self._diversity_metric: DiversityMetric = problem.diversity_metric
         self._constraints: list[Constraint] = problem.constraints

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING, Self
 
 from max_div._core.metrics import DiversityMetric
+from max_div._core.metrics._distance import DistanceStore, condensed_store
 from max_div._core.problem import MaxDivProblem
 
 from ._constraint_penalty import ConstraintPenalty
@@ -11,8 +12,6 @@ from ._solver_step import InitializationStep, OptimizationStep, SolverStep
 from ._strategies import InitializationStrategy
 
 if TYPE_CHECKING:
-    import numpy as np
-
     from max_div._core.constraints import Constraint
 
 
@@ -34,7 +33,7 @@ class MaxDivSolverBuilder:
 
         # --- problem properties ----------------
         self._n: int = problem.n
-        self._pdist: np.ndarray = problem.condensed_distances()
+        self._store: DistanceStore = condensed_store(problem.condensed_distances(), problem.n)
         self._k: int = problem.k
         self._diversity_metric: DiversityMetric = problem.diversity_metric
         self._constraints: list[Constraint] = problem.constraints
@@ -152,7 +151,7 @@ class MaxDivSolverBuilder:
     def build(self) -> MaxDivSolver:
         return MaxDivSolver(
             n=self._n,
-            pdist=self._pdist,
+            store=self._store,
             k=self._k,
             diversity_metric=self._diversity_metric,
             diversity_tie_breakers=self._determine_diversity_tie_breakers(),

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
     from max_div._core.metrics import DiversityMetric
+    from max_div._core.metrics._distance import DistanceStore
 
 
 # =================================================================================================
@@ -373,7 +374,7 @@ class SolverState:
     def new(
         cls,
         n: int,
-        pdist: NDArray[np.float32],
+        store: DistanceStore,
         k: int,
         diversity_metric: DiversityMetric,
         diversity_tie_breakers: list[DiversityMetric],
@@ -383,7 +384,7 @@ class SolverState:
         # --- diversity contributions ---
         n_np = np.int32(n)
         contribution_trackers = DiversityContributionTrackers.for_metrics(
-            diversity_metric, diversity_tie_breakers, pdist, n_np
+            diversity_metric, diversity_tie_breakers, store
         )
 
         # --- selection ---

--- a/tests/_core/metrics/test_distance_metric.py
+++ b/tests/_core/metrics/test_distance_metric.py
@@ -1,14 +1,11 @@
 import numpy as np
 import pytest
 from scipy.spatial.distance import pdist as scipy_pdist
-from scipy.spatial.distance import squareform
 
 from max_div._core.metrics._distance import (
     DistanceMetric,
     compute_pdist,
-    get_pdist_el,
 )
-from max_div._core.metrics._distance._compute import _pdist_index
 
 _SCIPY_METRIC = {
     "L1_MANHATTAN": "cityblock",
@@ -120,48 +117,3 @@ def test_compute_pdist_zero_for_identical_vectors(metric: DistanceMetric):
 
     # --- assert ------------------------------------------
     assert result[0] == np.float32(0.0)  # distance between the two identical vectors
-
-
-# -------------------------------------------------------------------------
-#  Low-level
-# -------------------------------------------------------------------------
-@pytest.mark.parametrize("i", [0, 1, 2, 3])
-@pytest.mark.parametrize("j", [0, 1, 2, 3])
-def test_get_pdist_values(i: int, j: int):
-    """Check if get_pdist produces correct values."""
-
-    # --- arrange -----------------------------------------
-    vectors = np.array([[0, 0], [3, 4], [1, 0], [0, 2]], dtype=np.float32)
-    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
-    m = vectors.shape[0]
-
-    expected_value = squareform(d)[i, j]
-
-    # --- act ---------------------------------------------
-    value = get_pdist_el(d, np.int32(i), np.int32(j), np.int32(m))
-
-    # --- assert ------------------------------------------
-    assert value == pytest.approx(expected_value)
-
-
-@pytest.mark.parametrize(
-    "i, j, n",
-    [
-        (0, 1, 4),  # first pair, small n
-        (2, 3, 4),  # last pair, small n
-        (30_000, 45_000, 50_000),  # off-diagonal in the int32-overflow regime
-        (49_998, 49_999, 50_000),  # last pair at n where 32-bit index math overflows
-    ],
-)
-def test_pdist_index_no_int32_overflow(i: int, j: int, n: int):
-    """_pdist_index must return the exact condensed offset even where int32 arithmetic would overflow."""
-
-    # --- arrange -----------------------------------------
-    # reference offset computed with unbounded Python ints (the value the kernel must match)
-    expected = (n * i) + j - ((i + 2) * (i + 1)) // 2
-
-    # --- act ---------------------------------------------
-    index = _pdist_index(np.int32(i), np.int32(j), np.int32(n))
-
-    # --- assert ------------------------------------------
-    assert int(index) == expected

--- a/tests/_core/metrics/test_distance_store.py
+++ b/tests/_core/metrics/test_distance_store.py
@@ -1,0 +1,82 @@
+import numpy as np
+import pytest
+from scipy.spatial.distance import squareform
+
+from max_div._core.metrics._distance import (
+    DistanceMetric,
+    DistanceStore,
+    compute_pdist,
+    condensed_store,
+    get_distance,
+)
+from max_div._core.metrics._distance._store import KIND_CONDENSED, _condensed_index
+
+
+# -------------------------------------------------------------------------
+#  condensed_store
+# -------------------------------------------------------------------------
+def test_condensed_store_fields():
+    """A condensed store holds the given distances and n; unused backend fields are zero-size."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0, 0], [3, 4], [1, 0], [0, 2]], dtype=np.float32)
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+
+    # --- act ---------------------------------------------
+    store = condensed_store(d, n=4)
+
+    # --- assert ------------------------------------------
+    assert isinstance(store, DistanceStore)
+    assert store.kind == KIND_CONDENSED
+    assert store.n == np.int32(4)
+    assert store.condensed is d
+    assert store.matrix.size == 0
+    assert store.vectors.size == 0
+
+
+# -------------------------------------------------------------------------
+#  get_distance
+# -------------------------------------------------------------------------
+@pytest.mark.parametrize("i", [0, 1, 2, 3])
+@pytest.mark.parametrize("j", [0, 1, 2, 3])
+def test_get_distance_condensed_values(i: int, j: int):
+    """get_distance returns the correct condensed-layout value for every (i, j), including i == j."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0, 0], [3, 4], [1, 0], [0, 2]], dtype=np.float32)
+    d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
+    store = condensed_store(d, n=vectors.shape[0])
+
+    expected_value = squareform(d)[i, j]
+
+    # --- act ---------------------------------------------
+    value = get_distance(store, np.int32(i), np.int32(j))
+
+    # --- assert ------------------------------------------
+    assert value == pytest.approx(expected_value)
+
+
+# -------------------------------------------------------------------------
+#  Low-level
+# -------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "i, j, n",
+    [
+        (0, 1, 4),  # first pair, small n
+        (2, 3, 4),  # last pair, small n
+        (30_000, 45_000, 50_000),  # off-diagonal in the int32-overflow regime
+        (49_998, 49_999, 50_000),  # last pair at n where 32-bit index math overflows
+    ],
+)
+def test_condensed_index_no_int32_overflow(i: int, j: int, n: int):
+    """_condensed_index must return the exact condensed offset even where int32 arithmetic would overflow."""
+
+    # --- arrange -----------------------------------------
+    # reference offset computed with unbounded Python ints (the value the kernel must match)
+    expected = (n * i) + j - ((i + 2) * (i + 1)) // 2
+
+    # --- act ---------------------------------------------
+    index = _condensed_index(np.int32(i), np.int32(j), np.int32(n))
+
+    # --- assert ------------------------------------------
+    assert int(index) == expected

--- a/tests/_core/metrics/test_distance_store.py
+++ b/tests/_core/metrics/test_distance_store.py
@@ -6,16 +6,15 @@ from max_div._core.metrics._distance import (
     DistanceMetric,
     DistanceStore,
     compute_pdist,
-    condensed_store,
     get_distance,
 )
 from max_div._core.metrics._distance._store import KIND_CONDENSED, _condensed_index
 
 
 # -------------------------------------------------------------------------
-#  condensed_store
+#  DistanceStore.condensed
 # -------------------------------------------------------------------------
-def test_condensed_store_fields():
+def test_condensed_factory_fields():
     """A condensed store holds the given distances and n; unused backend fields are zero-size."""
 
     # --- arrange -----------------------------------------
@@ -23,13 +22,13 @@ def test_condensed_store_fields():
     d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
 
     # --- act ---------------------------------------------
-    store = condensed_store(d, n=4)
+    store = DistanceStore.condensed(d, n=4)
 
     # --- assert ------------------------------------------
     assert isinstance(store, DistanceStore)
     assert store.kind == KIND_CONDENSED
     assert store.n == np.int32(4)
-    assert store.condensed is d
+    assert store.pdist is d
     assert store.matrix.size == 0
     assert store.vectors.size == 0
 
@@ -45,7 +44,7 @@ def test_get_distance_condensed_values(i: int, j: int):
     # --- arrange -----------------------------------------
     vectors = np.array([[0, 0], [3, 4], [1, 0], [0, 2]], dtype=np.float32)
     d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
-    store = condensed_store(d, n=vectors.shape[0])
+    store = DistanceStore.condensed(d, n=vectors.shape[0])
 
     expected_value = squareform(d)[i, j]
 

--- a/tests/_core/solver/_diversity_contribution/test_factory.py
+++ b/tests/_core/solver/_diversity_contribution/test_factory.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from max_div._core.metrics import DistanceMetric, DiversityContributionFamily
-from max_div._core.metrics._distance import compute_pdist, condensed_store
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import (
     MeanDistanceTracker,
     SeparationTracker,
@@ -20,7 +20,7 @@ from max_div._core.solver._diversity_contribution import (
 def test_build_diversity_contribution_tracker(family: DiversityContributionFamily, expected_type: type):
     # --- arrange -----------------------------------------
     vectors = np.array([[0.0], [1.0], [3.0]], dtype=np.float32)
-    store = condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=3)
+    store = DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=3)
 
     # --- act ---------------------------------------------
     tracker = build_diversity_contribution_tracker(family, store)

--- a/tests/_core/solver/_diversity_contribution/test_factory.py
+++ b/tests/_core/solver/_diversity_contribution/test_factory.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from max_div._core.metrics import DistanceMetric, DiversityContributionFamily
-from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance import compute_pdist, condensed_store
 from max_div._core.solver._diversity_contribution import (
     MeanDistanceTracker,
     SeparationTracker,
@@ -20,10 +20,10 @@ from max_div._core.solver._diversity_contribution import (
 def test_build_diversity_contribution_tracker(family: DiversityContributionFamily, expected_type: type):
     # --- arrange -----------------------------------------
     vectors = np.array([[0.0], [1.0], [3.0]], dtype=np.float32)
-    pdist = compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
+    store = condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=3)
 
     # --- act ---------------------------------------------
-    tracker = build_diversity_contribution_tracker(family, pdist, np.int32(3))
+    tracker = build_diversity_contribution_tracker(family, store)
 
     # --- assert ------------------------------------------
     assert type(tracker) is expected_type

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -4,7 +4,7 @@ from numpy import random
 from scipy.spatial.distance import squareform
 
 from max_div._core.metrics import DistanceMetric
-from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance import compute_pdist, condensed_store
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker
 from max_div._core.solver._diversity_contribution._mean_distance import (
     compute_distance_sums,
@@ -27,7 +27,7 @@ def pdist() -> np.ndarray:
 
 @pytest.fixture
 def tracker(pdist: np.ndarray) -> MeanDistanceTracker:
-    return MeanDistanceTracker(pdist, np.int32(N))
+    return MeanDistanceTracker(condensed_store(pdist, n=N))
 
 
 def _selection_args(indices: list[int]) -> tuple[np.ndarray, np.int32]:
@@ -71,7 +71,7 @@ def test_construction_precomputed_arrays_skip_recompute(pdist: np.ndarray):
 
     # --- act ---------------------------------------------
     tracker = MeanDistanceTracker(
-        pdist, np.int32(N), contribution_wrt_dataset=contribution_wrt_dataset, dist_sums=dist_sums
+        condensed_store(pdist, n=N), contribution_wrt_dataset=contribution_wrt_dataset, dist_sums=dist_sums
     )
 
     # --- assert ------------------------------------------
@@ -174,7 +174,9 @@ def test_copy_is_independent(tracker: MeanDistanceTracker):
 
     # --- assert ------------------------------------------
     np.testing.assert_array_equal(clone.contribution_wrt_selection(selected, n_selected), contribution_before)
-    assert clone.contribution_wrt_dataset is not tracker.contribution_wrt_dataset
+    # the immutable store and global contributions are shared by contract, not duplicated
+    assert clone._store is tracker._store
+    assert clone.contribution_wrt_dataset is tracker.contribution_wrt_dataset
 
 
 # =================================================================================================
@@ -191,7 +193,7 @@ def test_compute_distance_sums():
     expected = squareform(d).astype(np.float64).sum(axis=1)
 
     # --- act ---------------------------------------------
-    dist_sums = compute_distance_sums(d, np.int32(m))
+    dist_sums = compute_distance_sums(condensed_store(d, n=m))
 
     # --- assert ------------------------------------------
     assert dist_sums.dtype == np.float64
@@ -217,12 +219,12 @@ def test_update_distance_sums_add_remove():
 
     # --- act / assert ------------------------------------
     for index in [3, 17, 0, 9, 12]:
-        update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(index))
+        update_distance_sums_add(dist_sums, condensed_store(d, n=m), np.int32(index))
         selection.append(index)
         np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
 
     for index in [0, 3, 12]:
-        update_distance_sums_remove(dist_sums, d, np.int32(m), np.int32(index))
+        update_distance_sums_remove(dist_sums, condensed_store(d, n=m), np.int32(index))
         selection.remove(index)
         np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
 
@@ -237,12 +239,12 @@ def test_update_distance_sums_own_entry_untouched():
     dist_sums = np.zeros(m, dtype=np.float64)
 
     # selection {1}: point 1's own entry stays 0 (no other selected points yet)
-    update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(1))
+    update_distance_sums_add(dist_sums, condensed_store(d, n=m), np.int32(1))
     assert dist_sums[1] == 0.0
 
     # --- act ---------------------------------------------
     # selection {1, 2}: point 2's own entry must equal its distance to point 1 only
-    update_distance_sums_add(dist_sums, d, np.int32(m), np.int32(2))
+    update_distance_sums_add(dist_sums, condensed_store(d, n=m), np.int32(2))
 
     # --- assert ------------------------------------------
     assert dist_sums[2] == pytest.approx(squareform(d)[2, 1])

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -4,7 +4,7 @@ from numpy import random
 from scipy.spatial.distance import squareform
 
 from max_div._core.metrics import DistanceMetric
-from max_div._core.metrics._distance import compute_pdist, condensed_store
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker
 from max_div._core.solver._diversity_contribution._mean_distance import (
     compute_distance_sums,
@@ -27,7 +27,7 @@ def pdist() -> np.ndarray:
 
 @pytest.fixture
 def tracker(pdist: np.ndarray) -> MeanDistanceTracker:
-    return MeanDistanceTracker(condensed_store(pdist, n=N))
+    return MeanDistanceTracker(DistanceStore.condensed(pdist, n=N))
 
 
 def _selection_args(indices: list[int]) -> tuple[np.ndarray, np.int32]:
@@ -71,7 +71,7 @@ def test_construction_precomputed_arrays_skip_recompute(pdist: np.ndarray):
 
     # --- act ---------------------------------------------
     tracker = MeanDistanceTracker(
-        condensed_store(pdist, n=N), contribution_wrt_dataset=contribution_wrt_dataset, dist_sums=dist_sums
+        DistanceStore.condensed(pdist, n=N), contribution_wrt_dataset=contribution_wrt_dataset, dist_sums=dist_sums
     )
 
     # --- assert ------------------------------------------
@@ -193,7 +193,7 @@ def test_compute_distance_sums():
     expected = squareform(d).astype(np.float64).sum(axis=1)
 
     # --- act ---------------------------------------------
-    dist_sums = compute_distance_sums(condensed_store(d, n=m))
+    dist_sums = compute_distance_sums(DistanceStore.condensed(d, n=m))
 
     # --- assert ------------------------------------------
     assert dist_sums.dtype == np.float64
@@ -219,12 +219,12 @@ def test_update_distance_sums_add_remove():
 
     # --- act / assert ------------------------------------
     for index in [3, 17, 0, 9, 12]:
-        update_distance_sums_add(dist_sums, condensed_store(d, n=m), np.int32(index))
+        update_distance_sums_add(dist_sums, DistanceStore.condensed(d, n=m), np.int32(index))
         selection.append(index)
         np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
 
     for index in [0, 3, 12]:
-        update_distance_sums_remove(dist_sums, condensed_store(d, n=m), np.int32(index))
+        update_distance_sums_remove(dist_sums, DistanceStore.condensed(d, n=m), np.int32(index))
         selection.remove(index)
         np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
 
@@ -239,12 +239,12 @@ def test_update_distance_sums_own_entry_untouched():
     dist_sums = np.zeros(m, dtype=np.float64)
 
     # selection {1}: point 1's own entry stays 0 (no other selected points yet)
-    update_distance_sums_add(dist_sums, condensed_store(d, n=m), np.int32(1))
+    update_distance_sums_add(dist_sums, DistanceStore.condensed(d, n=m), np.int32(1))
     assert dist_sums[1] == 0.0
 
     # --- act ---------------------------------------------
     # selection {1, 2}: point 2's own entry must equal its distance to point 1 only
-    update_distance_sums_add(dist_sums, condensed_store(d, n=m), np.int32(2))
+    update_distance_sums_add(dist_sums, DistanceStore.condensed(d, n=m), np.int32(2))
 
     # --- assert ------------------------------------------
     assert dist_sums[2] == pytest.approx(squareform(d)[2, 1])

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.spatial.distance import squareform
 
 from max_div._core.metrics import DistanceMetric
-from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance import compute_pdist, condensed_store
 from max_div._core.solver._diversity_contribution import SeparationTracker
 from max_div._core.solver._diversity_contribution._separation import (
     compute_separation,
@@ -18,8 +18,8 @@ from max_div._core.solver._diversity_contribution._separation import (
 @pytest.fixture
 def tracker() -> SeparationTracker:
     vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0]], dtype=np.float32)
-    pdist = compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
-    return SeparationTracker(pdist, np.int32(vectors.shape[0]))
+    store = condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0])
+    return SeparationTracker(store)
 
 
 def _selection_args(indices: list[int], n: int) -> tuple[np.ndarray, np.int32]:
@@ -46,12 +46,12 @@ def test_construction_fresh(tracker: SeparationTracker):
 def test_construction_precomputed_arrays_skip_recompute():
     # --- arrange -----------------------------------------
     vectors = np.array([[0.0], [1.0], [5.0]], dtype=np.float32)
-    pdist = compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
-    sep_global = compute_separation(pdist, np.int32(3))
+    store = condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=3)
+    sep_global = compute_separation(store)
     sep_selected = np.array([7.0, 8.0, 9.0], dtype=np.float32)
 
     # --- act ---------------------------------------------
-    tracker = SeparationTracker(pdist, np.int32(3), sep_global=sep_global, sep_selected=sep_selected)
+    tracker = SeparationTracker(store, sep_global=sep_global, sep_selected=sep_selected)
 
     # --- assert ------------------------------------------
     assert tracker.contribution_wrt_dataset is sep_global  # taken as-is, not recomputed
@@ -112,7 +112,9 @@ def test_copy_is_independent(tracker: SeparationTracker):
     # --- assert ------------------------------------------
     selected, n_selected = _selection_args([0], 5)
     np.testing.assert_allclose(clone.contribution_wrt_selection(selected, n_selected), [np.inf, 1, 3, 6, 10])
-    assert clone.contribution_wrt_dataset is not tracker.contribution_wrt_dataset
+    # the immutable store and global contributions are shared by contract, not duplicated
+    assert clone._store is tracker._store
+    assert clone.contribution_wrt_dataset is tracker.contribution_wrt_dataset
 
 
 def test_snapshot_stack(tracker: SeparationTracker):
@@ -160,7 +162,7 @@ def test_compute_separation():
                     expected_separation[i] = dist
 
     # --- act ---------------------------------------------
-    separation = compute_separation(d, np.int32(m))
+    separation = compute_separation(condensed_store(d, n=m))
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(separation, expected_separation)
@@ -201,7 +203,7 @@ def test_update_separation_add():
     )
 
     # --- act ---------------------------------------------
-    update_separation_add(separation, d, np.int32(m), np.int32(i_added))
+    update_separation_add(separation, condensed_store(d, n=m), np.int32(i_added))
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(separation, expected_separation)
@@ -242,7 +244,7 @@ def test_update_separation_remove():
     )
 
     # --- act ---------------------------------------------
-    update_separation_remove(separation, d, np.int32(m), np.int32(i_removed), np.array([0], dtype=np.int32))
+    update_separation_remove(separation, condensed_store(d, n=m), np.int32(i_removed), np.array([0], dtype=np.int32))
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(separation, expected_separation)

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -3,7 +3,7 @@ import pytest
 from scipy.spatial.distance import squareform
 
 from max_div._core.metrics import DistanceMetric
-from max_div._core.metrics._distance import compute_pdist, condensed_store
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import SeparationTracker
 from max_div._core.solver._diversity_contribution._separation import (
     compute_separation,
@@ -18,7 +18,7 @@ from max_div._core.solver._diversity_contribution._separation import (
 @pytest.fixture
 def tracker() -> SeparationTracker:
     vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0]], dtype=np.float32)
-    store = condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0])
+    store = DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0])
     return SeparationTracker(store)
 
 
@@ -46,7 +46,7 @@ def test_construction_fresh(tracker: SeparationTracker):
 def test_construction_precomputed_arrays_skip_recompute():
     # --- arrange -----------------------------------------
     vectors = np.array([[0.0], [1.0], [5.0]], dtype=np.float32)
-    store = condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=3)
+    store = DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=3)
     sep_global = compute_separation(store)
     sep_selected = np.array([7.0, 8.0, 9.0], dtype=np.float32)
 
@@ -162,7 +162,7 @@ def test_compute_separation():
                     expected_separation[i] = dist
 
     # --- act ---------------------------------------------
-    separation = compute_separation(condensed_store(d, n=m))
+    separation = compute_separation(DistanceStore.condensed(d, n=m))
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(separation, expected_separation)
@@ -203,7 +203,7 @@ def test_update_separation_add():
     )
 
     # --- act ---------------------------------------------
-    update_separation_add(separation, condensed_store(d, n=m), np.int32(i_added))
+    update_separation_add(separation, DistanceStore.condensed(d, n=m), np.int32(i_added))
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(separation, expected_separation)
@@ -244,7 +244,9 @@ def test_update_separation_remove():
     )
 
     # --- act ---------------------------------------------
-    update_separation_remove(separation, condensed_store(d, n=m), np.int32(i_removed), np.array([0], dtype=np.int32))
+    update_separation_remove(
+        separation, DistanceStore.condensed(d, n=m), np.int32(i_removed), np.array([0], dtype=np.int32)
+    )
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(separation, expected_separation)

--- a/tests/_core/solver/_diversity_contribution/test_trackers.py
+++ b/tests/_core/solver/_diversity_contribution/test_trackers.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from max_div._core.metrics import DistanceMetric, DiversityContributionFamily, DiversityMetric
-from max_div._core.metrics._distance import DistanceStore, compute_pdist, condensed_store
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import (
     DiversityContributionTrackers,
     MeanDistanceTracker,
@@ -19,7 +19,7 @@ N = 6
 @pytest.fixture
 def store() -> DistanceStore:
     vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0], [15.0]], dtype=np.float32)
-    return condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=N)
+    return DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=N)
 
 
 # =================================================================================================

--- a/tests/_core/solver/_diversity_contribution/test_trackers.py
+++ b/tests/_core/solver/_diversity_contribution/test_trackers.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 
 from max_div._core.metrics import DistanceMetric, DiversityContributionFamily, DiversityMetric
-from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance import DistanceStore, compute_pdist, condensed_store
 from max_div._core.solver._diversity_contribution import (
     DiversityContributionTrackers,
     MeanDistanceTracker,
@@ -17,21 +17,20 @@ N = 6
 
 
 @pytest.fixture
-def pdist() -> np.ndarray:
+def store() -> DistanceStore:
     vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0], [15.0]], dtype=np.float32)
-    return compute_pdist(vectors, DistanceMetric.L1_MANHATTAN)
+    return condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=N)
 
 
 # =================================================================================================
 #  Tests
 # =================================================================================================
-def test_for_metrics_single_family(pdist: np.ndarray):
+def test_for_metrics_single_family(store: DistanceStore):
     # --- act ---------------------------------------------
     trackers = DiversityContributionTrackers.for_metrics(
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
-        pdist=pdist,
-        n=np.int32(N),
+        store=store,
     )
 
     # --- assert ------------------------------------------
@@ -41,13 +40,12 @@ def test_for_metrics_single_family(pdist: np.ndarray):
     assert trackers.main is trackers._trackers[0]
 
 
-def test_for_metrics_mixed_families(pdist: np.ndarray):
+def test_for_metrics_mixed_families(store: DistanceStore):
     # --- act ---------------------------------------------
     trackers = DiversityContributionTrackers.for_metrics(
         diversity_metric=DiversityMetric.MIN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.MIN_SEPARATION, DiversityMetric.MEAN_SEPARATION],
-        pdist=pdist,
-        n=np.int32(N),
+        store=store,
     )
 
     # --- assert ------------------------------------------
@@ -56,10 +54,10 @@ def test_for_metrics_mixed_families(pdist: np.ndarray):
     assert type(trackers.main) is SeparationTracker
 
 
-def test_mutations_fan_out_to_all_trackers(pdist: np.ndarray):
+def test_mutations_fan_out_to_all_trackers(store: DistanceStore):
     # --- arrange -----------------------------------------
     # hand-built two-family set, mirroring what a mixed-metric configuration would construct
-    sep, mean = SeparationTracker(pdist, np.int32(N)), MeanDistanceTracker(pdist, np.int32(N))
+    sep, mean = SeparationTracker(store), MeanDistanceTracker(store)
     trackers = DiversityContributionTrackers(
         trackers_by_family={
             DiversityContributionFamily.SEPARATION: sep,
@@ -67,7 +65,7 @@ def test_mutations_fan_out_to_all_trackers(pdist: np.ndarray):
         },
         main_family=DiversityContributionFamily.MEAN_DISTANCE,
     )
-    sep_ref, mean_ref = SeparationTracker(pdist, np.int32(N)), MeanDistanceTracker(pdist, np.int32(N))
+    sep_ref, mean_ref = SeparationTracker(store), MeanDistanceTracker(store)
     selected = np.full(N, False, dtype=np.bool)
     selected[[0, 3]] = True
 
@@ -96,13 +94,12 @@ def test_mutations_fan_out_to_all_trackers(pdist: np.ndarray):
     )
 
 
-def test_copy_is_independent(pdist: np.ndarray):
+def test_copy_is_independent(store: DistanceStore):
     # --- arrange -----------------------------------------
     trackers = DiversityContributionTrackers.for_metrics(
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[],
-        pdist=pdist,
-        n=np.int32(N),
+        store=store,
     )
     trackers.add(np.int32(0))
     clone = trackers.copy()
@@ -118,15 +115,14 @@ def test_copy_is_independent(pdist: np.ndarray):
     np.testing.assert_array_equal(clone.main.contribution_wrt_selection(selected, np.int32(1)), before)
 
 
-def test_selected_contributions_slots(pdist: np.ndarray):
+def test_selected_contributions_slots(store: DistanceStore):
     """Active families fill their slot with the selected vectors' values; untracked slots are empty."""
 
     # --- arrange -----------------------------------------
     trackers = DiversityContributionTrackers.for_metrics(
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[],
-        pdist=pdist,
-        n=np.int32(N),
+        store=store,
     )
     trackers.add(np.int32(0))
     trackers.add(np.int32(2))  # selection: points 0.0 and 3.0 on a line

--- a/tests/_core/solver/_strategies/_initialization/_helpers.py
+++ b/tests/_core/solver/_strategies/_initialization/_helpers.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
-from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance import compute_pdist, condensed_store
 from max_div._core.solver._solver_state import SolverState
 
 
@@ -20,7 +20,7 @@ def new_solver_state(has_constraints: bool) -> SolverState:
 
     return SolverState.new(
         n=vectors.shape[0],
-        pdist=compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN),
+        store=condensed_store(compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN), n=vectors.shape[0]),
         k=50,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[],

--- a/tests/_core/solver/_strategies/_initialization/_helpers.py
+++ b/tests/_core/solver/_strategies/_initialization/_helpers.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
-from max_div._core.metrics._distance import compute_pdist, condensed_store
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._solver_state import SolverState
 
 
@@ -20,7 +20,7 @@ def new_solver_state(has_constraints: bool) -> SolverState:
 
     return SolverState.new(
         n=vectors.shape[0],
-        store=condensed_store(compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN), n=vectors.shape[0]),
+        store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN), n=vectors.shape[0]),
         k=50,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[],

--- a/tests/_core/solver/_strategies/_optimization/test_optim_guided_swaps.py
+++ b/tests/_core/solver/_strategies/_optimization/test_optim_guided_swaps.py
@@ -4,6 +4,7 @@ import pytest
 
 from max_div._core.benchmark_problems import BenchmarkProblemFactory
 from max_div._core.metrics import DiversityMetric
+from max_div._core.metrics._distance import condensed_store
 from max_div._core.solver._parameters import ParameterSchedule, linear
 from max_div._core.solver._solver_state import SolverState
 from max_div._core.solver._solver_step import InitializationStep
@@ -65,7 +66,7 @@ def test_optim_guided_swaps(
     )
     solver_state = SolverState.new(
         n=problem.n,
-        pdist=problem.condensed_distances(),
+        store=condensed_store(problem.condensed_distances(), n=problem.n),
         k=problem.k,
         diversity_metric=problem.diversity_metric,
         diversity_tie_breakers=[],

--- a/tests/_core/solver/_strategies/_optimization/test_optim_guided_swaps.py
+++ b/tests/_core/solver/_strategies/_optimization/test_optim_guided_swaps.py
@@ -4,7 +4,7 @@ import pytest
 
 from max_div._core.benchmark_problems import BenchmarkProblemFactory
 from max_div._core.metrics import DiversityMetric
-from max_div._core.metrics._distance import condensed_store
+from max_div._core.metrics._distance import DistanceStore
 from max_div._core.solver._parameters import ParameterSchedule, linear
 from max_div._core.solver._solver_state import SolverState
 from max_div._core.solver._solver_step import InitializationStep
@@ -66,7 +66,7 @@ def test_optim_guided_swaps(
     )
     solver_state = SolverState.new(
         n=problem.n,
-        store=condensed_store(problem.condensed_distances(), n=problem.n),
+        store=DistanceStore.condensed(problem.condensed_distances(), n=problem.n),
         k=problem.k,
         diversity_metric=problem.diversity_metric,
         diversity_tie_breakers=[],

--- a/tests/_core/solver/_strategies/_optimization/test_optim_random_swaps.py
+++ b/tests/_core/solver/_strategies/_optimization/test_optim_random_swaps.py
@@ -4,7 +4,7 @@ import pytest
 
 from max_div._core.benchmark_problems import BenchmarkProblemFactory
 from max_div._core.metrics import DiversityMetric
-from max_div._core.metrics._distance import condensed_store
+from max_div._core.metrics._distance import DistanceStore
 from max_div._core.solver._solver_state import SolverState
 from max_div._core.solver._solver_step import InitializationStep
 from max_div._core.solver._strategies._initialization import InitializationStrategy
@@ -33,7 +33,7 @@ def test_optim_random_swaps(problem_name: str, size: int):
     )
     solver_state = SolverState.new(
         n=problem.n,
-        store=condensed_store(problem.condensed_distances(), n=problem.n),
+        store=DistanceStore.condensed(problem.condensed_distances(), n=problem.n),
         k=problem.k,
         diversity_metric=problem.diversity_metric,
         diversity_tie_breakers=[],

--- a/tests/_core/solver/_strategies/_optimization/test_optim_random_swaps.py
+++ b/tests/_core/solver/_strategies/_optimization/test_optim_random_swaps.py
@@ -4,6 +4,7 @@ import pytest
 
 from max_div._core.benchmark_problems import BenchmarkProblemFactory
 from max_div._core.metrics import DiversityMetric
+from max_div._core.metrics._distance import condensed_store
 from max_div._core.solver._solver_state import SolverState
 from max_div._core.solver._solver_step import InitializationStep
 from max_div._core.solver._strategies._initialization import InitializationStrategy
@@ -32,7 +33,7 @@ def test_optim_random_swaps(problem_name: str, size: int):
     )
     solver_state = SolverState.new(
         n=problem.n,
-        pdist=problem.condensed_distances(),
+        store=condensed_store(problem.condensed_distances(), n=problem.n),
         k=problem.k,
         diversity_metric=problem.diversity_metric,
         diversity_tie_breakers=[],

--- a/tests/_core/solver/test_solver_builder.py
+++ b/tests/_core/solver/test_solver_builder.py
@@ -174,7 +174,7 @@ def test_max_div_solver_builder_end_to_end():
     # --- assert ------------------------------------------
     assert isinstance(solver, MaxDivSolver)
     assert solver._n == vectors.shape[0]
-    assert solver._pdist.shape == ((vectors.shape[0] * (vectors.shape[0] - 1)) // 2,)
+    assert solver._store.condensed.shape == ((vectors.shape[0] * (vectors.shape[0] - 1)) // 2,)
     assert solver._k == k
     assert len(solver._solver_steps) == 3
     assert solver._solver_steps[0].name() == init_strategy.name

--- a/tests/_core/solver/test_solver_builder.py
+++ b/tests/_core/solver/test_solver_builder.py
@@ -174,7 +174,7 @@ def test_max_div_solver_builder_end_to_end():
     # --- assert ------------------------------------------
     assert isinstance(solver, MaxDivSolver)
     assert solver._n == vectors.shape[0]
-    assert solver._store.condensed.shape == ((vectors.shape[0] * (vectors.shape[0] - 1)) // 2,)
+    assert solver._store.pdist.shape == ((vectors.shape[0] * (vectors.shape[0] - 1)) // 2,)
     assert solver._k == k
     assert len(solver._solver_steps) == 3
     assert solver._solver_steps[0].name() == init_strategy.name

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -4,7 +4,7 @@ from numpy import random
 
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
-from max_div._core.metrics._distance import compute_pdist, condensed_store
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker, SeparationTracker
 from max_div._core.solver._solver_state import Savepoint, SolverState, _build_con_membership
 
@@ -17,7 +17,7 @@ def new_solver_state() -> SolverState:
     vectors = np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]], dtype=np.float32)
     return SolverState.new(
         n=vectors.shape[0],
-        store=condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
+        store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
         k=3,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
@@ -33,7 +33,7 @@ def new_solver_state_unconstrained() -> SolverState:
     vectors = np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]], dtype=np.float32)
     return SolverState.new(
         n=vectors.shape[0],
-        store=condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
+        store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
         k=3,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
@@ -329,7 +329,7 @@ def test_solver_state_tracker_set_mean_distance(new_solver_state):
     # --- act ---------------------------------------------
     state_pure = SolverState.new(
         n=4,
-        store=condensed_store(pdist, n=4),
+        store=DistanceStore.condensed(pdist, n=4),
         k=2,
         diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
         diversity_tie_breakers=[],
@@ -337,7 +337,7 @@ def test_solver_state_tracker_set_mean_distance(new_solver_state):
     )
     state_mixed = SolverState.new(
         n=4,
-        store=condensed_store(pdist, n=4),
+        store=DistanceStore.condensed(pdist, n=4),
         k=2,
         diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
@@ -357,7 +357,7 @@ def test_solver_state_mean_pairwise_distance_score():
     vectors = np.array([[0.0], [1.0], [3.0], [7.0]], dtype=np.float32)
     state = SolverState.new(
         n=4,
-        store=condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=4),
+        store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=4),
         k=3,
         diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
         diversity_tie_breakers=[],
@@ -417,7 +417,7 @@ def _make_reference_state() -> SolverState:
     vectors = rng.random((30, 3)).astype(np.float32)
     return SolverState.new(
         n=vectors.shape[0],
-        store=condensed_store(compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN), n=vectors.shape[0]),
+        store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN), n=vectors.shape[0]),
         k=8,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -4,7 +4,7 @@ from numpy import random
 
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
-from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance import compute_pdist, condensed_store
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker, SeparationTracker
 from max_div._core.solver._solver_state import Savepoint, SolverState, _build_con_membership
 
@@ -17,7 +17,7 @@ def new_solver_state() -> SolverState:
     vectors = np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]], dtype=np.float32)
     return SolverState.new(
         n=vectors.shape[0],
-        pdist=compute_pdist(vectors, DistanceMetric.L1_MANHATTAN),
+        store=condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
         k=3,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
@@ -33,7 +33,7 @@ def new_solver_state_unconstrained() -> SolverState:
     vectors = np.array([[0.0], [1.0], [2.0], [3.0], [4.0], [5.0]], dtype=np.float32)
     return SolverState.new(
         n=vectors.shape[0],
-        pdist=compute_pdist(vectors, DistanceMetric.L1_MANHATTAN),
+        store=condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
         k=3,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
@@ -329,7 +329,7 @@ def test_solver_state_tracker_set_mean_distance(new_solver_state):
     # --- act ---------------------------------------------
     state_pure = SolverState.new(
         n=4,
-        pdist=pdist,
+        store=condensed_store(pdist, n=4),
         k=2,
         diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
         diversity_tie_breakers=[],
@@ -337,7 +337,7 @@ def test_solver_state_tracker_set_mean_distance(new_solver_state):
     )
     state_mixed = SolverState.new(
         n=4,
-        pdist=pdist,
+        store=condensed_store(pdist, n=4),
         k=2,
         diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],
@@ -357,7 +357,7 @@ def test_solver_state_mean_pairwise_distance_score():
     vectors = np.array([[0.0], [1.0], [3.0], [7.0]], dtype=np.float32)
     state = SolverState.new(
         n=4,
-        pdist=compute_pdist(vectors, DistanceMetric.L1_MANHATTAN),
+        store=condensed_store(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=4),
         k=3,
         diversity_metric=DiversityMetric.MEAN_PAIRWISE_DISTANCE,
         diversity_tie_breakers=[],
@@ -417,7 +417,7 @@ def _make_reference_state() -> SolverState:
     vectors = rng.random((30, 3)).astype(np.float32)
     return SolverState.new(
         n=vectors.shape[0],
-        pdist=compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN),
+        store=condensed_store(compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN), n=vectors.shape[0]),
         k=8,
         diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
         diversity_tie_breakers=[DiversityMetric.NON_ZERO_SEPARATION_FRAC],


### PR DESCRIPTION
**TL;DR**: Distance reads now go through a read-only `DistanceStore` bundle and one `get_distance` helper, so alternative storage layouts can plug in without forking every kernel. Behavior-neutral: golden master bit-exact.

## Description

### Problem addressed

The condensed-distance layout was hard-wired at every read: kernels took `(pdist, n)` in their signatures and indexed the condensed array via `get_pdist_el`. Any alternative storage layout (a full matrix for contiguous row scans, on-demand computation from vectors) would have required forking every kernel that touches distances.

### Implementation

- **`DistanceStore`** — a namedtuple of numpy arrays and scalars (njit-compatible, no object mode): a backend selector, `n`, and one field per storage layout, where unused fields hold zero-length arrays. Immutable by construction.
- **`get_distance(store, i, j)`** — a single inlined, cached read helper replacing `get_pdist_el` at every call site; the condensed index arithmetic moved with it into the store module.
- **Eager signatures preserved**: signature *strings* cannot spell a namedtuple type, so store-taking kernels use signature *objects* built from a module-level type constant derived via `numba.typeof` on a zero-size dummy. Compilation stays eager, typing exact, `cache=True` intact.
- **Copy contract refined**: tracker `copy()` shares the immutable store and global-contribution arrays instead of deep-copying them — the duplication predated large-n concerns and had only test callers; docstrings now state the sharing.
- The setup-time full scans (`compute_separation`, `compute_distance_sums`) now visit each item's partners in ascending order through `get_distance` instead of walking condensed storage order.

## Attention points

- **Bit-exactness of float64 sums**: per item, ascending-partner order is exactly the accumulation order the condensed pair sweep produced, so `compute_distance_sums` results are bit-identical — confirmed by the unchanged golden master.
- **Setup scans read each pair twice** now (n² point reads instead of one n²/2 sweep) — a one-time setup cost, traded for storage-layout independence.
- **`copy()` semantics changed** from "deep copy" to "independent copy sharing immutable distance data" — intentional; the sharing is safe because namedtuple fields cannot be reassigned and no kernel writes distances.

## Tests / Spikes

- **SPIKE:** namedtuple-as-njit-argument and eager signature objects verified on every supported numba (0.57–0.66, each Python leg at its floor) before this design was committed.
- **TEST:** full suite with numba JIT: 3642 passed, golden master bit-exact; store/tracker subset re-run with `NUMBA_DISABLE_JIT=1` (coverage mode) — green.
- Unit tests: new `test_distance_store.py` (store construction, `get_distance` values, condensed-offset overflow guard); tracker copy tests now assert the sharing contract explicitly.

## Changelog entry

None: behavior-neutral refactor.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
