### PR TITLE
feat: add the Linf (Chebyshev) distance metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `CONDENSED` remains the memory-lean stored layout (previously the only option)
   - `AUTO` (default) picks the fastest layout that fits in memory for vector problems, and keeps the provided format for distance-input problems; the solution summary reports the resolved choice
   - all layouts produce bit-identical distances, so backend choice never changes which items get selected
+- Linf (Chebyshev) distance metric: `DistanceMetric.LINF_CHEBYSHEV` measures each pair by its largest per-dimension difference
 
 ### Changed
 - Square distance inputs are now kept in full-matrix form rather than condensed (zero-copy when possible), and asymmetric input is repaired to exact symmetry with a warning instead of rejected

--- a/docs/concepts/diversity.md
+++ b/docs/concepts/diversity.md
@@ -36,6 +36,7 @@ The distance metric determines how the distance between two vectors is measured.
 | `L2_EUCLIDEAN` | $$d = \sqrt{\sum_i (x_i - y_i)^2}$$ | Standard Euclidean distance. Default. |
 | `L1_MANHATTAN` | $$d = \sum_i \lvert x_i - y_i \rvert$$ | Less sensitive to outlier dimensions. |
 | `L2S_EUCLIDEAN_SQUARED` | $$d = \sum_i (x_i - y_i)^2$$ | Avoids the square root. Produces identical solutions to `L2_EUCLIDEAN` when used with `GEOMEAN_SEPARATION`, since the geometric mean preserves distance ordering regardless of squaring. |
