### PR TITLE
feat: keep user-provided distance matrices in the format they arrive in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Full-matrix distance storage: roughly 2× faster solving at large problem sizes, for twice the distance-storage memory
 
 ### Changed
+- Square distance inputs are now kept in full-matrix form (previously condensed), adopted zero-copy when possible, and repaired to exact symmetry with a warning when asymmetric
 
 ### Deprecated
 

--- a/src/max_div/_core/_warnings.py
+++ b/src/max_div/_core/_warnings.py
@@ -1,0 +1,17 @@
+"""Warning categories emitted by max-div.
+
+All max-div warnings derive from `MaxDivWarning`, so users can filter the whole family with one
+`warnings.filterwarnings` rule, or target a specific subclass.
+"""
+
+# =================================================================================================
+#  Warning categories
+# =================================================================================================
+
+
+class MaxDivWarning(UserWarning):
+    """Base category for every warning max-div emits."""
+
+
+class DistanceInputWarning(MaxDivWarning):
+    """Distance input needed intervention at the problem boundary: a conversion copy or a symmetry repair."""

--- a/src/max_div/_core/problem/_problem.py
+++ b/src/max_div/_core/problem/_problem.py
@@ -6,7 +6,7 @@ from numpy.typing import NDArray
 
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric, validate_cosine_vectors
-from max_div._core.metrics._distance import DistanceStore, compute_pdist, condensed_store, full_matrix_store
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 
 from ._validate_distances import _n_from_condensed_size, validated_condensed_distances, validated_square_distances
 
@@ -181,7 +181,7 @@ class VectorMaxDivProblem(MaxDivProblem):
         return compute_pdist(self.vectors, self.distance_metric)
 
     def distance_store(self) -> DistanceStore:
-        return condensed_store(self.condensed_distances(), self.n)
+        return DistanceStore.condensed(self.condensed_distances(), self.n)
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -209,8 +209,8 @@ class DistanceMaxDivProblem(MaxDivProblem):
 
     def distance_store(self) -> DistanceStore:
         if self.distances.ndim == 2:
-            return full_matrix_store(self.distances)
-        return condensed_store(self.distances, self.n)
+            return DistanceStore.full_matrix(self.distances)
+        return DistanceStore.condensed(self.distances, self.n)
 
 
 # =================================================================================================

--- a/src/max_div/_core/problem/_problem.py
+++ b/src/max_div/_core/problem/_problem.py
@@ -6,7 +6,9 @@ from numpy.typing import NDArray
 
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric, validate_cosine_vectors
-from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance import DistanceStore, compute_pdist, condensed_store, full_matrix_store
+
+from ._validate_distances import _n_from_condensed_size, validated_condensed_distances, validated_square_distances
 
 
 # =================================================================================================
@@ -42,6 +44,15 @@ class MaxDivProblem(ABC):
     @abstractmethod
     def condensed_distances(self) -> NDArray[np.float32]:
         """Return the condensed pairwise-distance vector (scipy layout), computing it if needed."""
+
+    @abstractmethod
+    def distance_store(self) -> DistanceStore:
+        """Return the distance store in the problem's as-given storage format.
+
+        Distance-input problems keep the format the user provided (condensed stays condensed, a
+        square matrix stays a full matrix — zero-copy in both cases); vector problems default to
+        the condensed layout.
+        """
 
     # --- computed fields ---------------------------------
     @property
