### PR TITLE
feat: make distance storage selectable on the builder, with an automatic default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Lazy distance computation for vector problems: solve without ever materializing the pairwise-distance matrix, removing the O(n²) memory requirement
 - Full-matrix distance storage: roughly 2× faster solving at large problem sizes, for twice the distance-storage memory
+- Distance storage is selectable on the solver builder (condensed, full-matrix, lazy), with an automatic default that picks the fastest layout fitting in memory for vector problems and keeps the provided format for distance problems
 
 ### Changed
 - Square distance inputs are now kept in full-matrix form (previously condensed), adopted zero-copy when possible, and repaired to exact symmetry with a warning when asymmetric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Lazy distance computation for vector problems: solve without ever materializing the pairwise-distance matrix, removing the O(n²) memory requirement
-- Full-matrix distance storage: roughly 2× faster solving at large problem sizes, for twice the distance-storage memory
-- Distance storage is selectable on the solver builder (condensed, full-matrix, lazy), with an automatic default that picks the fastest layout fitting in memory for vector problems and keeps the provided format for distance problems
+- More flexible distance storage and computation: how pairwise distances are held during solving is now selectable on the solver builder (`DistanceStorage`), with an automatic default —
+  - `FULL_MATRIX` stores the full n×n matrix: roughly 2× faster solving at large problem sizes, for twice the memory
+  - `LAZY` computes distances on demand from the vectors: removes the O(n²) memory requirement, so much larger problems become feasible
+  - `CONDENSED` remains the memory-lean stored layout (previously the only option)
+  - `AUTO` (default) picks the fastest layout that fits in memory for vector problems, and keeps the provided format for distance-input problems; the solution summary reports the resolved choice
+  - all layouts produce bit-identical distances, so backend choice never changes which items get selected
 
 ### Changed
