### PR TITLE
feat: compute dataset-wide contributions lazily, element by element on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Solver setup no longer computes all-pairs contribution data up front; it is computed on demand by the strategies that use it
+- Solver setup no longer computes dataset-wide diversity contributions (requiring all pairwise distances) up front; they are computed on demand by the strategies that use them
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Solver setup no longer computes all-pairs contribution data up front; it is computed on demand by the strategies that use it
 
 ### Deprecated
 

--- a/src/max_div/_core/solver/_diversity_contribution/_base.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_base.py
@@ -50,7 +50,24 @@ class DiversityContributionTracker(ABC):
     def contribution_wrt_dataset(self) -> NDArray[np.floating]:
         """Return static per-point contribution of each point wrt the whole dataset (selection-independent).
 
+        Dataset-wide contributions are computed lazily, one point's row scan at a time; this
+        property first computes every not-yet-computed entry, so it is always safe to read but
+        costs the full O(n²) sweep on first access.  Callers needing only some entries use
+        `contribution_wrt_dataset_for`, which computes just the rows it returns.
+
         The returned array is a reference to internal state — callers must not modify it.
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
+        """Return dataset-wide contributions for `indices`, computing missing entries first.
+
+        The targeted counterpart of `contribution_wrt_dataset`: only the requested rows are
+        guaranteed computed afterwards, so the cost is proportional to the not-yet-computed rows
+        among `indices` rather than to n.
+
+        Returns a freshly allocated array (safe for in-place mutation by the caller).
         """
         raise NotImplementedError
 

--- a/src/max_div/_core/solver/_diversity_contribution/_base.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_base.py
@@ -50,10 +50,11 @@ class DiversityContributionTracker(ABC):
     def contribution_wrt_dataset(self) -> NDArray[np.floating]:
         """Return static per-point contribution of each point wrt the whole dataset (selection-independent).
 
-        Dataset-wide contributions are computed lazily, one point's row scan at a time; this
-        property first computes every not-yet-computed entry, so it is always safe to read but
-        costs the full O(n²) sweep on first access.  Callers needing only some entries use
-        `contribution_wrt_dataset_for`, which computes just the rows it returns.
+        Dataset-wide contributions are computed lazily, element by element — each element requiring
+        a scan of one full row of the pairwise-distance matrix; this property first computes every
+        not-yet-computed element, so it is always safe to read but costs the full O(n²) sweep on
+        first access.  Callers needing only some elements use `contribution_wrt_dataset_for`,
+        which computes just the elements it returns.
 
         The returned array is a reference to internal state — callers must not modify it.
         """
@@ -63,9 +64,9 @@ class DiversityContributionTracker(ABC):
     def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
         """Return dataset-wide contributions for `indices`, computing missing entries first.
 
-        The targeted counterpart of `contribution_wrt_dataset`: only the requested rows are
-        guaranteed computed afterwards, so the cost is proportional to the not-yet-computed rows
-        among `indices` rather than to n.
+        The targeted counterpart of `contribution_wrt_dataset`: only the requested elements are
+        guaranteed computed afterwards, so the cost is proportional to the not-yet-computed
+        elements among `indices` rather than to n.
 
         Returns a freshly allocated array (safe for in-place mutation by the caller).
         """

--- a/src/max_div/_core/solver/_diversity_contribution/_base.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_base.py
@@ -50,9 +50,10 @@ class DiversityContributionTracker(ABC):
     def contribution_wrt_dataset(self) -> NDArray[np.floating]:
         """Return static per-point contribution of each point wrt the whole dataset (selection-independent).
 
-        Dataset-wide contributions are computed lazily, element by element — each element requiring
-        a scan of one full row of the pairwise-distance matrix; this property first computes every
-        not-yet-computed element, so it is always safe to read but costs the full O(n²) sweep on
+        Dataset-wide contributions live in a lazily filled cache: elements start as NaN (not yet
+        computed), are computed on first read — each requiring a scan of one full row of the
+        pairwise-distance matrix — and never change afterwards.  This property first computes
+        every missing element, so it is always safe to read but costs the full O(n²) sweep on
         first access.  Callers needing only some elements use `contribution_wrt_dataset_for`,
         which computes just the elements it returns.
 

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
@@ -94,18 +94,18 @@ class MeanDistanceTracker(DiversityContributionTracker):
         if contribution_wrt_dataset is not None:
             self._contribution_wrt_dataset = contribution_wrt_dataset
         else:
-            # lazy memo: NaN = not yet computed; elements are filled on read and never change
-            # once written (monotone), which is what makes sharing the array across copies safe
+            # lazily filled cache: NaN marks a not-yet-computed element; elements are computed on
+            # read and never change afterwards, which is what makes sharing the array across copies safe
             self._contribution_wrt_dataset = np.full(store.n, np.nan, dtype=np.float32)
         self._dist_sums = dist_sums if dist_sums is not None else np.zeros(store.n, dtype=np.float64)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
         self._snapshot_dist_sums: list[NDArray[np.float64]] = []
 
     def copy(self) -> MeanDistanceTracker:
-        """Return an independent copy of this tracker; the store and the global-contribution memo are shared.
+        """Return an independent copy of this tracker; store and lazily filled cache are shared.
 