+| `LINF_CHEBYSHEV` | $$d = \max_i \lvert x_i - y_i \rvert$$ | Chebyshev distance: set by the single largest per-dimension gap, so no dimension's difference is averaged away by the others. |
 | `COSINE` | $$d = 1 - \frac{x \cdot y}{\lVert x \rVert \, \lVert y \rVert}$$ | Angular distance in $[0, 2]$, invariant to vector magnitude -- the natural choice for embedding-style vectors. Undefined for zero vectors, which are rejected at problem construction. |
 
 ## Separation

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -133,6 +133,7 @@ problem = MaxDivProblem.new(
     distance_metric=DistanceMetric.L2_EUCLIDEAN,       # default
     # distance_metric=DistanceMetric.L1_MANHATTAN,
     # distance_metric=DistanceMetric.L2S_EUCLIDEAN_SQUARED,
+    # distance_metric=DistanceMetric.LINF_CHEBYSHEV,
     # distance_metric=DistanceMetric.COSINE,
 )
 ```
@@ -142,6 +143,7 @@ problem = MaxDivProblem.new(
 | `L2_EUCLIDEAN` | Standard Euclidean distance (default) |
 | `L1_MANHATTAN` | Sum of absolute differences |
 | `L2S_EUCLIDEAN_SQUARED` | Squared Euclidean -- avoids the square root, produces identical solutions when used with `GEOMEAN_SEPARATION` |
+| `LINF_CHEBYSHEV` | Chebyshev distance -- the largest per-dimension difference |
 | `COSINE` | Cosine distance (1 &minus; cosine similarity) -- angular, magnitude-invariant, for embedding-style vectors; zero vectors are rejected |
 
 #### Precomputed distances

--- a/src/max_div/_core/metrics/_distance/_compute.py
+++ b/src/max_div/_core/metrics/_distance/_compute.py
@@ -32,6 +32,8 @@ def compute_pdist(vectors: NDArray[np.float32], metric: DistanceMetric) -> NDArr
             _pdist_l2(vectors, out)
         case DistanceMetric.L2S_EUCLIDEAN_SQUARED:
             _pdist_l2s(vectors, out)
+        case DistanceMetric.LINF_CHEBYSHEV:
+            _pdist_linf(vectors, out)
         case DistanceMetric.COSINE:
             validate_cosine_vectors(vectors)
             _pdist_cos(vectors, out)
@@ -72,6 +74,17 @@ def _l2sq_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int |
     return acc
 
 
+@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True)
+def _linf_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int | np.signedinteger) -> np.float64:
+    """Return the Linf (Chebyshev) distance between vectors i and j, accumulated in float64."""
+    acc = np.float64(0.0)
+    for c in range(vectors.shape[1]):
+        diff = abs(np.float64(vectors[i, c]) - np.float64(vectors[j, c]))
+        if diff > acc:
+            acc = diff
+    return acc
+
+
 @numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
 def _pdist_l1(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
     """Write the condensed L1 distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
@@ -102,6 +115,17 @@ def _pdist_l2s(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
     for i in range(n):
         for j in range(i + 1, n):
             out[idx] = np.float32(_l2sq_pair(vectors, i, j))
+            idx += 1
+
+
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+def _pdist_linf(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
+    """Write the condensed Linf distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
+    n = vectors.shape[0]
+    idx = np.int64(0)
+    for i in range(n):
+        for j in range(i + 1, n):
+            out[idx] = np.float32(_linf_pair(vectors, i, j))
             idx += 1
 
 

--- a/src/max_div/_core/metrics/_distance/_enum.py
+++ b/src/max_div/_core/metrics/_distance/_enum.py
@@ -12,6 +12,8 @@ class DistanceMetric(StrEnum):
         - L2S_EUCLIDEAN_SQUARED:   L2 squared (Euclidean squared) distance   = sum_i (x_i - y_i)^2
                                           --> avoids computing square root
                                           --> and produces identical solutions for GEOMEAN_SEPARATION diversity metric
+        - LINF_CHEBYSHEV:          Linf (Chebyshev) distance                 = max_i |x_i - y_i|
+                                          --> distance set by the single largest per-dimension gap
         - COSINE:                  cosine distance                           = 1 - (x . y) / (|x| |y|)
                                           --> range [0, 2]; angular, for embedding-style vectors
                                           --> undefined for zero vectors (rejected with an error)
@@ -20,4 +22,5 @@ class DistanceMetric(StrEnum):
     L1_MANHATTAN = "L1_MANHATTAN"
     L2_EUCLIDEAN = "L2_EUCLIDEAN"
     L2S_EUCLIDEAN_SQUARED = "L2S_EUCLIDEAN_SQUARED"
+    LINF_CHEBYSHEV = "LINF_CHEBYSHEV"
     COSINE = "COSINE"

--- a/src/max_div/_core/metrics/_distance/_store.py
+++ b/src/max_div/_core/metrics/_distance/_store.py
@@ -11,7 +11,7 @@ import numba
 import numpy as np
 from numpy.typing import NDArray
 
-from ._compute import _l1_pair, _l2sq_pair, normalize_rows, validate_cosine_vectors
+from ._compute import _l1_pair, _l2sq_pair, _linf_pair, normalize_rows, validate_cosine_vectors
 from ._enum import DistanceMetric
 
 # =================================================================================================
@@ -28,12 +28,14 @@ _METRIC_KIND_L1 = np.int32(0)
 _METRIC_KIND_L2 = np.int32(1)
 _METRIC_KIND_L2S = np.int32(2)
 _METRIC_KIND_COS = np.int32(3)
+_METRIC_KIND_LINF = np.int32(4)
 
 _METRIC_KINDS = {
     DistanceMetric.L1_MANHATTAN: _METRIC_KIND_L1,
     DistanceMetric.L2_EUCLIDEAN: _METRIC_KIND_L2,
     DistanceMetric.L2S_EUCLIDEAN_SQUARED: _METRIC_KIND_L2S,
     DistanceMetric.COSINE: _METRIC_KIND_COS,
+    DistanceMetric.LINF_CHEBYSHEV: _METRIC_KIND_LINF,
 }
 
 # shared placeholders for the fields a backend does not use, so empty stores cost nothing
@@ -182,6 +184,8 @@ def _lazy_pair(vectors: NDArray[np.float32], metric_kind: np.int32, i: np.int32,
         return np.float32(np.sqrt(_l2sq_pair(vectors, i, j)))
     if metric_kind == _METRIC_KIND_L2S:
         return np.float32(_l2sq_pair(vectors, i, j))
+    if metric_kind == _METRIC_KIND_LINF:
+        return np.float32(_linf_pair(vectors, i, j))
     return np.float32(0.5 * _l2sq_pair(vectors, i, j))  # cosine: rows are pre-normalized
 
 

--- a/tests/_core/metrics/test_distance_metric.py
+++ b/tests/_core/metrics/test_distance_metric.py
@@ -11,6 +11,7 @@ _SCIPY_METRIC = {
     "L1_MANHATTAN": "cityblock",
     "L2_EUCLIDEAN": "euclidean",
     "L2S_EUCLIDEAN_SQUARED": "sqeuclidean",
+    "LINF_CHEBYSHEV": "chebyshev",
     "COSINE": "cosine",
 }
 
@@ -40,6 +41,7 @@ def test_compute_pdist_metrics(metric: DistanceMetric):
         (DistanceMetric.L1_MANHATTAN, 7.0),
         (DistanceMetric.L2_EUCLIDEAN, 5.0),
         (DistanceMetric.L2S_EUCLIDEAN_SQUARED, 25.0),
+        (DistanceMetric.LINF_CHEBYSHEV, 4.0),
     ],
 )
 def test_compute_pdist_values(metric: DistanceMetric, expected_value: float):


### PR DESCRIPTION
**Problem**: The built-in distance metrics stop at L1, L2, squared L2, and cosine — Chebyshev distance, where a pair is as far apart as its single most different dimension, required precomputing distances externally.

**Solution**: A `DistanceMetric.LINF_CHEBYSHEV` member, implemented as one pair kernel (`max_i |x_i - y_i|`, float64 accumulation, float32 narrowing like every other metric) used by both the condensed pdist fill and the lazy store's on-demand read, so all storage backends produce bit-identical values.

- **TEST:** the existing metric-coverage drift guard and cross-backend bit-equality suites parametrize over the enum, so they cover the new member automatically; added a scipy `chebyshev` cross-check and a hand-computed value case.

**Changelog** (Added):
```
Linf (Chebyshev) distance metric: `DistanceMetric.LINF_CHEBYSHEV` measures each pair by its largest per-dimension difference
```


Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