@@ -118,21 +129,17 @@ class MaxDivProblem(ABC):
         :param diversity_metric: Diversity metric to maximize.
         :param constraints: Optional list of fairness constraints.
         """
-        # --- validate & condense -----
+        # --- validate, keeping the provided format -----
         distances = np.asarray(distances)
         if distances.ndim == 2:
-            pdist = _condense_square_distances(distances)
+            validated = validated_square_distances(distances)
+            n = validated.shape[0]
         elif distances.ndim == 1:
-            pdist = _validate_condensed_distances(distances)
+            validated = validated_condensed_distances(distances)
+            n = _n_from_condensed_size(validated.size)
         else:
             raise ValueError(f"Distances must be a square (n, n) matrix or condensed 1D vector; got {distances.ndim}D.")
 
-        if not np.all(np.isfinite(pdist)):
-            raise ValueError("Distances must all be finite (no NaN or inf).")
-        if np.any(pdist < 0.0):
-            raise ValueError("Distances must all be non-negative.")
-
-        n = _n_from_condensed_size(pdist.size)
         _validate_k(k, n)
 
         if constraints is None:
@@ -140,7 +147,7 @@ class MaxDivProblem(ABC):
 
         # --- build -------------------
         return DistanceMaxDivProblem(
-            pdist=pdist,
+            distances=validated,
             k=k,
             diversity_metric=diversity_metric,
             constraints=constraints,
@@ -173,6 +180,9 @@ class VectorMaxDivProblem(MaxDivProblem):
     def condensed_distances(self) -> NDArray[np.float32]:
         return compute_pdist(self.vectors, self.distance_metric)
 
+    def distance_store(self) -> DistanceStore:
+        return condensed_store(self.condensed_distances(), self.n)
+
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class DistanceMaxDivProblem(MaxDivProblem):
@@ -182,15 +192,25 @@ class DistanceMaxDivProblem(MaxDivProblem):
     """
 
     # --- primary fields ----------------------------------
-    pdist: NDArray[np.float32]
+    distances: NDArray[np.float32]  # as provided: (n, n) square matrix or condensed 1D vector
 
     # --- flavor-specific ---------------------------------
     @property
     def n(self) -> int:
-        return _n_from_condensed_size(self.pdist.size)
+        if self.distances.ndim == 2:
+            return self.distances.shape[0]
+        return _n_from_condensed_size(self.distances.size)
 
     def condensed_distances(self) -> NDArray[np.float32]:
-        return self.pdist
+        if self.distances.ndim == 2:
+            i_upper, j_upper = np.triu_indices(self.n, k=1)
+            return np.ascontiguousarray(self.distances[i_upper, j_upper])
+        return self.distances
+
+    def distance_store(self) -> DistanceStore:
+        if self.distances.ndim == 2:
+            return full_matrix_store(self.distances)
+        return condensed_store(self.distances, self.n)
 
 
 # =================================================================================================
@@ -200,35 +220,3 @@ def _validate_k(k: int, n: int) -> None:
     """Raise ValueError unless 2 <= k <= n."""
     if not (2 <= k <= n):
         raise ValueError(f"k must be in range [2, number of items (={n})]; here: {k}.")
-
-
-def _n_from_condensed_size(size: int) -> int:
-    """Return n such that n*(n-1)/2 == size, raising ValueError if no such integer exists."""
-    n = round((1 + np.sqrt(1 + 8 * size)) / 2)
-    if (n * (n - 1)) // 2 != size:
-        raise ValueError(f"Condensed distance vector has invalid length {size}: not a triangular number n*(n-1)/2.")
-    return n
-
-
-def _condense_square_distances(distances: np.ndarray) -> NDArray[np.float32]:
-    """Validate a square symmetric distance matrix and return its condensed float32 form."""
-    n = distances.shape[0]
-    if distances.shape[0] != distances.shape[1]:
-        raise ValueError(f"Square distance matrix must be (n, n); got {distances.shape}.")
-    if n < 3:
-        raise ValueError("At least 3 items are required to formulate a max-div problem.")
-    distances = distances.astype(np.float32)
-    if not np.allclose(np.diag(distances), 0.0, atol=1e-6):
-        raise ValueError("Square distance matrix must have a zero diagonal.")
-    if not np.allclose(distances, distances.T, rtol=1e-5, atol=1e-6, equal_nan=True):
-        raise ValueError("Square distance matrix must be symmetric.")
-    i_upper, j_upper = np.triu_indices(n, k=1)
-    return np.ascontiguousarray(distances[i_upper, j_upper])
-
-
-def _validate_condensed_distances(distances: np.ndarray) -> NDArray[np.float32]:
-    """Validate a condensed distance vector and return it as contiguous float32."""
-    n = _n_from_condensed_size(distances.size)
-    if n < 3:
-        raise ValueError("At least 3 items are required to formulate a max-div problem.")
-    return np.ascontiguousarray(distances, dtype=np.float32)