-        Sharing the memo is safe because its elements are monotone: filled on read, never
-        rewritten, so copies can only ever benefit from each other's computed elements.
+        Sharing the global-contribution cache is safe because its elements are computed once and
+        never rewritten, so copies can only ever benefit from each other's computed elements.
         """
         return MeanDistanceTracker(
             store=self._store,

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
@@ -21,18 +21,22 @@ if TYPE_CHECKING:
 # iterations, and float32 drift there would change scores with iteration count.  Distances of a
 # point to itself are 0, so a point's own entry never needs special-casing: it always equals the
 # sum of its distances to the *other* selected points.
-@numba.njit(numba.float64[::1](DISTANCE_STORE_TYPE), cache=True)
-def compute_distance_sums(store: DistanceStore) -> NDArray[np.float64]:
-    """Compute sum of distances of each item wrt all others, given the distance store."""
+@numba.njit(numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32[::1]), cache=True)
+def compute_mean_distance_rows(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
+    """Fill the given rows of `out` with each item's mean distance to all others.
+
+    Rows are independent, so any subset can be computed in any order.  Per row: a float64 sum over
+    partners in ascending index (so sums stay bit-equal across store layouts), one divide by
+    (n-1), one cast to float32.
+    """
     n = store.n
-    dist_sums = np.zeros(n, dtype=np.float64)
-    # partners are visited in ascending index per item, so each float64 sum accumulates in the
-    # same order however the store lays distances out — sums stay bit-equal across backends
-    for i in np.arange(n, dtype=np.int32):
+    den = np.float64(max(n - 1, 1))
+    for idx in indices:
+        row_sum = np.float64(0.0)
         for j in np.arange(n, dtype=np.int32):
-            if j != i:
-                dist_sums[i] += np.float64(get_distance(store, i, j))
-    return dist_sums
+            if j != idx:
+                row_sum += np.float64(get_distance(store, idx, j))
+        out[idx] = np.float32(row_sum / den)
 
 
 @numba.njit(numba.void(numba.float64[::1], DISTANCE_STORE_TYPE, numba.int32), cache=True)
@@ -79,24 +83,29 @@ class MeanDistanceTracker(DiversityContributionTracker):
         """Initialize the MeanDistanceTracker for an empty selection.
 
         :param store: (DistanceStore) pairwise-distance storage; immutable, so shareable across copies.
