### PR TITLE
feat: add a full-matrix distance backend for contiguous row scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Lazy distance computation for vector problems: solve without ever materializing the pairwise-distance matrix, removing the O(n²) memory requirement
+- Full-matrix distance storage: roughly 2× faster solving at large problem sizes, for twice the distance-storage memory
 
 ### Changed
 

--- a/src/max_div/_core/metrics/_distance/_store.py
+++ b/src/max_div/_core/metrics/_distance/_store.py
@@ -20,6 +20,7 @@ from ._enum import DistanceMetric
 # Backend selector values for DistanceStore.kind.
 KIND_CONDENSED = np.int32(0)
 KIND_LAZY = np.int32(1)
+KIND_FULL_MATRIX = np.int32(2)
 
 # Pair-kernel selector values for DistanceStore.metric_kind (lazy backend only).  Cosine holds
 # pre-normalized vectors, so its pair read is the half-squared-L2 form on those.
@@ -52,7 +53,7 @@ class DistanceStore(NamedTuple):
     kind: np.int32
     n: np.int32
     pdist: NDArray[np.float32]  # (n*(n-1)/2,) condensed distances (scipy layout), KIND_CONDENSED
-    matrix: NDArray[np.float32]  # placeholder for a full (n, n) distance matrix backend
+    matrix: NDArray[np.float32]  # (n, n) full distance matrix (exactly symmetric), KIND_FULL_MATRIX
     vectors: NDArray[np.float32]  # (n, d) vectors distances are computed from, KIND_LAZY
     metric_kind: np.int32  # pair-kernel selector, KIND_LAZY only
 
@@ -97,6 +98,55 @@ class DistanceStore(NamedTuple):
             vectors=vectors,
             metric_kind=_METRIC_KINDS[metric],
         )
+
+    @classmethod
+    def full_matrix(cls, matrix: NDArray[np.float32]) -> "DistanceStore":
+        """Return a DistanceStore reading from a full (n, n) distance matrix.
+
+        The matrix must be float32, C-contiguous, and exactly symmetric with a zero diagonal —
+        kernels read whichever of (i, j)/(j, i) suits their access pattern, so the two halves must
+        be bit-equal.  Construction paths that cannot guarantee this by construction must repair
+        or validate before wrapping.
+
+        :param matrix: ((n, n) ndarray) full pairwise-distance matrix.
+        """
+        return cls(
+            kind=KIND_FULL_MATRIX,
+            n=np.int32(matrix.shape[0]),
+            pdist=_EMPTY_1D,
+            matrix=matrix,
+            vectors=_EMPTY_2D,
+            metric_kind=np.int32(0),
+        )
+
+    @classmethod
+    def full_matrix_from_vectors(cls, vectors: NDArray[np.float32], metric: DistanceMetric) -> "DistanceStore":
+        """Return a full-matrix DistanceStore computed from vectors, exactly symmetric by construction.
+
+        Each pair is computed once through the same pair kernels the condensed and lazy paths use,
+        and written to both halves — so values are bit-equal across backends and symmetry is
+        structural.
+
+        :param vectors: (n x d ndarray) the vectors to compute distances from.
+        :param metric: (DistanceMetric) the distance metric to use.
+        """
+        vectors = np.ascontiguousarray(vectors, dtype=np.float32)
+        if metric == DistanceMetric.COSINE:
+            validate_cosine_vectors(vectors)
+            vectors = normalize_rows(vectors)
+        return cls.full_matrix(_fill_matrix_from_vectors(vectors, _METRIC_KINDS[metric]))
+
+    @classmethod
+    def full_matrix_from_condensed(cls, pdist: NDArray[np.float32], n: int) -> "DistanceStore":
+        """Return a full-matrix DistanceStore expanded from a condensed distance vector (scipy layout).
+
+        Each condensed value is written to both halves, so the matrix is exactly symmetric and
+        bit-equal to the condensed source.
+
+        :param pdist: ((n*(n-1))//2 ndarray) condensed pairwise distances, float32 C-contiguous.
+        :param n: (int) number of items.
+        """
+        return cls.full_matrix(_expand_condensed(pdist, np.int32(n)))
 
 
 # The numba type of every DistanceStore instance (all stores share it: field dtypes are fixed and
