### PR TITLE
docs: state the large-n cost of contribution-weighted initialization strategies

### DIFF
--- a/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_eager.py
@@ -27,6 +27,12 @@ class InitEager(InitializationStrategy):
     As we progress through the batches, selectivity of p[i] is modified with modifier = #sampled / #to_sample.
         (see modify_p_selectivity for details)
 
+    NOTE: the "contribution wrt all items" term computes every pairwise distance, which with
+    distances computed on demand from vectors takes roughly a minute at n ≈ 20,000 and grows
+    quadratically — hours by n ≈ 100,000 with high-dimensional vectors; with a stored distance
+    matrix, seconds up to n ≈ 20,000. The presets' uniform one-shot initialization avoids this
+    entirely.
+
     Suggested use: when highest quality results are desired and time permits.  This method is computationally more
                    expensive than most other methods.
 

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_random_batched.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_random_batched.py
@@ -28,6 +28,12 @@ class InitRandomBatched(InitializationStrategy):
     Suggested use: when `InitRandomOneShot` does not provide a sufficiently high-quality initialization, but when
                    e.g. `InitEager` is too slow.
 
+    NOTE: the "contribution wrt all items" term computes every pairwise distance, which with
+    distances computed on demand from vectors takes roughly a minute at n ≈ 20,000 and grows
+    quadratically — hours by n ≈ 100,000 with high-dimensional vectors; with a stored distance
+    matrix, seconds up to n ≈ 20,000. The presets' uniform one-shot initialization avoids this
+    entirely.
+
     Parameters:
     - b (int): Number of batches to sample (must be > 1).
                      -> If e.g. k=100 and b=5, each batch samples 20 items.

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_random_one_shot.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_random_one_shot.py
@@ -13,6 +13,11 @@ class InitRandomOneShot(InitializationStrategy):
     This is among the fastest initialization strategies, but potentially also with the lowest quality.
 
     Suggested use: if time constraints are severe or problem dimensions `n` or `k` are very large.
+    For very large `n`, prefer `uniform=True` (what the solver presets use): contribution-weighted
+    sampling (`uniform=False`) computes every pairwise distance, which with distances computed on
+    demand from vectors takes roughly a minute at n ≈ 20,000 and grows quadratically — hours
+    before solving starts by n ≈ 100,000 with high-dimensional vectors. With a stored distance
+    matrix: seconds up to n ≈ 20,000, with the same quadratic growth.
 
     Parameters:
     - uniform (bool): If `True`, samples uniformly at random.


### PR DESCRIPTION
**Problem**: three opt-in initialization strategies read dataset-wide diversity contributions — computing every pairwise distance, O(n²·d) when distances are computed on demand — and their docstrings said nothing about it; one even suggested itself for "very large n" while defaulting to the expensive mode.

**Solution**: docstring guidance on all three (`InitRandomOneShot(uniform=False)`, `InitRandomBatched`, `InitEager`): name the scaling behavior, and point large-n users at uniform initialization (what the presets use). Documentation only — a runtime warning on a deliberate opt-in choice would be noise.

**Changelog** (none): docstrings only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