-        :param contribution_wrt_dataset: (np.ndarray[np.float32] | None) precomputed global contribution;
-                                    computed if omitted.
+        :param contribution_wrt_dataset: (np.ndarray[np.float32] | None) global-contribution array to adopt;
+                                    a fresh lazy (all-NaN) array if omitted.
         :param dist_sums: (np.ndarray[np.float64] | None) current distance sums wrt selection; fresh (all 0.0,
                           i.e. empty selection) if omitted.  Together with `contribution_wrt_dataset` this
                           enables copies without recomputation.
         """
         self._store = store  # READ-ONLY
         if contribution_wrt_dataset is not None:
-            self._contribution_wrt_dataset = contribution_wrt_dataset  # READ-ONLY
+            self._contribution_wrt_dataset = contribution_wrt_dataset
         else:
-            n = int(store.n)
-            self._contribution_wrt_dataset = (compute_distance_sums(store) / max(n - 1, 1)).astype(np.float32)
+            # lazy memo: NaN = not yet computed; rows are filled on read and never change once
+            # written (monotone), which is what makes sharing the array across copies safe
+            self._contribution_wrt_dataset = np.full(store.n, np.nan, dtype=np.float32)
         self._dist_sums = dist_sums if dist_sums is not None else np.zeros(store.n, dtype=np.float64)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
         self._snapshot_dist_sums: list[NDArray[np.float64]] = []
 
     def copy(self) -> MeanDistanceTracker:
-        """Return an independent copy of this tracker; the immutable store and global contributions are shared."""
+        """Return an independent copy of this tracker; the store and the global-contribution memo are shared.
+
+        Sharing the memo is safe because its rows are monotone: filled on read, never rewritten,
+        so copies can only ever benefit from each other's computed rows.
+        """
         return MeanDistanceTracker(
             store=self._store,
             contribution_wrt_dataset=self._contribution_wrt_dataset,
@@ -114,8 +123,25 @@ class MeanDistanceTracker(DiversityContributionTracker):
 
     @property
     def contribution_wrt_dataset(self) -> NDArray[np.float32]:
-        """Return mean distance of all points wrt all other points (reference; do not modify)."""
+        """Return mean distance of all points wrt all other points (reference; do not modify).
+
+        Computes every not-yet-computed row first; see the base class for the lazy contract.
+        """
+        self._ensure_global_rows(np.arange(self._store.n, dtype=np.int32))
         return self._contribution_wrt_dataset
+
+    def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
+        """Return global mean-distance contributions for `indices`, computing missing rows first (fresh array)."""
+        self._ensure_global_rows(indices)
+        return self._contribution_wrt_dataset[indices]
+
+    def _ensure_global_rows(self, indices: NDArray[np.int32]) -> None:
+        """Compute any not-yet-computed global-contribution rows among `indices`."""
+        missing = indices[np.isnan(self._contribution_wrt_dataset[indices])]
+        if missing.size:
+            compute_mean_distance_rows(
+                self._contribution_wrt_dataset, self._store, np.ascontiguousarray(missing, dtype=np.int32)
+            )
 
     # -------------------------------------------------------------------------
     #  Mutations

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance.py
@@ -22,10 +22,11 @@ if TYPE_CHECKING:
 # point to itself are 0, so a point's own entry never needs special-casing: it always equals the
 # sum of its distances to the *other* selected points.
 @numba.njit(numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32[::1]), cache=True)
-def compute_mean_distance_rows(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
-    """Fill the given rows of `out` with each item's mean distance to all others.
+def compute_mean_distance_elements(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
+    """Fill the given elements of `out` with each item's mean distance to all others.
 
-    Rows are independent, so any subset can be computed in any order.  Per row: a float64 sum over
+    Each element requires scanning that item's full row of the pairwise-distance matrix; elements
+    are independent, so any subset can be computed in any order.  Per element: a float64 sum over
     partners in ascending index (so sums stay bit-equal across store layouts), one divide by
     (n-1), one cast to float32.
     """
@@ -93,8 +94,8 @@ class MeanDistanceTracker(DiversityContributionTracker):
         if contribution_wrt_dataset is not None:
             self._contribution_wrt_dataset = contribution_wrt_dataset
         else:
-            # lazy memo: NaN = not yet computed; rows are filled on read and never change once
-            # written (monotone), which is what makes sharing the array across copies safe
+            # lazy memo: NaN = not yet computed; elements are filled on read and never change
+            # once written (monotone), which is what makes sharing the array across copies safe
             self._contribution_wrt_dataset = np.full(store.n, np.nan, dtype=np.float32)
         self._dist_sums = dist_sums if dist_sums is not None else np.zeros(store.n, dtype=np.float64)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
@@ -103,8 +104,8 @@ class MeanDistanceTracker(DiversityContributionTracker):
     def copy(self) -> MeanDistanceTracker:
         """Return an independent copy of this tracker; the store and the global-contribution memo are shared.
 
-        Sharing the memo is safe because its rows are monotone: filled on read, never rewritten,
-        so copies can only ever benefit from each other's computed rows.
+        Sharing the memo is safe because its elements are monotone: filled on read, never
+        rewritten, so copies can only ever benefit from each other's computed elements.
         """
         return MeanDistanceTracker(
             store=self._store,
@@ -125,21 +126,21 @@ class MeanDistanceTracker(DiversityContributionTracker):
     def contribution_wrt_dataset(self) -> NDArray[np.float32]:
         """Return mean distance of all points wrt all other points (reference; do not modify).
 
-        Computes every not-yet-computed row first; see the base class for the lazy contract.
+        Computes every not-yet-computed element first; see the base class for the lazy contract.
         """
-        self._ensure_global_rows(np.arange(self._store.n, dtype=np.int32))
+        self._ensure_global_elements(np.arange(self._store.n, dtype=np.int32))
         return self._contribution_wrt_dataset
 
     def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
-        """Return global mean-distance contributions for `indices`, computing missing rows first (fresh array)."""
-        self._ensure_global_rows(indices)
+        """Return global mean-distance contributions for `indices`, computing missing elements first (fresh array)."""
+        self._ensure_global_elements(indices)
         return self._contribution_wrt_dataset[indices]
 
-    def _ensure_global_rows(self, indices: NDArray[np.int32]) -> None:
-        """Compute any not-yet-computed global-contribution rows among `indices`."""
+    def _ensure_global_elements(self, indices: NDArray[np.int32]) -> None:
+        """Compute any not-yet-computed global-contribution elements among `indices`."""
         missing = indices[np.isnan(self._contribution_wrt_dataset[indices])]
-        if missing.size:
-            compute_mean_distance_rows(
+        if missing.size > 0:
+            compute_mean_distance_elements(
                 self._contribution_wrt_dataset, self._store, np.ascontiguousarray(missing, dtype=np.int32)
             )
 

--- a/src/max_div/_core/solver/_diversity_contribution/_separation.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_separation.py
@@ -17,11 +17,12 @@ if TYPE_CHECKING:
 #  Separation kernels
 # =================================================================================================
 @numba.njit(numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32[::1]), cache=True)
-def compute_separation_rows(sep: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
-    """Fill the given rows of `sep` with each item's separation wrt all others.
+def compute_separation_elements(sep: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
+    """Fill the given elements of `sep` with each item's separation wrt all others.
 
-    Rows are independent, so any subset can be computed in any order; a filled row equals what a
-    full sweep would produce for it.
+    Each element requires scanning that item's full row of the pairwise-distance matrix.
+    Elements are independent, so any subset can be computed in any order; a filled element
+    equals what a full sweep would produce for it.
     """
     n = store.n
     for idx in indices:
@@ -39,7 +40,7 @@ def compute_separation(store: DistanceStore) -> NDArray[np.float32]:
     """Compute separation of each item wrt all others, given the distance store."""
     n = store.n
     sep = np.full(n, fill_value=np.inf, dtype=np.float32)
-    compute_separation_rows(sep, store, np.arange(n, dtype=np.int32))
+    compute_separation_elements(sep, store, np.arange(n, dtype=np.int32))
     return sep
 
 
@@ -106,8 +107,8 @@ class SeparationTracker(DiversityContributionTracker):
                              without recomputation.
         """
         self._store = store  # READ-ONLY
-        # lazy memo: NaN = not yet computed; rows are filled on read and never change once written
-        # (monotone), which is what makes sharing the array across copies safe
+        # lazy memo: NaN = not yet computed; elements are filled on read and never change once
+        # written (monotone), which is what makes sharing the array across copies safe
         self._sep_global = sep_global if sep_global is not None else np.full(store.n, np.nan, dtype=np.float32)
         self._sep_selected = sep_selected if sep_selected is not None else np.full(store.n, np.inf, dtype=np.float32)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
@@ -116,8 +117,8 @@ class SeparationTracker(DiversityContributionTracker):
     def copy(self) -> SeparationTracker:
         """Return an independent copy of this tracker; the store and the global-separation memo are shared.
 
-        Sharing the memo is safe because its rows are monotone: filled on read, never rewritten,
-        so copies can only ever benefit from each other's computed rows.
+        Sharing the memo is safe because its elements are monotone: filled on read, never
+        rewritten, so copies can only ever benefit from each other's computed elements.
         """
         return SeparationTracker(
             store=self._store,
@@ -136,21 +137,21 @@ class SeparationTracker(DiversityContributionTracker):
     def contribution_wrt_dataset(self) -> NDArray[np.float32]:
         """Return separation of all points wrt all other points (reference; do not modify).
 
-        Computes every not-yet-computed row first; see the base class for the lazy contract.
+        Computes every not-yet-computed element first; see the base class for the lazy contract.
         """
-        self._ensure_global_rows(np.arange(self._store.n, dtype=np.int32))
+        self._ensure_global_elements(np.arange(self._store.n, dtype=np.int32))
         return self._sep_global
 
     def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
-        """Return global separations for `indices`, computing missing rows first (fresh array)."""
-        self._ensure_global_rows(indices)
+        """Return global separations for `indices`, computing missing elements first (fresh array)."""
+        self._ensure_global_elements(indices)
         return self._sep_global[indices]
 
-    def _ensure_global_rows(self, indices: NDArray[np.int32]) -> None:
-        """Compute any not-yet-computed global-separation rows among `indices`."""
+    def _ensure_global_elements(self, indices: NDArray[np.int32]) -> None:
+        """Compute any not-yet-computed global-separation elements among `indices`."""
         missing = indices[np.isnan(self._sep_global[indices])]
-        if missing.size:
-            compute_separation_rows(self._sep_global, self._store, np.ascontiguousarray(missing, dtype=np.int32))
+        if missing.size > 0:
+            compute_separation_elements(self._sep_global, self._store, np.ascontiguousarray(missing, dtype=np.int32))
 
     # -------------------------------------------------------------------------
     #  Mutations

--- a/src/max_div/_core/solver/_diversity_contribution/_separation.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_separation.py
@@ -16,17 +16,30 @@ if TYPE_CHECKING:
 # =================================================================================================
 #  Separation kernels
 # =================================================================================================
+@numba.njit(numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32[::1]), cache=True)
+def compute_separation_rows(sep: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
+    """Fill the given rows of `sep` with each item's separation wrt all others.
+
+    Rows are independent, so any subset can be computed in any order; a filled row equals what a
+    full sweep would produce for it.
+    """
+    n = store.n
+    for idx in indices:
+        row_min = np.float32(np.inf)
+        for j in np.arange(n, dtype=np.int32):
+            if j != idx:
+                dist_ij = get_distance(store, idx, j)
+                if dist_ij < row_min:
+                    row_min = dist_ij
+        sep[idx] = row_min
+
+
 @numba.njit(numba.float32[::1](DISTANCE_STORE_TYPE), cache=True)
 def compute_separation(store: DistanceStore) -> NDArray[np.float32]:
     """Compute separation of each item wrt all others, given the distance store."""
     n = store.n
     sep = np.full(n, fill_value=np.inf, dtype=np.float32)
-    for i in np.arange(n, dtype=np.int32):
-        for j in np.arange(n, dtype=np.int32):
-            if j != i:
-                dist_ij = get_distance(store, i, j)
-                if dist_ij < sep[i]:
-                    sep[i] = dist_ij
+    compute_separation_rows(sep, store, np.arange(n, dtype=np.int32))
     return sep
 
 
@@ -86,19 +99,26 @@ class SeparationTracker(DiversityContributionTracker):
         """Initialize the SeparationTracker for an empty selection.
 
         :param store: (DistanceStore) pairwise-distance storage; immutable, so shareable across copies.
-        :param sep_global: (np.ndarray[np.float32] | None) precomputed global separations; computed if omitted.
+        :param sep_global: (np.ndarray[np.float32] | None) global-separation array to adopt; a fresh lazy
+                           (all-NaN) array if omitted.
         :param sep_selected: (np.ndarray[np.float32] | None) current separations wrt selection; fresh (all +inf,
                              i.e. empty selection) if omitted.  Together with `sep_global` this enables copies
                              without recomputation.
         """
         self._store = store  # READ-ONLY
-        self._sep_global = sep_global if sep_global is not None else compute_separation(store)  # READ-ONLY
+        # lazy memo: NaN = not yet computed; rows are filled on read and never change once written
+        # (monotone), which is what makes sharing the array across copies safe
+        self._sep_global = sep_global if sep_global is not None else np.full(store.n, np.nan, dtype=np.float32)
         self._sep_selected = sep_selected if sep_selected is not None else np.full(store.n, np.inf, dtype=np.float32)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
         self._snapshot_sep_selected: list[NDArray[np.float32]] = []
 
     def copy(self) -> SeparationTracker:
-        """Return an independent copy of this tracker; the immutable store and global separations are shared."""
+        """Return an independent copy of this tracker; the store and the global-separation memo are shared.
+
+        Sharing the memo is safe because its rows are monotone: filled on read, never rewritten,
+        so copies can only ever benefit from each other's computed rows.
+        """
         return SeparationTracker(
             store=self._store,
             sep_global=self._sep_global,
@@ -114,8 +134,23 @@ class SeparationTracker(DiversityContributionTracker):
 
     @property
     def contribution_wrt_dataset(self) -> NDArray[np.float32]:
-        """Return separation of all points wrt all other points (reference; do not modify)."""
+        """Return separation of all points wrt all other points (reference; do not modify).
+
+        Computes every not-yet-computed row first; see the base class for the lazy contract.
+        """
+        self._ensure_global_rows(np.arange(self._store.n, dtype=np.int32))
         return self._sep_global
+
+    def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
+        """Return global separations for `indices`, computing missing rows first (fresh array)."""
+        self._ensure_global_rows(indices)
+        return self._sep_global[indices]
+
+    def _ensure_global_rows(self, indices: NDArray[np.int32]) -> None:
+        """Compute any not-yet-computed global-separation rows among `indices`."""
+        missing = indices[np.isnan(self._sep_global[indices])]
+        if missing.size:
+            compute_separation_rows(self._sep_global, self._store, np.ascontiguousarray(missing, dtype=np.int32))
 
     # -------------------------------------------------------------------------
     #  Mutations

--- a/src/max_div/_core/solver/_diversity_contribution/_separation.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_separation.py
@@ -107,18 +107,18 @@ class SeparationTracker(DiversityContributionTracker):
                              without recomputation.
         """
         self._store = store  # READ-ONLY
-        # lazy memo: NaN = not yet computed; elements are filled on read and never change once
-        # written (monotone), which is what makes sharing the array across copies safe
+        # lazily filled cache: NaN marks a not-yet-computed element; elements are computed on read
+        # and never change afterwards, which is what makes sharing the array across copies safe
         self._sep_global = sep_global if sep_global is not None else np.full(store.n, np.nan, dtype=np.float32)
         self._sep_selected = sep_selected if sep_selected is not None else np.full(store.n, np.inf, dtype=np.float32)
         # snapshot stack, innermost last; entries are owned copies handed back on a restoring pop
         self._snapshot_sep_selected: list[NDArray[np.float32]] = []
 
     def copy(self) -> SeparationTracker:
-        """Return an independent copy of this tracker; the store and the global-separation memo are shared.
+        """Return an independent copy of this tracker; store and lazily filled cache are shared.
 
-        Sharing the memo is safe because its elements are monotone: filled on read, never
-        rewritten, so copies can only ever benefit from each other's computed elements.
+        Sharing the global-separation cache is safe because its elements are computed once and
+        never rewritten, so copies can only ever benefit from each other's computed elements.
         """
         return SeparationTracker(
             store=self._store,

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -357,7 +357,7 @@ class SolverState:
         """Return dataset-wide contributions for `indices`, computing missing entries first.
 
         Returns a freshly allocated array (safe for in-place mutation by the caller); cost is
-        proportional to the not-yet-computed rows among `indices` rather than to n.
+        proportional to the not-yet-computed elements among `indices` rather than to n.
         """
         return self._contribution_tracker.contribution_wrt_dataset_for(indices)
 

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -346,8 +346,20 @@ class SolverState:
 
     @property
     def global_contribution_array(self) -> NDArray[np.float32]:
-        """Return static diversity contribution of all items wrt the whole dataset (np.float32 ndarray)."""
+        """Return static diversity contribution of all items wrt the whole dataset (np.float32 ndarray).
+
+        Accessing this computes any not-yet-computed entries first (the full O(n²) sweep on first
+        access); callers needing only some entries use `global_contribution_for`.
+        """
         return self._contribution_tracker.contribution_wrt_dataset  # should not be modified (!)
+
+    def global_contribution_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
+        """Return dataset-wide contributions for `indices`, computing missing entries first.
+
+        Returns a freshly allocated array (safe for in-place mutation by the caller); cost is
+        proportional to the not-yet-computed rows among `indices` rather than to n.
+        """
+        return self._contribution_tracker.contribution_wrt_dataset_for(indices)
 
     # -------------------------------------------------------------------------
     #  Scoring

--- a/src/max_div/_core/solver/_strategies/_sampling/add.py
+++ b/src/max_div/_core/solver/_strategies/_sampling/add.py
@@ -62,12 +62,12 @@ def select_items_to_add(
     if state.n_selected == 0:
         # the only option is to look at the global contribution (wrt all other items), as we don't have a selection yet
         # this branch is only taken in the first iteration of initialization strategies
-        p = state.global_contribution_array[candidates]  # contribution of candidates wrt all other items
+        p = state.global_contribution_for(candidates)  # contribution of candidates wrt all other items
     else:
         # standard path
         p = state.full_contribution_array[candidates]  # new array; contribution of candidates wrt selected items
         if include_within_group_contribution:
-            p += state.global_contribution_array[candidates]  # add contribution of candidates wrt all other items
+            p += state.global_contribution_for(candidates)  # add contribution of candidates wrt all other items
 
     exponential_selectivity(
         p_in=p,

--- a/tests/_core/solver/_diversity_contribution/test_base.py
+++ b/tests/_core/solver/_diversity_contribution/test_base.py
@@ -21,6 +21,9 @@ class _CallRecordingTracker(DiversityContributionTracker):
     def contribution_wrt_dataset(self) -> NDArray[np.float32]:
         return np.array([], dtype=np.float32)
 
+    def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
+        return np.array([], dtype=np.float32)  # pragma: no cover - not exercised by these tests
+
     def add(self, index: np.int32) -> None:
         self.calls.append(("add", int(index)))
 

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -172,15 +172,15 @@ def test_lazy_global_targeted_read_computes_only_requested(tracker: MeanDistance
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(values, expected_global[requested], rtol=1e-6)
-    # only the requested elements are computed; the rest of the memo is still pending
+    # only the requested elements are computed; the rest of the cache is still pending
     untouched = np.setdiff1d(np.arange(N), requested)
     assert np.all(np.isnan(tracker._contribution_wrt_dataset[untouched]))
-    # the returned array is a fresh copy, not a view into the memo
+    # the returned array is a fresh copy, not a view into the cache
     values[0] = -1.0
     assert tracker._contribution_wrt_dataset[2] != -1.0
 
 
-def test_lazy_global_memo_shared_across_copies(tracker: MeanDistanceTracker):
+def test_lazy_global_cache_shared_across_copies(tracker: MeanDistanceTracker):
     # --- arrange -----------------------------------------
     clone = tracker.copy()
 
@@ -188,7 +188,7 @@ def test_lazy_global_memo_shared_across_copies(tracker: MeanDistanceTracker):
     clone.contribution_wrt_dataset_for(np.array([4], dtype=np.int32))
 
     # --- assert ------------------------------------------
-    # an element computed through the clone is visible through the original (one shared, monotone memo)
+    # an element computed through the clone is visible through the original (one shared cache)
     assert not np.isnan(tracker._contribution_wrt_dataset[4])
 
 

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -7,7 +7,7 @@ from max_div._core.metrics import DistanceMetric
 from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker
 from max_div._core.solver._diversity_contribution._mean_distance import (
-    compute_distance_sums,
+    compute_mean_distance_rows,
     update_distance_sums_add,
     update_distance_sums_remove,
 )
@@ -162,6 +162,36 @@ def test_invariant_random_operations_match_recompute(tracker: MeanDistanceTracke
         )
 
 
+def test_lazy_global_targeted_read_computes_only_requested(tracker: MeanDistanceTracker, pdist: np.ndarray):
+    # --- arrange -----------------------------------------
+    expected_global = (squareform(pdist).astype(np.float64).sum(axis=1) / (N - 1)).astype(np.float32)
+    requested = np.array([2, 11, 5], dtype=np.int32)
+
+    # --- act ---------------------------------------------
+    values = tracker.contribution_wrt_dataset_for(requested)
+
+    # --- assert ------------------------------------------
+    np.testing.assert_allclose(values, expected_global[requested], rtol=1e-6)
+    # only the requested rows are computed; the rest of the memo is still pending
+    untouched = np.setdiff1d(np.arange(N), requested)
+    assert np.all(np.isnan(tracker._contribution_wrt_dataset[untouched]))
+    # the returned array is a fresh copy, not a view into the memo
+    values[0] = -1.0
+    assert tracker._contribution_wrt_dataset[2] != -1.0
+
+
+def test_lazy_global_memo_shared_across_copies(tracker: MeanDistanceTracker):
+    # --- arrange -----------------------------------------
+    clone = tracker.copy()
+
+    # --- act ---------------------------------------------
+    clone.contribution_wrt_dataset_for(np.array([4], dtype=np.int32))
+
+    # --- assert ------------------------------------------
+    # a row computed through the clone is visible through the original (one shared, monotone memo)
+    assert not np.isnan(tracker._contribution_wrt_dataset[4])
+
+
 def test_copy_is_independent(tracker: MeanDistanceTracker):
     # --- arrange -----------------------------------------
     tracker.add(np.int32(0))
@@ -182,22 +212,25 @@ def test_copy_is_independent(tracker: MeanDistanceTracker):
 # =================================================================================================
 #  Kernels
 # =================================================================================================
-def test_compute_distance_sums():
-    """Check if compute_distance_sums matches a brute-force row-sum of the full distance matrix."""
+def test_compute_mean_distance_rows_partial_fill():
+    """The rows kernel fills exactly the requested rows, with brute-force row-mean values."""
 
     # --- arrange -----------------------------------------
     rng = np.random.default_rng(20260713)
     vectors = rng.standard_normal((30, 4)).astype(np.float32)
     m = vectors.shape[0]
     d = compute_pdist(vectors, metric=DistanceMetric.L2_EUCLIDEAN)
-    expected = squareform(d).astype(np.float64).sum(axis=1)
+    expected = (squareform(d).astype(np.float64).sum(axis=1) / (m - 1)).astype(np.float32)
+    out = np.full(m, np.nan, dtype=np.float32)
+    requested = np.array([0, 7, 29, 13], dtype=np.int32)
 
     # --- act ---------------------------------------------
-    dist_sums = compute_distance_sums(DistanceStore.condensed(d, n=m))
+    compute_mean_distance_rows(out, DistanceStore.condensed(d, n=m), requested)
 
     # --- assert ------------------------------------------
-    assert dist_sums.dtype == np.float64
-    np.testing.assert_allclose(dist_sums, expected, rtol=1e-6)
+    np.testing.assert_allclose(out[requested], expected[requested], rtol=1e-6)
+    untouched = np.setdiff1d(np.arange(m), requested)
+    assert np.all(np.isnan(out[untouched]))  # only the requested rows were written
 
 
 def test_update_distance_sums_add_remove():

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -7,7 +7,7 @@ from max_div._core.metrics import DistanceMetric
 from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker
 from max_div._core.solver._diversity_contribution._mean_distance import (
-    compute_mean_distance_rows,
+    compute_mean_distance_elements,
     update_distance_sums_add,
     update_distance_sums_remove,
 )
@@ -172,7 +172,7 @@ def test_lazy_global_targeted_read_computes_only_requested(tracker: MeanDistance
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(values, expected_global[requested], rtol=1e-6)
-    # only the requested rows are computed; the rest of the memo is still pending
+    # only the requested elements are computed; the rest of the memo is still pending
     untouched = np.setdiff1d(np.arange(N), requested)
     assert np.all(np.isnan(tracker._contribution_wrt_dataset[untouched]))
     # the returned array is a fresh copy, not a view into the memo
@@ -188,7 +188,7 @@ def test_lazy_global_memo_shared_across_copies(tracker: MeanDistanceTracker):
     clone.contribution_wrt_dataset_for(np.array([4], dtype=np.int32))
 
     # --- assert ------------------------------------------
-    # a row computed through the clone is visible through the original (one shared, monotone memo)
+    # an element computed through the clone is visible through the original (one shared, monotone memo)
     assert not np.isnan(tracker._contribution_wrt_dataset[4])
 
 
@@ -212,8 +212,8 @@ def test_copy_is_independent(tracker: MeanDistanceTracker):
 # =================================================================================================
 #  Kernels
 # =================================================================================================
-def test_compute_mean_distance_rows_partial_fill():
-    """The rows kernel fills exactly the requested rows, with brute-force row-mean values."""
+def test_compute_mean_distance_elements_partial_fill():
+    """The elements kernel fills exactly the requested elements, with brute-force mean values."""
 
     # --- arrange -----------------------------------------
     rng = np.random.default_rng(20260713)
@@ -225,12 +225,12 @@ def test_compute_mean_distance_rows_partial_fill():
     requested = np.array([0, 7, 29, 13], dtype=np.int32)
 
     # --- act ---------------------------------------------
-    compute_mean_distance_rows(out, DistanceStore.condensed(d, n=m), requested)
+    compute_mean_distance_elements(out, DistanceStore.condensed(d, n=m), requested)
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(out[requested], expected[requested], rtol=1e-6)
     untouched = np.setdiff1d(np.arange(m), requested)
-    assert np.all(np.isnan(out[untouched]))  # only the requested rows were written
+    assert np.all(np.isnan(out[untouched]))  # only the requested elements were written
 
 
 def test_update_distance_sums_add_remove():

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -155,14 +155,14 @@ def test_lazy_global_targeted_read_computes_only_requested(tracker: SeparationTr
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(values, [1, 3])
-    # only the requested elements are computed; the rest of the memo is still pending
+    # only the requested elements are computed; the rest of the cache is still pending
     assert np.all(np.isnan(tracker._sep_global[[1, 2, 4]]))
-    # the returned array is a fresh copy, not a view into the memo
+    # the returned array is a fresh copy, not a view into the cache
     values[0] = -1.0
     assert tracker._sep_global[0] != -1.0
 
 
-def test_lazy_global_memo_shared_across_copies(tracker: SeparationTracker):
+def test_lazy_global_cache_shared_across_copies(tracker: SeparationTracker):
     # --- arrange -----------------------------------------
     clone = tracker.copy()
 
@@ -170,7 +170,7 @@ def test_lazy_global_memo_shared_across_copies(tracker: SeparationTracker):
     clone.contribution_wrt_dataset_for(np.array([2], dtype=np.int32))
 
     # --- assert ------------------------------------------
-    # an element computed through the clone is visible through the original (one shared, monotone memo)
+    # an element computed through the clone is visible through the original (one shared cache)
     assert not np.isnan(tracker._sep_global[2])
 
 

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -7,7 +7,7 @@ from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import SeparationTracker
 from max_div._core.solver._diversity_contribution._separation import (
     compute_separation,
-    compute_separation_rows,
+    compute_separation_elements,
     update_separation_add,
     update_separation_remove,
 )
@@ -155,7 +155,7 @@ def test_lazy_global_targeted_read_computes_only_requested(tracker: SeparationTr
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(values, [1, 3])
-    # only the requested rows are computed; the rest of the memo is still pending
+    # only the requested elements are computed; the rest of the memo is still pending
     assert np.all(np.isnan(tracker._sep_global[[1, 2, 4]]))
     # the returned array is a fresh copy, not a view into the memo
     values[0] = -1.0
@@ -170,12 +170,12 @@ def test_lazy_global_memo_shared_across_copies(tracker: SeparationTracker):
     clone.contribution_wrt_dataset_for(np.array([2], dtype=np.int32))
 
     # --- assert ------------------------------------------
-    # a row computed through the clone is visible through the original (one shared, monotone memo)
+    # an element computed through the clone is visible through the original (one shared, monotone memo)
     assert not np.isnan(tracker._sep_global[2])
 
 
-def test_compute_separation_rows_partial_fill():
-    """The rows kernel fills exactly the requested rows; untouched rows keep their sentinel."""
+def test_compute_separation_elements_partial_fill():
+    """The elements kernel fills exactly the requested elements; untouched ones keep their sentinel."""
 
     # --- arrange -----------------------------------------
     vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0]], dtype=np.float32)
@@ -184,11 +184,11 @@ def test_compute_separation_rows_partial_fill():
     requested = np.array([1, 4], dtype=np.int32)
 
     # --- act ---------------------------------------------
-    compute_separation_rows(sep, store, requested)
+    compute_separation_elements(sep, store, requested)
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(sep[requested], [1, 4])
-    assert np.all(np.isnan(sep[[0, 2, 3]]))  # only the requested rows were written
+    assert np.all(np.isnan(sep[[0, 2, 3]]))  # only the requested elements were written
 
 
 def test_compute_separation():

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -7,6 +7,7 @@ from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import SeparationTracker
 from max_div._core.solver._diversity_contribution._separation import (
     compute_separation,
+    compute_separation_rows,
     update_separation_add,
     update_separation_remove,
 )
@@ -144,6 +145,52 @@ def test_snapshot_stack(tracker: SeparationTracker):
 # =================================================================================================
 #  Kernels
 # =================================================================================================
+def test_lazy_global_targeted_read_computes_only_requested(tracker: SeparationTracker):
+    # --- arrange -----------------------------------------
+    # points [0, 1, 3, 6, 10] on a line: nearest-neighbor distances [1, 1, 2, 3, 4]
+    requested = np.array([0, 3], dtype=np.int32)
+
+    # --- act ---------------------------------------------
+    values = tracker.contribution_wrt_dataset_for(requested)
+
+    # --- assert ------------------------------------------
+    np.testing.assert_allclose(values, [1, 3])
+    # only the requested rows are computed; the rest of the memo is still pending
+    assert np.all(np.isnan(tracker._sep_global[[1, 2, 4]]))
+    # the returned array is a fresh copy, not a view into the memo
+    values[0] = -1.0
+    assert tracker._sep_global[0] != -1.0
+
+
+def test_lazy_global_memo_shared_across_copies(tracker: SeparationTracker):
+    # --- arrange -----------------------------------------
+    clone = tracker.copy()
+
+    # --- act ---------------------------------------------
+    clone.contribution_wrt_dataset_for(np.array([2], dtype=np.int32))
+
+    # --- assert ------------------------------------------
+    # a row computed through the clone is visible through the original (one shared, monotone memo)
+    assert not np.isnan(tracker._sep_global[2])
+
+
+def test_compute_separation_rows_partial_fill():
+    """The rows kernel fills exactly the requested rows; untouched rows keep their sentinel."""
+
+    # --- arrange -----------------------------------------
+    vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0]], dtype=np.float32)
+    store = DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=5)
+    sep = np.full(5, np.nan, dtype=np.float32)
+    requested = np.array([1, 4], dtype=np.int32)
+
+    # --- act ---------------------------------------------
+    compute_separation_rows(sep, store, requested)
+
+    # --- assert ------------------------------------------
+    np.testing.assert_allclose(sep[requested], [1, 4])
+    assert np.all(np.isnan(sep[[0, 2, 3]]))  # only the requested rows were written
+
+
 def test_compute_separation():
     """Check if compute_separation produces correct separation values."""
 


### PR DESCRIPTION
**TL;DR**: The trackers' dataset-wide contribution arrays are now computed lazily on read, one element at a time, removing the O(n²·d) eager setup cost for every configuration that never reads them — with bit-identical values.

## Description

### Problem addressed

Every diversity-contribution tracker computed its dataset-wide array (each item's nearest-neighbor separation, or mean distance to all others) **eagerly at solver-state construction**: n full row scans, O(n²·d) arithmetic on the lazy distance backend. That cost is paid **before the first iteration**, on every backend, under every strategy configuration — including ones that never read a single value. At n=100000 with high-dimensional vectors the setup alone runs well over an hour before any solving starts.

### Implementation

- **Element-wise lazily filled cache**: the arrays start NaN-initialized; batched kernels (index-array variants of the existing full sweeps) fill exactly the requested elements, each from a scan of one full row of the pairwise-distance matrix. A filled element is **bit-identical** to what the eager sweep produces.
- **Ensure-on-read accessor**: `SolverState.global_contribution_for(indices)` computes missing rows and returns exact values — structurally impossible to read an uncomputed entry. The full-array property remains for whole-array readers (fill-all on access).
- **Monotone sharing**: elements are written once and never change, so the cache stays shared across tracker copies — copies benefit from each other's computed elements.
- The eager full-sweep kernel for distance sums became dead code and was removed; the separation full sweep now delegates to the elements kernel.

## Attention points

- **The property/accessor split is the contract**: the bare property is always safe but costs the full sweep on first access; hot paths and targeted readers use the accessor. Docstrings on the tracker base class carry this.
- **Golden masters pass unregenerated** — that is the proof the lazy values are exactly the eager values, not an approximation.

## Tests / Spikes

- **TEST:** full suite green (3697), golden master 64/64 bit-exact without regeneration, lint clean.
- **TEST:** 100% coverage on all touched files.
- 6 unit tests added: partial-fill kernels write only requested elements, targeted reads compute only requested elements and return fresh arrays, cache sharing across copies.

## Changelog entry

Changed:
```
Solver setup no longer computes dataset-wide diversity contributions (requiring all pairwise distances) up front; they are computed on demand by the strategies that use them
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