@@ -145,8 +195,40 @@ def get_distance(store: DistanceStore, i: np.int32, j: np.int32) -> np.float32:
     """
     if i == j:
         return np.float32(0.0)
+    if store.kind == KIND_FULL_MATRIX:
+        return store.matrix[i, j]
     if store.kind == KIND_LAZY:
         return _lazy_pair(store.vectors, store.metric_kind, i, j)
     if i < j:
         return store.pdist[_condensed_index(i, j, store.n)]
     return store.pdist[_condensed_index(j, i, store.n)]
+
+
+# =================================================================================================
+#  Full-matrix construction kernels
+# =================================================================================================
+@numba.njit(numba.float32[:, ::1](numba.float32[:, ::1], numba.int32), cache=True)
+def _fill_matrix_from_vectors(vectors: NDArray[np.float32], metric_kind: np.int32) -> NDArray[np.float32]:
+    """Fill a full (n, n) distance matrix from vectors: each pair computed once, written to both halves."""
+    n = vectors.shape[0]
+    matrix = np.zeros((n, n), dtype=np.float32)
+    for i in np.arange(n, dtype=np.int32):
+        for j in np.arange(i + 1, n, dtype=np.int32):
+            value = _lazy_pair(vectors, metric_kind, i, j)
+            matrix[i, j] = value
+            matrix[j, i] = value
+    return matrix
+
+
+@numba.njit(numba.float32[:, ::1](numba.float32[::1], numba.int32), cache=True)
+def _expand_condensed(condensed: NDArray[np.float32], n: np.int32) -> NDArray[np.float32]:
+    """Expand a condensed distance vector into a full (n, n) matrix: each value written to both halves."""
+    matrix = np.zeros((n, n), dtype=np.float32)
+    idx = np.int64(0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            value = condensed[idx]
+            idx += 1
+            matrix[i, j] = value
+            matrix[j, i] = value
+    return matrix

--- a/tests/_core/metrics/test_distance_store.py
+++ b/tests/_core/metrics/test_distance_store.py
@@ -8,7 +8,7 @@ from max_div._core.metrics._distance import (
     compute_pdist,
     get_distance,
 )
-from max_div._core.metrics._distance._store import KIND_CONDENSED, KIND_LAZY, _condensed_index
+from max_div._core.metrics._distance._store import KIND_CONDENSED, KIND_FULL_MATRIX, KIND_LAZY, _condensed_index
 
 
 # -------------------------------------------------------------------------
@@ -96,16 +96,57 @@ def test_lazy_factory_cosine_zero_vector_raises():
 
 
 # -------------------------------------------------------------------------
+#  DistanceStore.full_matrix
+# -------------------------------------------------------------------------
+def test_full_matrix_factory_fields():
+    """A full-matrix store holds the given matrix and n; other backend fields are zero-size."""
+
+    # --- arrange -----------------------------------------
+    matrix = np.zeros((4, 4), dtype=np.float32)
+
+    # --- act ---------------------------------------------
+    store = DistanceStore.full_matrix(matrix)
+
+    # --- assert ------------------------------------------
+    assert store.kind == KIND_FULL_MATRIX
+    assert store.n == np.int32(4)
+    assert store.matrix is matrix
+    assert store.pdist.size == 0
+    assert store.vectors.size == 0
+
+
+@pytest.mark.parametrize("metric", list(DistanceMetric))
+def test_full_matrix_construction_exactly_symmetric(metric: DistanceMetric):
+    """Both full-matrix construction paths produce exactly symmetric matrices with zero diagonals."""
+
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(20260731)
+    vectors = (rng.standard_normal((12, 3)) * 5).astype(np.float32)
+
+    # --- act ---------------------------------------------
+    from_vectors = DistanceStore.full_matrix_from_vectors(vectors, metric)
+    from_condensed = DistanceStore.full_matrix_from_condensed(compute_pdist(vectors, metric), n=12)
+
+    # --- assert ------------------------------------------
+    for store in (from_vectors, from_condensed):
+        np.testing.assert_array_equal(store.matrix, store.matrix.T)  # bit-exact symmetry
+        np.testing.assert_array_equal(np.diag(store.matrix), np.zeros(12, dtype=np.float32))
+
+
+# -------------------------------------------------------------------------
 #  Cross-backend bit-equality
 # -------------------------------------------------------------------------
 # The invariant every backend must uphold: get_distance returns bit-identical float32 values for
 # every (i, j) pair, whichever storage layout the store holds.  Assertions use exact equality on
 # purpose — bit-equality is what keeps solver trajectories identical across backends.
 def _all_backend_stores(vectors: np.ndarray, metric: DistanceMetric) -> dict[str, DistanceStore]:
-    """Build one store per available backend over the same data."""
+    """Build one store per available backend (and construction path) over the same data."""
+    condensed = compute_pdist(vectors, metric)
     return {
-        "condensed": DistanceStore.condensed(compute_pdist(vectors, metric), n=vectors.shape[0]),
+        "condensed": DistanceStore.condensed(condensed, n=vectors.shape[0]),
         "lazy": DistanceStore.lazy(vectors, metric),
+        "full_from_vectors": DistanceStore.full_matrix_from_vectors(vectors, metric),
+        "full_from_condensed": DistanceStore.full_matrix_from_condensed(condensed, n=vectors.shape[0]),
     }
 
 

--- a/tests/_core/solver/test_solver.py
+++ b/tests/_core/solver/test_solver.py
@@ -130,9 +130,10 @@ def test_solver_vector_and_distance_input_bit_identical():
     assert solutions[0].score == solutions[1].score
 
 
+@pytest.mark.parametrize("backend", ["lazy", "full_matrix"])
 @pytest.mark.parametrize("distance_metric", [DistanceMetric.L2_EUCLIDEAN, DistanceMetric.COSINE])
-def test_solver_lazy_backend_bit_identical_selection(distance_metric: DistanceMetric):
-    """A solve reading distances on demand selects exactly what the condensed-store solve selects."""
+def test_solver_alternative_backend_bit_identical_selection(backend: str, distance_metric: DistanceMetric):
+    """A solve on any alternative distance backend selects exactly what the condensed solve selects."""
 
     # --- arrange -----------------------------------------
     rng = np.random.default_rng(20260731)
@@ -141,17 +142,20 @@ def test_solver_lazy_backend_bit_identical_selection(distance_metric: DistanceMe
         vectors, k=8, distance_metric=distance_metric, diversity_metric=DiversityMetric.GEOMEAN_SEPARATION
     )
     solver_condensed = MaxDivSolverBuilder(problem).with_preset(iterations(500)).with_seed(7).build()
-    solver_lazy = MaxDivSolverBuilder(problem).with_preset(iterations(500)).with_seed(7).build()
-    # the builder always constructs a condensed store; swap in the lazy backend directly
-    solver_lazy._store = DistanceStore.lazy(vectors, distance_metric)
+    solver_other = MaxDivSolverBuilder(problem).with_preset(iterations(500)).with_seed(7).build()
+    # the builder always constructs a condensed store; swap in the alternative backend directly
+    if backend == "lazy":
+        solver_other._store = DistanceStore.lazy(vectors, distance_metric)
+    else:
+        solver_other._store = DistanceStore.full_matrix_from_vectors(vectors, distance_metric)
 
     # --- act ---------------------------------------------
     solution_condensed = solver_condensed.solve(verbosity=0)
-    solution_lazy = solver_lazy.solve(verbosity=0)
+    solution_other = solver_other.solve(verbosity=0)
 
     # --- assert ------------------------------------------
-    assert list(solution_lazy.i_selected) == list(solution_condensed.i_selected)
-    assert solution_lazy.score == solution_condensed.score
+    assert list(solution_other.i_selected) == list(solution_condensed.i_selected)
+    assert solution_other.score == solution_condensed.score
 
 
 # =================================================================================================


### PR DESCRIPTION
**TL;DR**: The distance store gains a full n×n matrix backend: contiguous row scans in the tracker kernels, measured ~2× end-to-end at n=20000 for 2× the distance memory. Exactly symmetric by construction; values bit-equal to the other backends.

## Description

### Problem addressed

The condensed layout splits every row scan into a contiguous half and a strided column walk — heavy read amplification that dominates tracker-mutation cost at large n. A full n×n matrix makes every row scan contiguous, at the cost of storing each distance twice.

### Implementation

- **`get_distance` gains the matrix branch** — a plain `matrix[i, j]` read, no index arithmetic. Tracker loops fix `i` and sweep `j`, so row reads are contiguous with no new API.
- **Two construction paths, both exactly symmetric by construction**: from vectors (each pair computed once through the shared pair kernels, written to both halves) and from a condensed vector (each value mirrored). A third, trusting constructor wraps an existing matrix for callers that guarantee symmetry themselves.
- **Exact symmetry is a correctness precondition, not hygiene**: kernels are free to read either half, and the incremental trackers assume every read of a pair returns the same value — any difference between halves would desync the bookkeeping. The construction paths make this structural; the equality suite asserts it bit-exactly.
- The cross-backend equality suite extends to both new construction paths automatically, and the end-to-end solve test now covers the full-matrix backend alongside lazy.

## Attention points

- **The measured speedup is ~2×, below the ~3.0× projection** from the earlier row-scan microbenchmark + Amdahl estimate: 1.98× (separation family) / 1.83× (mean-pairwise) at n=20000 / k=2000 over 10k iterations, setup excluded, scores bit-identical. The speedup grows with run length (1.59× at 1k iterations) as iterations become more read-heavy, and both families benefit similarly. The changelog entry says "roughly 2×" accordingly.
- **The backend is internal for now**: nothing selects it yet; the end-to-end test injects the store directly.

## Tests / Spikes

- **SPIKE:** end-to-end iteration-rate measurement condensed vs full matrix (numbers above) — the direct confirmation the earlier microbenchmark-based projection lacked.
- **TEST:** full suite with numba JIT green; golden master unchanged.
- Unit tests added: full-matrix store construction, bit-exact symmetry + zero diagonal for both construction paths, cross-backend bit-equality extended, end-to-end selection identity per backend.

## Changelog entry

Added:
```
Full-matrix distance storage: roughly 2× faster solving at large problem sizes, for twice the distance-storage memory
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