--- a/src/max_div/_core/problem/_validate_distances.py
+++ b/src/max_div/_core/problem/_validate_distances.py
@@ -90,9 +90,7 @@ def _scan_square(matrix: NDArray[np.float32]) -> tuple[int, int, float, int, flo
             max_abs_diag = max(max_abs_diag, np.float64(abs(v)))
     for ib in range(0, n, _BLOCK):
         for jb in range(ib, n, _BLOCK):
-            nf, neg, asym, d_abs, d_rel = _scan_square_block(
-                matrix, ib, jb, min(ib + _BLOCK, n), min(jb + _BLOCK, n)
-            )
+            nf, neg, asym, d_abs, d_rel = _scan_square_block(matrix, ib, jb, min(ib + _BLOCK, n), min(jb + _BLOCK, n))
             n_nonfinite += nf
             n_negative += neg
             n_asym += asym

--- a/src/max_div/_core/problem/_validate_distances.py
+++ b/src/max_div/_core/problem/_validate_distances.py
@@ -1,0 +1,224 @@
+"""Validation and symmetry repair for user-provided distance input.
+
+Square matrices must end up *exactly* symmetric: solver kernels read whichever of (i, j)/(j, i)
+suits their access pattern, and the incremental trackers assume every read of a pair returns the
+same value — any difference between the halves would desync their bookkeeping.  Exactly symmetric
+input is adopted as-is (zero-copy when float32 C-contiguous); asymmetric input is repaired by
+averaging each pair, disclosed via `DistanceInputWarning`.
+
+Scans are blocked so each (i, j) block is visited together with its transpose partner — two
+blocks in cache at a time over data that is O(n²) by definition.
+"""
+
+import warnings
+
+import numba
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div._core._warnings import DistanceInputWarning
+
+# side length of the square tiles the blocked scans walk; two float32 tiles fit comfortably in L2
+_BLOCK = 128
+
+# |diagonal| values above this are rejected (the solver never reads the diagonal, but a non-zero
+# one signals the input is not a distance matrix)
+_DIAGONAL_ATOL = 1e-6
+
+
+# =================================================================================================
+#  Kernels
+# =================================================================================================
+@numba.njit(
+    "Tuple((int64, int64, int64, float64, float64))(float32[:, ::1], int64, int64, int64, int64)",
+    inline="always",
+    cache=True,
+)
+def _scan_square_block(
+    matrix: NDArray[np.float32], ib: int, jb: int, i_end: int, j_end: int
+) -> tuple[int, int, int, float, float]:
+    """Scan the i<j pairs of one block of a square matrix, together with their transpose partners.
+
+    Returns:
+        Tuple ``(n_nonfinite, n_negative, n_asymmetric_pairs, max_abs_delta, max_rel_delta)``
+        where the deltas compare the (i, j) and (j, i) halves of each pair and the relative delta
+        is against the larger magnitude of the two.
+    """
+    n_nonfinite = 0
+    n_negative = 0
+    n_asym = 0
+    max_abs_delta = 0.0
+    max_rel_delta = 0.0
+    for i in range(ib, i_end):
+        j_start = jb if jb > i else i + 1
+        for j in range(j_start, j_end):
+            a = matrix[i, j]
+            b = matrix[j, i]
+            a_finite = np.isfinite(a)
+            b_finite = np.isfinite(b)
+            n_nonfinite += int(not a_finite) + int(not b_finite)
+            n_negative += int(a_finite and a < 0.0) + int(b_finite and b < 0.0)
+            if a_finite and b_finite and a != b:
+                n_asym += 1
+                delta = abs(np.float64(a) - np.float64(b))
+                max_abs_delta = max(max_abs_delta, delta)
+                max_rel_delta = max(max_rel_delta, delta / max(abs(np.float64(a)), abs(np.float64(b))))
+    return n_nonfinite, n_negative, n_asym, max_abs_delta, max_rel_delta
+
+
+@numba.njit("Tuple((int64, int64, float64, int64, float64, float64))(float32[:, ::1])", cache=True)
+def _scan_square(matrix: NDArray[np.float32]) -> tuple[int, int, float, int, float, float]:
+    """Read-only blocked scan of a square distance matrix.
+
+    Returns:
+        Tuple ``(n_nonfinite, n_negative, max_abs_diagonal, n_asymmetric_pairs, max_abs_delta,
+        max_rel_delta)``, aggregating `_scan_square_block` over all block pairs plus a diagonal
+        sweep.
+    """
+    n = matrix.shape[0]
+    n_nonfinite = 0
+    n_negative = 0
+    max_abs_diag = 0.0
+    n_asym = 0
+    max_abs_delta = 0.0
+    max_rel_delta = 0.0
+    for i in range(n):
+        v = matrix[i, i]
+        if not np.isfinite(v):
+            n_nonfinite += 1
+        else:
+            max_abs_diag = max(max_abs_diag, np.float64(abs(v)))
+    for ib in range(0, n, _BLOCK):
+        for jb in range(ib, n, _BLOCK):
+            nf, neg, asym, d_abs, d_rel = _scan_square_block(
+                matrix, ib, jb, min(ib + _BLOCK, n), min(jb + _BLOCK, n)
+            )
+            n_nonfinite += nf
+            n_negative += neg
+            n_asym += asym
+            max_abs_delta = max(max_abs_delta, d_abs)
+            max_rel_delta = max(max_rel_delta, d_rel)
+    return n_nonfinite, n_negative, max_abs_diag, n_asym, max_abs_delta, max_rel_delta
+
+
+@numba.njit("void(float32[:, ::1])", cache=True)
+def _symmetrize_square(matrix: NDArray[np.float32]) -> None:
+    """Make `matrix` exactly symmetric in place: each differing (i, j)/(j, i) pair gets its mean."""
+    n = matrix.shape[0]
+    for ib in range(0, n, _BLOCK):
+        for jb in range(ib, n, _BLOCK):
+            i_end = min(ib + _BLOCK, n)
+            j_end = min(jb + _BLOCK, n)
+            for i in range(ib, i_end):
+                j_start = jb if jb > i else i + 1
+                for j in range(j_start, j_end):
+                    a = matrix[i, j]
+                    b = matrix[j, i]
+                    if a != b:
+                        mean = np.float32(0.5 * (np.float64(a) + np.float64(b)))
+                        matrix[i, j] = mean
+                        matrix[j, i] = mean
+
+
+@numba.njit("Tuple((int64, int64))(float32[::1])", cache=True)
+def _scan_condensed(values: NDArray[np.float32]) -> tuple[int, int]:
+    """Single-pass scan of a condensed distance vector: counts of non-finite and negative values."""
+    n_nonfinite = 0
+    n_negative = 0
+    for idx in range(values.size):
+        v = values[idx]
+        if not np.isfinite(v):
+            n_nonfinite += 1
+        elif v < 0.0:
+            n_negative += 1
+    return n_nonfinite, n_negative
+
+
+# =================================================================================================
+#  Validated adoption
+# =================================================================================================
+def validated_square_distances(distances: np.ndarray) -> NDArray[np.float32]:
+    """Validate a square distance matrix for solver use and return it float32 C-contiguous.
+
+    Zero-copy when the input already is float32 C-contiguous; any conversion copy is disclosed via
+    `DistanceInputWarning`.  Asymmetric input is repaired to exact symmetry by averaging each
+    (i, j)/(j, i) pair — in place, which for zero-copy-adopted input means the provided array is
+    modified; the warning reports the largest absolute and relative deltas so the caller can judge
+    whether the asymmetry was float noise or a data problem.  Raw values are validated *before*
+    averaging: a negative or non-finite value anywhere is rejected, never averaged away.
+
+    Raises:
+        ValueError: On a non-square shape, fewer than 3 items, non-finite or negative values, or a
+            diagonal that is not zero within tolerance.
+    """
+    if distances.shape[0] != distances.shape[1]:
+        raise ValueError(f"Square distance matrix must be (n, n); got {distances.shape}.")
+    if distances.shape[0] < 3:
+        raise ValueError("At least 3 items are required to formulate a max-div problem.")
+
+    converted = np.ascontiguousarray(distances, dtype=np.float32)
+    if converted is not distances:
+        warnings.warn(
+            f"Square distance input required a conversion copy (dtype {distances.dtype} or memory layout); "
+            "pass a float32 C-contiguous array to avoid the copy and enable zero-copy adoption.",
+            DistanceInputWarning,
+            stacklevel=3,
+        )
+
+    n_nonfinite, n_negative, max_abs_diag, n_asym, max_abs_delta, max_rel_delta = _scan_square(converted)
+    if n_nonfinite:
+        raise ValueError("Distances must all be finite (no NaN or inf).")
+    if n_negative:
+        raise ValueError("Distances must all be non-negative.")
+    if max_abs_diag > _DIAGONAL_ATOL:
+        raise ValueError("Square distance matrix must have a zero diagonal.")
+    if n_asym:
+        _symmetrize_square(converted)
+        modified_note = " The provided array itself was modified." if converted is distances else ""
+        warnings.warn(
+            f"Asymmetric square distance matrix: {n_asym} (i, j)/(j, i) pairs differ "
+            f"(max |delta| = {max_abs_delta:.3e}, max relative delta = {max_rel_delta:.3e}); "
+            f"symmetrized in place by averaging each pair.{modified_note}",
+            DistanceInputWarning,
+            stacklevel=3,
+        )
+    return converted
+
+
+def validated_condensed_distances(distances: np.ndarray) -> NDArray[np.float32]:
+    """Validate a condensed distance vector for solver use and return it float32 C-contiguous.
+
+    Zero-copy when the input already is float32 C-contiguous; any conversion copy is disclosed via
+    `DistanceInputWarning`.  The condensed layout stores each pair once, so no symmetry question
+    exists here.
+
+    Raises:
+        ValueError: On a non-triangular length, fewer than 3 items, or non-finite or negative values.
+    """
+    n = _n_from_condensed_size(distances.size)
+    if n < 3:
+        raise ValueError("At least 3 items are required to formulate a max-div problem.")
+
+    converted = np.ascontiguousarray(distances, dtype=np.float32)
+    if converted is not distances:
+        warnings.warn(
+            f"Condensed distance input required a conversion copy (dtype {distances.dtype} or memory layout); "
+            "pass a float32 C-contiguous array to avoid the copy and enable zero-copy adoption.",
+            DistanceInputWarning,
+            stacklevel=3,
+        )
+
+    n_nonfinite, n_negative = _scan_condensed(converted)
+    if n_nonfinite:
+        raise ValueError("Distances must all be finite (no NaN or inf).")
+    if n_negative:
+        raise ValueError("Distances must all be non-negative.")
+    return converted
+
+
+def _n_from_condensed_size(size: int) -> int:
+    """Return n such that n*(n-1)/2 == size, raising ValueError if no such integer exists."""
+    n = round((1 + np.sqrt(1 + 8 * size)) / 2)
+    if (n * (n - 1)) // 2 != size:
+        raise ValueError(f"Condensed distance vector has invalid length {size}: not a triangular number n*(n-1)/2.")
+    return n

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Self
 
 from max_div._core.metrics import DiversityMetric
-from max_div._core.metrics._distance import DistanceStore
 from max_div._core.problem import MaxDivProblem
 
 from ._constraint_penalty import ConstraintPenalty
@@ -13,6 +12,7 @@ from ._strategies import InitializationStrategy
 
 if TYPE_CHECKING:
     from max_div._core.constraints import Constraint
+    from max_div._core.metrics._distance import DistanceStore
 
 
 class MaxDivSolverBuilder:
@@ -33,7 +33,7 @@ class MaxDivSolverBuilder:
 
         # --- problem properties ----------------
         self._n: int = problem.n
-        self._store: DistanceStore = DistanceStore.condensed(problem.condensed_distances(), problem.n)
+        self._store: DistanceStore = problem.distance_store()
         self._k: int = problem.k
         self._diversity_metric: DiversityMetric = problem.diversity_metric
         self._constraints: list[Constraint] = problem.constraints

--- a/src/max_div/problem.py
+++ b/src/max_div/problem.py
@@ -1,12 +1,15 @@
 """Public API for defining Maximum Diversity problems and constraints."""
 
+from ._core._warnings import DistanceInputWarning, MaxDivWarning
 from ._core.constraints import Constraint
 from ._core.problem import DistanceMaxDivProblem, MaxDivProblem, VectorMaxDivProblem
 
 __all__ = [
     "Constraint",
+    "DistanceInputWarning",
     "DistanceMaxDivProblem",
     "MaxDivProblem",
+    "MaxDivWarning",
     "VectorMaxDivProblem",
 ]
 

--- a/tests/_core/problem/test_problem.py
+++ b/tests/_core/problem/test_problem.py
@@ -246,7 +246,7 @@ def test_problem_distance_store_matches_input_format(form: str):
         assert store.matrix is problem.distances
     else:
         assert store.kind == KIND_CONDENSED
-        assert store.condensed is problem.distances
+        assert store.pdist is problem.distances
     assert store.n == np.int32(5)
 
 

--- a/tests/_core/problem/test_problem.py
+++ b/tests/_core/problem/test_problem.py
@@ -1,10 +1,14 @@
+import warnings
+
 import numpy as np
 import pytest
 from scipy.spatial.distance import squareform
 
+from max_div._core._warnings import DistanceInputWarning
 from max_div._core.constraints import Constraint
 from max_div._core.metrics import DistanceMetric, DiversityMetric
 from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance._store import KIND_CONDENSED, KIND_FULL_MATRIX
 from max_div._core.problem import DistanceMaxDivProblem, MaxDivProblem, VectorMaxDivProblem
 
 
@@ -116,7 +120,7 @@ def test_problem_new_cosine_non_zero_vectors_ok():
 # -------------------------------------------------------------------------
 @pytest.mark.parametrize("form", ["square", "condensed"])
 def test_problem_from_distances_happy_path(form: str):
-    """from_distances accepts square and condensed input and normalizes both to condensed float32."""
+    """from_distances accepts square and condensed input, keeping each in the format provided."""
 
     # --- arrange -----------------------------------------
     rng = np.random.default_rng(20260713)
@@ -131,7 +135,8 @@ def test_problem_from_distances_happy_path(form: str):
     assert isinstance(problem, DistanceMaxDivProblem)
     assert problem.n == 10
     assert problem.k == 4
-    assert problem.pdist.dtype == np.float32
+    assert problem.distances.dtype == np.float32
+    assert problem.distances.ndim == (2 if form == "square" else 1)
     np.testing.assert_allclose(problem.condensed_distances(), condensed, rtol=1e-6)
 
 
@@ -180,8 +185,8 @@ def _mutated_square_symmetric(i: int, j: int, value: float) -> np.ndarray:
 @pytest.mark.parametrize(
     "case, distances, k",
     [
-        ("asymmetric", _mutated_square(0, 1, 99.0), 3),
         ("non_zero_diagonal", _mutated_square(2, 2, 1.0), 3),
+        ("negative_asymmetric_raw", _mutated_square(0, 1, -0.5), 3),  # raw value checked before averaging
         ("negative", _mutated_square_symmetric(0, 1, -1.0), 3),
         ("nan", _mutated_square_symmetric(0, 1, np.nan), 3),
         ("inf", _mutated_square_symmetric(0, 1, np.inf), 3),
@@ -198,3 +203,120 @@ def test_problem_from_distances_value_error(case: str, distances: np.ndarray, k:
     # --- act & assert ------------------------------------
     with pytest.raises(ValueError):
         _ = MaxDivProblem.from_distances(distances, k=k)
+
+
+# -------------------------------------------------------------------------
+#  from_distances: format retention, zero-copy, and repair
+# -------------------------------------------------------------------------
+def _reference_square() -> np.ndarray:
+    """Return a well-formed 5x5 float32 C-contiguous distance matrix."""
+    return np.ascontiguousarray(squareform(np.arange(1, 11, dtype=np.float32)))
+
+
+@pytest.mark.parametrize("form", ["square", "condensed"])
+def test_problem_from_distances_zero_copy_adoption(form: str):
+    """Well-formed float32 C-contiguous input is adopted zero-copy, without any warning."""
+
+    # --- arrange -----------------------------------------
+    distances = _reference_square() if form == "square" else np.arange(1, 11, dtype=np.float32)
+
+    # --- act ---------------------------------------------
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning fails the test
+        problem = MaxDivProblem.from_distances(distances, k=3)
+
+    # --- assert ------------------------------------------
+    assert problem.distances is distances
+
+
+@pytest.mark.parametrize("form", ["square", "condensed"])
+def test_problem_distance_store_matches_input_format(form: str):
+    """The as-given store wraps the retained input directly: square -> full matrix, 1D -> condensed."""
+
+    # --- arrange -----------------------------------------
+    distances = _reference_square() if form == "square" else np.arange(1, 11, dtype=np.float32)
+    problem = MaxDivProblem.from_distances(distances, k=3)
+
+    # --- act ---------------------------------------------
+    store = problem.distance_store()
+
+    # --- assert ------------------------------------------
+    if form == "square":
+        assert store.kind == KIND_FULL_MATRIX
+        assert store.matrix is problem.distances
+    else:
+        assert store.kind == KIND_CONDENSED
+        assert store.condensed is problem.distances
+    assert store.n == np.int32(5)
+
+
+def test_problem_from_distances_asymmetric_repaired_with_warning():
+    """Asymmetric square input is symmetrized in place by averaging, disclosed with delta figures."""
+
+    # --- arrange -----------------------------------------
+    distances = _reference_square()
+    distances[0, 1] = 1.5  # partner [1, 0] stays 1.0 -> mean 1.25
+
+    # --- act ---------------------------------------------
+    with pytest.warns(DistanceInputWarning, match=r"max \|delta\| = 5\.000e-01"):
+        problem = MaxDivProblem.from_distances(distances, k=3)
+
+    # --- assert ------------------------------------------
+    assert problem.distances is distances  # zero-copy adoption, hence in-place repair
+    assert distances[0, 1] == distances[1, 0] == np.float32(1.25)
+    np.testing.assert_array_equal(distances, distances.T)
+
+
+def test_problem_from_distances_conversion_copy_warns_and_leaves_input_untouched():
+    """Input needing a dtype cast warns about the conversion copy; the user's array is not modified."""
+
+    # --- arrange -----------------------------------------
+    distances = _reference_square().astype(np.float64)
+    distances[0, 1] = 1.5  # asymmetric, so the repair must land in the cast copy only
+    original = distances.copy()
+
+    # --- act ---------------------------------------------
+    with pytest.warns(DistanceInputWarning, match="conversion copy"):
+        problem = MaxDivProblem.from_distances(distances, k=3)
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(distances, original)  # user's array untouched
+    assert problem.distances.dtype == np.float32
+    assert problem.distances[0, 1] == problem.distances[1, 0] == np.float32(1.25)
+
+
+def test_problem_from_distances_condensed_conversion_copy_warns():
+    """A condensed vector needing a dtype cast warns about the conversion copy."""
+
+    # --- arrange -----------------------------------------
+    distances = np.arange(1, 11, dtype=np.float64)
+
+    # --- act ---------------------------------------------
+    with pytest.warns(DistanceInputWarning, match="conversion copy"):
+        problem = MaxDivProblem.from_distances(distances, k=3)
+
+    # --- assert ------------------------------------------
+    assert problem.distances.dtype == np.float32
+
+
+def test_problem_from_distances_condensed_negative_raises():
+    """Negative values in condensed input are rejected, as for square input."""
+
+    # --- arrange -----------------------------------------
+    distances = np.arange(1, 11, dtype=np.float32)
+    distances[3] = -0.001
+
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError, match="non-negative"):
+        _ = MaxDivProblem.from_distances(distances, k=3)
+
+
+def test_problem_square_condensed_distances_extracts_upper_triangle():
+    """condensed_distances() on a retained square matrix returns the exact condensed values."""
+
+    # --- arrange -----------------------------------------
+    condensed = np.arange(1, 11, dtype=np.float32)
+    problem = MaxDivProblem.from_distances(squareform(condensed), k=3)
+
+    # --- act / assert ------------------------------------
+    np.testing.assert_array_equal(problem.condensed_distances(), condensed)

--- a/tests/_core/solver/test_solver.py
+++ b/tests/_core/solver/test_solver.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from scipy.spatial.distance import squareform
 
 from max_div._core._utils import stdout_to_file
 from max_div._core.metrics import DistanceMetric, DiversityMetric
@@ -109,15 +110,22 @@ def test_solver_verbosity(example_solver, tmp_path, verbosity: int, error_expect
             _ = example_solver.solve(verbosity=verbosity)
 
 
-def test_solver_vector_and_distance_input_bit_identical():
-    """Solving via from_distances with the vector flavor's own pdist gives bit-identical solutions."""
+@pytest.mark.parametrize("form", ["condensed", "square"])
+def test_solver_vector_and_distance_input_bit_identical(form: str):
+    """Solving via from_distances with the vector flavor's own distances gives bit-identical solutions.
+
+    Square input is retained as a full matrix, so this also exercises the full-matrix store on the
+    distance-input path.
+    """
 
     # --- arrange -----------------------------------------
     rng = np.random.default_rng(20260713)
     vectors = rng.random((40, 4)).astype(np.float32)
     kwargs: dict = {"k": 8, "diversity_metric": DiversityMetric.GEOMEAN_SEPARATION}
     problem_vec = MaxDivProblem.new(vectors, distance_metric=DistanceMetric.L2_EUCLIDEAN, **kwargs)
-    problem_dist = MaxDivProblem.from_distances(problem_vec.condensed_distances(), **kwargs)
+    condensed = problem_vec.condensed_distances()
+    distances = np.ascontiguousarray(squareform(condensed)) if form == "square" else condensed
+    problem_dist = MaxDivProblem.from_distances(distances, **kwargs)
 
     # --- act ---------------------------------------------
     solutions = [


### PR DESCRIPTION
**TL;DR**: `from_distances` stops eagerly condensing square matrices — each input format is validated in place, adopted zero-copy when possible, and drives the matching storage backend. Asymmetric squares are repaired to exact symmetry with a disclosing warning instead of rejected.

## Description

### Problem addressed

- **Square inputs were silently converted**: a copy plus a layout change the user never asked for — and with pluggable storage, a downgrade to the slower layout.
- **Symmetry handling was arbitrary**: asymmetry within a tolerance was resolved by silently letting the upper triangle win; beyond it, rejected. Neither is principled, and a relative tolerance is unreliable across large dynamic ranges.
- **Exact symmetry became a correctness precondition**: kernels now read whichever of (i, j)/(j, i) suits their access pattern, so the halves must be bit-equal.

### Implementation

- **Format retention**: the distance-input problem stores what the user provided (condensed vector or square matrix) and a new `distance_store()` on the problem hands the builder the matching backend — condensed stays condensed, square becomes the full-matrix store, zero-copy in both cases.
- **Blocked validation scans** (each (i, j) tile visited with its transpose partner, for locality on O(n²) data): finiteness, per-value non-negativity, diagonal tolerance, and an exact-equality symmetry check tracking the largest absolute and relative deltas — one read-only pass.
- **Symmetry repair**: differing pairs are averaged in place, disclosed by a warning carrying the delta figures so the user judges float-noise vs data bug. Raw values are validated *before* averaging — a negative value is rejected, never averaged away. Erroring input is never mutated (repair runs only after all checks pass).
- **Warning taxonomy**: new `MaxDivWarning` base plus `DistanceInputWarning` (also used for O(n²) conversion-copy disclosure), exported publicly so users can filter the family.

## Attention points

- **Behavior changes for asymmetric square input**: previously tolerance-checked and upper-triangle-resolved, now always averaged with a warning — near-symmetric inputs get slightly different (more principled) values than before.
- **Zero-copy adoption and in-place repair are two sides of one handover**: only inputs eligible for zero-copy can be mutated, and the warning says so; inputs that needed a cast copy are repaired in the copy, the user's array untouched.
- **The solver never reads the diagonal** (`get_distance` short-circuits i == j), so the diagonal is tolerance-validated but not zeroed.

## Tests / Spikes

- **TEST:** full suite with numba JIT green; golden master unchanged.
- Unit tests added: zero-copy adoption per format (warning-free), store-kind-matches-format, in-place asymmetry repair with delta-reporting warning, conversion-copy warnings (square + condensed, user array untouched), raw-negative rejection ahead of averaging, upper-triangle extraction, and the vector-vs-distance-input bit-identical solve now parametrized over both input formats.

## Changelog entry

Changed:
```
Square distance inputs are now kept in full-matrix form (previously condensed), adopted zero-copy when possible, and repaired to exact symmetry with a warning when asymmetric
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