-- Square distance inputs are now kept in full-matrix form (previously condensed), adopted zero-copy when possible, and repaired to exact symmetry with a warning when asymmetric
+- Square distance inputs are now kept in full-matrix form rather than condensed (zero-copy when possible), and asymmetric input is repaired to exact symmetry with a warning instead of rejected
 
 ### Deprecated
 

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -70,3 +70,35 @@ solver = (
 ```
 
 This gives you full control over which strategies run, in what order, and for how long.
+
+## Distance Storage
+
+During search the solver reads pairwise distances constantly, and how they are stored is
+selectable on the builder:
+
+```python
+from max_div.solver import DistanceStorage
+
+solver = (
+    MaxDivSolverBuilder(problem)
+    .with_preset(seconds(5))
+    .with_distance_storage(DistanceStorage.FULL_MATRIX)  # optional; AUTO is the default
+    .build()
+)
+```
+
+- **`CONDENSED`** — one entry per pair (`n·(n-1)/2` values); the most memory-lean stored layout.
+- **`FULL_MATRIX`** — a full `n x n` matrix; twice the memory of condensed, but distance reads
+  become contiguous row scans, which speeds up solving roughly 2x at large problem sizes.
+- **`LAZY`** — no stored distances at all: each distance is computed on demand from the vectors.
+  Slower per read, but removes the O(n²) memory requirement entirely, so much larger problems
+  become feasible. Available only when the problem is built from vectors.
+- **`AUTO`** (default) — for vector problems, picks the fastest layout that fits comfortably in
+  memory (full matrix, else condensed, else lazy); for problems built via `from_distances`, keeps
+  the format the distances were provided in. The resolved backend is reported in the solution
+  summary, e.g. `storage=full_matrix (auto)` — pin a backend explicitly to override.
+
+All backends produce bit-identical distance values, so with an iteration budget the selected
+items are the same whichever backend runs; the choice only affects speed and memory. (With a
+time budget, a faster backend completes more iterations — the same machine-dependence time
+budgets always have.)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -57,7 +57,7 @@ The solver will print progress as it runs. Pass `verbosity=0` for silent operati
 ```python
 # One-line summary
 print(solution)
-# MaxDivSolution: 20 items selected | diversity=0.7792 | 5.17s (39_008 iterations)
+# MaxDivSolution: 20 items selected | diversity=0.7792 | storage=full_matrix (auto) | 5.17s (39_008 iterations)
 
 # Indices of the selected items
 print(solution.i_selected)       # e.g. array([ 3,  7, 14, ...], dtype=int32)
@@ -105,7 +105,7 @@ solver = MaxDivSolverBuilder(problem).with_preset(seconds(5)).build()
 solution = solver.solve(verbosity=0)
 
 print(solution)
-# MaxDivSolution: 20 items selected | diversity=0.7702 | constraints: 2/2 satisfied | ...
+# MaxDivSolution: 20 items selected | diversity=0.7702 | constraints: 2/2 satisfied | storage=full_matrix (auto) | ...
 ```
 
 Note that the diversity is slightly lower than the unconstrained solution (0.7702 vs 0.7792) --

--- a/src/max_div/_core/solver/__init__.py
+++ b/src/max_div/_core/solver/__init__.py
@@ -8,6 +8,7 @@ m: number of (group) constraints imposed on the problem.
 """
 
 from ._constraint_penalty import ConstraintPenalty
+from ._distance_storage import DistanceStorage
 from ._duration import TargetDuration, TargetIterationCount, TargetTimeDuration, hours, iterations, minutes, seconds
 from ._presets import SolverPreset
 from ._score import Score

--- a/src/max_div/_core/solver/_distance_storage.py
+++ b/src/max_div/_core/solver/_distance_storage.py
@@ -1,0 +1,171 @@
+"""Distance-storage selection: the public choice enum, the AUTO policy, and store construction.
+
+AUTO semantics differ per problem flavor, deliberately:
+
+  - Vector problems: distances are an internal artifact the user never sees, so AUTO transparently
+    picks the fastest layout that fits in memory (full matrix, else condensed, else lazy).
+  - Distance problems: the provided format may encode a conscious memory decision, so AUTO keeps
+    it as given — condensed stays condensed, a square matrix stays a full matrix, zero-copy.
+
+The memory criterion compares backend bytes against a fraction of *total* physical RAM: total is
+cheap and stable to probe (unlike available memory, which fluctuates and is awkward to read on
+some platforms), and the conservative fraction absorbs the machine load the probe deliberately
+ignores.  Overshooting would page — worse than the foregone speedup — while undershooting only
+concedes a narrow band of problem sizes that explicit pinning recovers.
+"""
+
+import os
+from enum import StrEnum
+
+from max_div._core.metrics._distance import (
+    DistanceStore,
+    condensed_store,
+    full_matrix_store_from_condensed,
+    full_matrix_store_from_vectors,
+    lazy_store,
+)
+from max_div._core.problem import MaxDivProblem, VectorMaxDivProblem
+
+# fraction of total physical RAM a stored backend may claim under AUTO
+_AUTO_MEMORY_FRACTION = 1 / 3
+
+
+# =================================================================================================
+#  DistanceStorage
+# =================================================================================================
+class DistanceStorage(StrEnum):
+    """How the solver stores pairwise distances during search.
+
+    `AUTO` (the default) lets max-div decide: for vector problems, the fastest layout that fits in
+    memory; for distance-input problems, the format the distances were provided in.  The resolved
+    backend is reported in the solution summary.  Pinning a specific backend overrides the policy —
+    `LAZY` requires vectors, so it is unavailable for distance-input problems.
+    """
+
+    AUTO = "auto"
+    CONDENSED = "condensed"
+    FULL_MATRIX = "full_matrix"
+    LAZY = "lazy"
+
+
+# =================================================================================================
+#  Resolution & construction
+# =================================================================================================
+def resolve_distance_storage(
+    problem: MaxDivProblem, storage: DistanceStorage, total_memory_bytes: int | None
+) -> DistanceStorage:
+    """Resolve `AUTO` to a concrete backend for the given problem; explicit choices pass through.
+
+    A pure function of its arguments — the memory probe is injected, so resolution is
+    deterministic and testable.
+
+    :param problem: the problem to be solved.
+    :param storage: the user's choice, possibly AUTO.
+    :param total_memory_bytes: total physical RAM, or None when unknown (degrades to condensed).
+    """
+    if storage != DistanceStorage.AUTO:
+        return storage
+    if not isinstance(problem, VectorMaxDivProblem):
+        # distance-input problems: keep the format the user provided
+        return DistanceStorage.FULL_MATRIX if problem.distance_store().matrix.size else DistanceStorage.CONDENSED
+    if total_memory_bytes is None:
+        return DistanceStorage.CONDENSED  # probe failed on this platform: the proven default
+    budget = total_memory_bytes * _AUTO_MEMORY_FRACTION
+    n = problem.n
+    if 4 * n * n <= budget:
+        return DistanceStorage.FULL_MATRIX
+    if 2 * n * n <= budget:
+        return DistanceStorage.CONDENSED
+    return DistanceStorage.LAZY
+
+
+def build_distance_store(problem: MaxDivProblem, resolved: DistanceStorage) -> DistanceStore:
+    """Build the distance store for an already-resolved (non-AUTO) backend choice.
+
+    Zero-copy wherever the problem already holds the data in the requested layout; conversions
+    (e.g. condensed input with a full matrix requested) allocate consciously here.
+
+    Raises:
+        ValueError: For LAZY on a distance-input problem (no vectors to compute from), or when the
+            requested stored backend cannot fit in physical memory at all.
+    """
+    is_vector_problem = isinstance(problem, VectorMaxDivProblem)
+    n = problem.n
+    match resolved:
+        case DistanceStorage.CONDENSED:
+            if is_vector_problem:
+                _check_fits_physical_memory(resolved, 2 * n * n, is_vector_problem)
+            return condensed_store(problem.condensed_distances(), n)
+        case DistanceStorage.FULL_MATRIX:
+            if is_vector_problem:
+                _check_fits_physical_memory(resolved, 4 * n * n, is_vector_problem)
+                return full_matrix_store_from_vectors(problem.vectors, problem.distance_metric)
+            as_given = problem.distance_store()
+            if as_given.matrix.size:
+                return as_given  # square input: already a full matrix, zero-copy
+            _check_fits_physical_memory(resolved, 4 * n * n, is_vector_problem)
+            return full_matrix_store_from_condensed(as_given.condensed, n)
+        case DistanceStorage.LAZY:
+            if not is_vector_problem:
+                raise ValueError(
+                    "Lazy distance storage computes distances from vectors, which a distance-input "
+                    "problem does not have; choose CONDENSED or FULL_MATRIX, or construct the "
+                    "problem from vectors."
+                )
+            return lazy_store(problem.vectors, problem.distance_metric)
+        case _:
+            raise ValueError(f"Distance storage must be resolved before building a store; got {resolved}.")
+
+
+def _check_fits_physical_memory(resolved: DistanceStorage, bytes_needed: int, is_vector_problem: bool) -> None:
+    """Raise early, with the remedy named, when a stored backend cannot fit in physical RAM at all.
+
+    Only guards allocations this module is about to make; adopted user arrays already exist.
+    """
+    total = total_physical_memory_bytes()
+    if total is not None and bytes_needed > total:
+        lazy_hint = " or DistanceStorage.LAZY (no O(n²) memory)" if is_vector_problem else ""
+        raise ValueError(
+            f"Distance storage '{resolved.value}' needs ~{bytes_needed / 2**30:.1f} GiB, but this machine "
+            f"has {total / 2**30:.1f} GiB of physical memory; choose a smaller problem{lazy_hint}."
+        )
+
+
+def total_physical_memory_bytes() -> int | None:
+    """Return total physical RAM in bytes via the stdlib, or None when it cannot be determined.
+
+    POSIX exposes it through sysconf; Windows through one kernel32 call.  Callers must treat None
+    as "unknown" and degrade gracefully.
+    """
+    # --- POSIX -----------------------------------
+    try:
+        page_count = os.sysconf("SC_PHYS_PAGES")
+        page_size = os.sysconf("SC_PAGE_SIZE")
+        if page_count > 0 and page_size > 0:
+            return page_count * page_size
+    except (ValueError, OSError, AttributeError):
+        pass
+    # --- Windows ---------------------------------
+    try:
+        import ctypes
+
+        class _MemoryStatusEx(ctypes.Structure):
+            _fields_ = [  # noqa: RUF012  # ctypes protocol attribute, not a mutable default
+                ("dwLength", ctypes.c_ulong),
+                ("dwMemoryLoad", ctypes.c_ulong),
+                ("ullTotalPhys", ctypes.c_uint64),
+                ("ullAvailPhys", ctypes.c_uint64),
+                ("ullTotalPageFile", ctypes.c_uint64),
+                ("ullAvailPageFile", ctypes.c_uint64),
+                ("ullTotalVirtual", ctypes.c_uint64),
+                ("ullAvailVirtual", ctypes.c_uint64),
+                ("ullAvailExtendedVirtual", ctypes.c_uint64),
+            ]
+
+        status = _MemoryStatusEx()
+        status.dwLength = ctypes.sizeof(_MemoryStatusEx)
+        if ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):  # ty: ignore[unresolved-attribute]
+            return int(status.ullTotalPhys)
+    except (AttributeError, OSError):
+        pass  # ctypes.windll only exists on Windows
+    return None

--- a/src/max_div/_core/solver/_distance_storage.py
+++ b/src/max_div/_core/solver/_distance_storage.py
@@ -18,13 +18,7 @@ import os
 from enum import StrEnum
 from typing import ClassVar
 
-from max_div._core.metrics._distance import (
-    DistanceStore,
-    condensed_store,
-    full_matrix_store_from_condensed,
-    full_matrix_store_from_vectors,
-    lazy_store,
-)
+from max_div._core.metrics._distance import DistanceStore
 from max_div._core.problem import MaxDivProblem, VectorMaxDivProblem
 
 # fraction of total physical RAM a stored backend may claim under AUTO
@@ -96,16 +90,16 @@ def build_distance_store(problem: MaxDivProblem, resolved: DistanceStorage) -> D
         case DistanceStorage.CONDENSED:
             if is_vector_problem:
                 _check_fits_physical_memory(resolved, 2 * n * n, is_vector_problem)
-            return condensed_store(problem.condensed_distances(), n)
+            return DistanceStore.condensed(problem.condensed_distances(), n)
         case DistanceStorage.FULL_MATRIX:
             if is_vector_problem:
                 _check_fits_physical_memory(resolved, 4 * n * n, is_vector_problem)
-                return full_matrix_store_from_vectors(problem.vectors, problem.distance_metric)
+                return DistanceStore.full_matrix_from_vectors(problem.vectors, problem.distance_metric)
             as_given = problem.distance_store()
             if as_given.matrix.size:
                 return as_given  # square input: already a full matrix, zero-copy
             _check_fits_physical_memory(resolved, 4 * n * n, is_vector_problem)
-            return full_matrix_store_from_condensed(as_given.condensed, n)
+            return DistanceStore.full_matrix_from_condensed(as_given.pdist, n)
         case DistanceStorage.LAZY:
             if not is_vector_problem:
                 raise ValueError(
@@ -113,7 +107,7 @@ def build_distance_store(problem: MaxDivProblem, resolved: DistanceStorage) -> D
                     "problem does not have; choose CONDENSED or FULL_MATRIX, or construct the "
                     "problem from vectors."
                 )
-            return lazy_store(problem.vectors, problem.distance_metric)
+            return DistanceStore.lazy(problem.vectors, problem.distance_metric)
         case _:
             raise ValueError(f"Distance storage must be resolved before building a store; got {resolved}.")
 

--- a/src/max_div/_core/solver/_distance_storage.py
+++ b/src/max_div/_core/solver/_distance_storage.py
@@ -16,6 +16,7 @@ concedes a narrow band of problem sizes that explicit pinning recovers.
 
 import os
 from enum import StrEnum
+from typing import ClassVar
 
 from max_div._core.metrics._distance import (
     DistanceStore,
@@ -150,7 +151,8 @@ def total_physical_memory_bytes() -> int | None:
         import ctypes
 
         class _MemoryStatusEx(ctypes.Structure):
-            _fields_ = [  # noqa: RUF012  # ctypes protocol attribute, not a mutable default
+            # ClassVar: the ctypes protocol reads _fields_ from the class, never per-instance
+            _fields_: ClassVar = [
                 ("dwLength", ctypes.c_ulong),
                 ("dwMemoryLoad", ctypes.c_ulong),
                 ("ullTotalPhys", ctypes.c_uint64),

--- a/src/max_div/_core/solver/_solution.py
+++ b/src/max_div/_core/solver/_solution.py
@@ -40,6 +40,10 @@ class MaxDivSolution:
     n_constraints: int = 0
     n_constraints_satisfied: int = 0
 
+    # --- distance storage --------------------------------
+    # resolved backend label, e.g. "full_matrix (auto)" or "condensed"; empty when unreported
+    distance_storage: str = ""
+
     # --- string representation ---------------------------
     def __str__(self) -> str:
         parts = [
@@ -48,5 +52,7 @@ class MaxDivSolution:
         ]
         if self.n_constraints > 0:
             parts.append(f"constraints: {self.n_constraints_satisfied}/{self.n_constraints} satisfied")
+        if self.distance_storage:
+            parts.append(f"storage={self.distance_storage}")
         parts.append(str(self.duration))
         return " | ".join(parts)

--- a/src/max_div/_core/solver/_solver.py
+++ b/src/max_div/_core/solver/_solver.py
@@ -33,6 +33,7 @@ class MaxDivSolver:
         solver_steps: list[SolverStep],
         seed: int = 42,
         constraint_penalty: ConstraintPenalty = ConstraintPenalty.LINEAR,
+        distance_storage_label: str = "",
     ) -> None:
         """Initialize the MaxDivSolver with the given configuration.
 
@@ -47,10 +48,12 @@ class MaxDivSolver:
                                        while all latter ones need to be OptimizationSteps.
         :param seed: (int) Random seed for the solver.
         :param constraint_penalty: (ConstraintPenalty) How constraint violations are penalized (default: LINEAR).
+        :param distance_storage_label: (str) Resolved distance-storage backend, reported in the solution summary.
         """
         # --- problem description -------------------------
         self._n = n
         self._store = store
+        self._distance_storage_label = distance_storage_label
         self._k = k
         self._diversity_metric = diversity_metric
         self._constraints = constraints
@@ -149,8 +152,9 @@ class MaxDivSolver:
         n_steps = len(self._solver_steps)
         return ljust_str_list([f"step {i}/{n_steps} - {name}" for i, name in enumerate(names)])
 
-    @staticmethod
-    def _construct_final_solution(state: SolverState, step_results: dict[str, SolverStepResult]) -> MaxDivSolution:
+    def _construct_final_solution(
+        self, state: SolverState, step_results: dict[str, SolverStepResult]
+    ) -> MaxDivSolution:
         """Construct the final MaxDivSolution from the current state & step results."""
         # --- collect step durations --------------------
         step_durations = {step_name: result.elapsed for step_name, result in step_results.items()}
@@ -182,4 +186,5 @@ class MaxDivSolver:
             step_durations=step_durations,
             n_constraints=int(n_constraints),
             n_constraints_satisfied=n_constraints_satisfied,
+            distance_storage=self._distance_storage_label,
         )

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -4,6 +4,12 @@ from max_div._core.metrics import DiversityMetric
 from max_div._core.problem import MaxDivProblem
 
 from ._constraint_penalty import ConstraintPenalty
+from ._distance_storage import (
+    DistanceStorage,
+    build_distance_store,
+    resolve_distance_storage,
+    total_physical_memory_bytes,
+)
 from ._duration import TargetDuration
 from ._presets import SolverPreset, get_preset_strategies
 from ._solver import MaxDivSolver
@@ -12,7 +18,6 @@ from ._strategies import InitializationStrategy
 
 if TYPE_CHECKING:
     from max_div._core.constraints import Constraint
-    from max_div._core.metrics._distance import DistanceStore
 
 
 class MaxDivSolverBuilder:
@@ -33,7 +38,6 @@ class MaxDivSolverBuilder:
 
         # --- problem properties ----------------
         self._n: int = problem.n
-        self._store: DistanceStore = problem.distance_store()
         self._k: int = problem.k
         self._diversity_metric: DiversityMetric = problem.diversity_metric
         self._constraints: list[Constraint] = problem.constraints
@@ -46,6 +50,7 @@ class MaxDivSolverBuilder:
         ]
         self._seed = 42
         self._constraint_penalty: ConstraintPenalty = ConstraintPenalty.LINEAR
+        self._distance_storage: DistanceStorage = DistanceStorage.AUTO
 
     # -------------------------------------------------------------------------
     #  Builder API
@@ -88,6 +93,11 @@ class MaxDivSolverBuilder:
     def with_constraint_penalty(self, penalty: ConstraintPenalty) -> Self:
         """Set how constraint violations are penalized in the feasibility score (default: LINEAR)."""
         self._constraint_penalty = penalty
+        return self
+
+    def with_distance_storage(self, storage: DistanceStorage) -> Self:
+        """Set how pairwise distances are stored during search (default: DistanceStorage.AUTO)."""
+        self._distance_storage = storage
         return self
 
     # -------------------------------------------------------------------------
@@ -149,9 +159,12 @@ class MaxDivSolverBuilder:
         return []
 
     def build(self) -> MaxDivSolver:
+        resolved = resolve_distance_storage(self._problem, self._distance_storage, total_physical_memory_bytes())
+        label = resolved.value + (" (auto)" if self._distance_storage == DistanceStorage.AUTO else "")
         return MaxDivSolver(
             n=self._n,
-            store=self._store,
+            store=build_distance_store(self._problem, resolved),
+            distance_storage_label=label,
             k=self._k,
             diversity_metric=self._diversity_metric,
             diversity_tie_breakers=self._determine_diversity_tie_breakers(),

--- a/src/max_div/solver.py
+++ b/src/max_div/solver.py
@@ -2,6 +2,7 @@
 
 from ._core.solver import (
     ConstraintPenalty,
+    DistanceStorage,
     InitializationStrategy,
     MaxDivSolver,
     MaxDivSolverBuilder,
@@ -18,6 +19,7 @@ from ._core.solver import (
 
 __all__ = [
     "ConstraintPenalty",
+    "DistanceStorage",
     "InitializationStrategy",
     "MaxDivSolver",
     "MaxDivSolverBuilder",

--- a/tests/_core/solver/test_distance_storage.py
+++ b/tests/_core/solver/test_distance_storage.py
@@ -1,0 +1,163 @@
+import numpy as np
+import pytest
+
+from max_div._core.metrics import DistanceMetric
+from max_div._core.metrics._distance import compute_pdist
+from max_div._core.metrics._distance._store import KIND_CONDENSED, KIND_FULL_MATRIX, KIND_LAZY
+from max_div._core.problem import MaxDivProblem
+from max_div._core.solver._distance_storage import (
+    DistanceStorage,
+    build_distance_store,
+    resolve_distance_storage,
+    total_physical_memory_bytes,
+)
+
+# =================================================================================================
+#  Fixtures / helpers
+# =================================================================================================
+GIB = 2**30
+
+
+def _vector_problem(n: int = 10) -> MaxDivProblem:
+    rng = np.random.default_rng(20260731)
+    return MaxDivProblem.new(rng.random((n, 3)).astype(np.float32), k=3)
+
+
+def _distance_problem(form: str) -> MaxDivProblem:
+    from scipy.spatial.distance import squareform
+
+    condensed = compute_pdist(_vector_problem().vectors, DistanceMetric.L2_EUCLIDEAN)  # ty: ignore[unresolved-attribute]
+    distances = np.ascontiguousarray(squareform(condensed)) if form == "square" else condensed
+    return MaxDivProblem.from_distances(distances, k=3)
+
+
+# =================================================================================================
+#  Resolution policy
+# =================================================================================================
+@pytest.mark.parametrize(
+    "storage",
+    [DistanceStorage.CONDENSED, DistanceStorage.FULL_MATRIX, DistanceStorage.LAZY],
+)
+def test_resolve_explicit_choice_passes_through(storage: DistanceStorage):
+    # --- act / assert ------------------------------------
+    assert resolve_distance_storage(_vector_problem(), storage, 64 * GIB) == storage
+
+
+@pytest.mark.parametrize(
+    "n, total_memory, expected",
+    [
+        (10, 64 * GIB, DistanceStorage.FULL_MATRIX),  # tiny problem: matrix always fits
+        (10, None, DistanceStorage.CONDENSED),  # probe failed: degrade to the proven default
+        (50_000, 32 * GIB, DistanceStorage.FULL_MATRIX),  # 10.0 GiB matrix <= 1/3 of 32 GiB
+        (50_000, 16 * GIB, DistanceStorage.CONDENSED),  # matrix over budget, half-size fits
+        (50_000, 8 * GIB, DistanceStorage.LAZY),  # even condensed over budget
+    ],
+)
+def test_resolve_auto_vector_ladder(n: int, total_memory: int | None, expected: DistanceStorage):
+    """AUTO on vector problems: fastest layout whose bytes fit within a third of total RAM."""
+
+    # --- arrange -----------------------------------------
+    problem = _vector_problem() if n == 10 else _stub_vector_problem(n)
+
+    # --- act ---------------------------------------------
+    resolved = resolve_distance_storage(problem, DistanceStorage.AUTO, total_memory)
+
+    # --- assert ------------------------------------------
+    assert resolved == expected
+
+
+def _stub_vector_problem(n: int):
+    """A stand-in exposing only what the resolution policy reads (isinstance + n), without allocations."""
+    from max_div._core.problem import VectorMaxDivProblem
+
+    stub = object.__new__(VectorMaxDivProblem)
+    object.__setattr__(stub, "vectors", np.zeros((n, 0), dtype=np.float32))
+    return stub
+
+
+@pytest.mark.parametrize(
+    "form, expected", [("condensed", DistanceStorage.CONDENSED), ("square", DistanceStorage.FULL_MATRIX)]
+)
+def test_resolve_auto_distance_problem_keeps_format(form: str, expected: DistanceStorage):
+    """AUTO on distance-input problems resolves to the format the user provided, ignoring memory."""
+
+    # --- act / assert ------------------------------------
+    assert resolve_distance_storage(_distance_problem(form), DistanceStorage.AUTO, None) == expected
+
+
+# =================================================================================================
+#  Store construction
+# =================================================================================================
+@pytest.mark.parametrize(
+    "storage, expected_kind",
+    [
+        (DistanceStorage.CONDENSED, KIND_CONDENSED),
+        (DistanceStorage.FULL_MATRIX, KIND_FULL_MATRIX),
+        (DistanceStorage.LAZY, KIND_LAZY),
+    ],
+)
+def test_build_distance_store_vector_problem(storage: DistanceStorage, expected_kind: np.int32):
+    # --- act ---------------------------------------------
+    store = build_distance_store(_vector_problem(), storage)
+
+    # --- assert ------------------------------------------
+    assert store.kind == expected_kind
+    assert store.n == np.int32(10)
+
+
+def test_build_distance_store_square_input_zero_copy():
+    """FULL_MATRIX on a square-input problem adopts the retained matrix without copying."""
+
+    # --- arrange -----------------------------------------
+    problem = _distance_problem("square")
+
+    # --- act ---------------------------------------------
+    store = build_distance_store(problem, DistanceStorage.FULL_MATRIX)
+
+    # --- assert ------------------------------------------
+    assert store.matrix is problem.distances  # ty: ignore[unresolved-attribute]
+
+
+def test_build_distance_store_condensed_input_full_matrix_converts():
+    """FULL_MATRIX on a condensed-input problem expands consciously into a fresh symmetric matrix."""
+
+    # --- arrange -----------------------------------------
+    problem = _distance_problem("condensed")
+
+    # --- act ---------------------------------------------
+    store = build_distance_store(problem, DistanceStorage.FULL_MATRIX)
+
+    # --- assert ------------------------------------------
+    assert store.kind == KIND_FULL_MATRIX
+    np.testing.assert_array_equal(store.matrix, store.matrix.T)
+
+
+def test_build_distance_store_lazy_on_distance_problem_raises():
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="from vectors"):
+        build_distance_store(_distance_problem("condensed"), DistanceStorage.LAZY)
+
+
+def test_build_distance_store_infeasible_raises_early():
+    """A stored backend that cannot fit in physical RAM is rejected with the remedy named."""
+
+    # --- arrange -----------------------------------------
+    stub = _stub_vector_problem(2_000_000)  # full matrix would need ~16 TiB
+
+    # --- act / assert ------------------------------------
+    with pytest.raises(ValueError, match="LAZY"):
+        build_distance_store(stub, DistanceStorage.FULL_MATRIX)
+
+
+# =================================================================================================
+#  Memory probe
+# =================================================================================================
+def test_total_physical_memory_bytes_on_this_platform():
+    """On every CI platform the stdlib probe must return a sane positive figure."""
+
+    # --- act ---------------------------------------------
+    total = total_physical_memory_bytes()
+
+    # --- assert ------------------------------------------
+    assert total is not None
+    assert total >= 1 * GIB

--- a/tests/_core/solver/test_solver_builder.py
+++ b/tests/_core/solver/test_solver_builder.py
@@ -174,7 +174,8 @@ def test_max_div_solver_builder_end_to_end():
     # --- assert ------------------------------------------
     assert isinstance(solver, MaxDivSolver)
     assert solver._n == vectors.shape[0]
-    assert solver._store.pdist.shape == ((vectors.shape[0] * (vectors.shape[0] - 1)) // 2,)
+    # AUTO resolves to the full matrix for a problem this small
+    assert solver._store.matrix.shape == (vectors.shape[0], vectors.shape[0])
     assert solver._k == k
     assert len(solver._solver_steps) == 3
     assert solver._solver_steps[0].name() == init_strategy.name


### PR DESCRIPTION
**TL;DR**: The storage backends become user-facing: a `DistanceStorage` enum on the builder (`AUTO` default), an automatic policy that picks the fastest layout fitting in memory for vector problems and keeps the provided format for distance problems, and backend reporting in the solution summary.

## Description

### Problem addressed

Three storage backends existed internally with no way to choose one, no default policy, and no visibility into which one a solve used.

### Implementation

- **`DistanceStorage` enum** (`AUTO` / `CONDENSED` / `FULL_MATRIX` / `LAZY`), set via `with_distance_storage()` on the builder next to the existing seed/preset/penalty knobs. Exported publicly.
- **AUTO is mode-dependent by design**: vector problems get the fastest-that-fits ladder (full matrix → condensed → lazy); distance-input problems keep the format the user provided, since that format may encode a conscious memory decision.
- **Memory criterion: backend bytes ≤ 1/3 of total physical RAM.** Total (not available) keeps the probe cheap, stable, and stdlib-only (POSIX `sysconf`, one `ctypes` call on Windows); the conservative fraction absorbs the machine load the probe deliberately ignores. Probe failure degrades to condensed — the long-proven default. The fraction is an internal constant, not a knob: explicit pinning is the escape hatch.
- **Resolution is a pure function** of (problem, choice, total RAM), with the probe injected — deterministic in tests, reusable per-worker later.
- **Visibility and early failure**: the solution summary reports the resolved backend (`storage=full_matrix (auto)`), and a stored backend that cannot fit in physical RAM at all is rejected at build time with the remedy named, instead of dying in a raw allocation.

## Attention points

- **The default changes for vector problems**: AUTO resolves to the full matrix wherever it fits in the memory budget — roughly 2× faster at large n, but twice the internal distance memory (e.g. ~1.6 GB instead of ~800 MB at n=20000). Results are bit-identical (golden master passes unchanged on the new default backend); with *time* budgets, faster iterations mean more of them, the machine-dependence time budgets always had.
- **Store construction moved from builder construction to `build()`** — the O(n²) work now happens where the resolution does. Each `build()` call constructs a fresh store.
- **The solution summary line grew a `storage=` part**, and the getting-started snippets quoting it were updated accordingly.

## Tests / Spikes

- **TEST:** full suite with numba JIT green; golden master bit-exact on the new full-matrix default — the strongest direct evidence the backend switch is behavior-neutral under iteration budgets.
- Unit tests added: resolution ladder against mocked RAM totals (including probe-failure degradation), pass-through of explicit choices, as-given resolution per input format, store construction per backend (zero-copy square adoption, conscious condensed→full conversion), lazy-on-distance-problem rejection, early infeasibility error, and a platform sanity check of the memory probe.

## Changelog entry

This PR also consolidates the stack's accumulated entries into one umbrella entry. Added:
```
More flexible distance storage and computation: how pairwise distances are held during solving is now selectable on the solver builder (`DistanceStorage`), with an automatic default —
  - `FULL_MATRIX` stores the full n×n matrix: roughly 2× faster solving at large problem sizes, for twice the memory
  - `LAZY` computes distances on demand from the vectors: removes the O(n²) memory requirement, so much larger problems become feasible
  - `CONDENSED` remains the memory-lean stored layout (previously the only option)
  - `AUTO` (default) picks the fastest layout that fits in memory for vector problems, and keeps the provided format for distance-input problems; the solution summary reports the resolved choice
  - all layouts produce bit-identical distances, so backend choice never changes which items get selected
```
plus a tightened Changed entry covering the square-input format retention and symmetry repair.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

