### PR TITLE
refactor: one mean-distance backend per distance-storage layout

### DIFF
--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/__init__.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/__init__.py
@@ -1,0 +1,6 @@
+"""Mean-distance diversity contribution: one backend per storage layout, plus the tracker."""
+
+from ._backends import MeanDistanceBackend, backend_for
+from ._tracker import MeanDistanceTracker
+
+__all__ = ["MeanDistanceBackend", "MeanDistanceTracker", "backend_for"]

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/__init__.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/__init__.py
@@ -1,0 +1,48 @@
+"""One module per storage layout, and the lookup that picks the right one.
+
+Each module provides the same three calculations over the signatures in `.._signatures`, so the
+modules are interchangeable by construction and a fourth layout is a module plus an entry below.
+
+Which one to use is decided here, in Python, and never inside a compiled function — see the
+separation package for why a layout test cannot live inside one of these loops.
+
+Each calculation covers a range excluding its own index, which keeps partners in ascending order
+so sums stay bit-equal across layouts, and lets every read go through a distinct-items reader.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+from max_div._core.metrics._distance._store import KIND_CONDENSED, KIND_FULL_MATRIX, KIND_LAZY
+
+from . import _condensed, _full_matrix, _lazy
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from max_div._core.metrics._distance import DistanceStore
+
+
+class MeanDistanceBackend(NamedTuple):
+    """What the mean-distance tracker needs from one storage layout.
+
+    `elements` computes mean distances for the given items from scratch; `add` and `remove` update
+    the running sums after an item joins or leaves the selection.
+    """
+
+    elements: Callable[..., None]
+    add: Callable[..., None]
+    remove: Callable[..., None]
+
+
+BACKEND_BY_KIND: dict[int, MeanDistanceBackend] = {
+    int(KIND_FULL_MATRIX): MeanDistanceBackend(_full_matrix.elements, _full_matrix.add, _full_matrix.remove),
+    int(KIND_CONDENSED): MeanDistanceBackend(_condensed.elements, _condensed.add, _condensed.remove),
+    int(KIND_LAZY): MeanDistanceBackend(_lazy.elements, _lazy.add, _lazy.remove),
+}
+
+
+def backend_for(store: DistanceStore) -> MeanDistanceBackend:
+    """Return the mean-distance calculations valid for this store's layout."""
+    return BACKEND_BY_KIND[int(store.kind)]

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_condensed.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_condensed.py
@@ -1,0 +1,53 @@
+"""Mean-distance calculations for a condensed store.
+
+One of three interchangeable modules — see this package's `__init__` for the pattern and why the backend is
+chosen once per tracker rather than tested inside these loops.  Each module defines the same
+three calculations over the same signatures, differing only in how a distance is read.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numba
+import numpy as np
+
+from max_div._core.metrics._distance import get_distance_condensed
+
+from .._signatures import ELEMENTS_SIGNATURE, UPDATE_SIGNATURE
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from max_div._core.metrics._distance import DistanceStore
+
+
+@numba.njit(ELEMENTS_SIGNATURE, cache=True)
+def elements(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
+    """Fill the given elements of `out` with each item's mean distance to all others."""
+    den = np.float64(max(store.n - 1, 1))
+    for idx in indices:
+        row_sum = np.float64(0.0)
+        for j in range(idx):
+            row_sum += np.float64(get_distance_condensed(store, idx, j))
+        for j in range(idx + 1, store.n):
+            row_sum += np.float64(get_distance_condensed(store, idx, j))
+        out[idx] = np.float32(row_sum / den)
+
+
+@numba.njit(UPDATE_SIGNATURE, cache=True)
+def add(dist_sums: NDArray[np.float64], store: DistanceStore, i_added: np.int32) -> None:
+    """Update distance sums of each item wrt selection after adding i_added."""
+    for j in range(i_added):
+        dist_sums[j] += np.float64(get_distance_condensed(store, i_added, j))
+    for j in range(i_added + 1, store.n):
+        dist_sums[j] += np.float64(get_distance_condensed(store, i_added, j))
+
+
+@numba.njit(UPDATE_SIGNATURE, cache=True)
+def remove(dist_sums: NDArray[np.float64], store: DistanceStore, i_removed: np.int32) -> None:
+    """Update distance sums of each item wrt selection after removing i_removed."""
+    for j in range(i_removed):
+        dist_sums[j] -= np.float64(get_distance_condensed(store, i_removed, j))
+    for j in range(i_removed + 1, store.n):
+        dist_sums[j] -= np.float64(get_distance_condensed(store, i_removed, j))

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_full_matrix.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_full_matrix.py
@@ -1,0 +1,53 @@
+"""Mean-distance calculations for a full-matrix store.
+
+One of three interchangeable modules — see this package's `__init__` for the pattern and why the backend is
+chosen once per tracker rather than tested inside these loops.  Each module defines the same
+three calculations over the same signatures, differing only in how a distance is read.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numba
+import numpy as np
+
+from max_div._core.metrics._distance import get_distance_full_matrix
+
+from .._signatures import ELEMENTS_SIGNATURE, UPDATE_SIGNATURE
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from max_div._core.metrics._distance import DistanceStore
+
+
+@numba.njit(ELEMENTS_SIGNATURE, cache=True)
+def elements(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
+    """Fill the given elements of `out` with each item's mean distance to all others."""
+    den = np.float64(max(store.n - 1, 1))
+    for idx in indices:
+        row_sum = np.float64(0.0)
+        for j in range(idx):
+            row_sum += np.float64(get_distance_full_matrix(store, idx, j))
+        for j in range(idx + 1, store.n):
+            row_sum += np.float64(get_distance_full_matrix(store, idx, j))
+        out[idx] = np.float32(row_sum / den)
+
+
+@numba.njit(UPDATE_SIGNATURE, cache=True)
+def add(dist_sums: NDArray[np.float64], store: DistanceStore, i_added: np.int32) -> None:
+    """Update distance sums of each item wrt selection after adding i_added."""
+    for j in range(i_added):
+        dist_sums[j] += np.float64(get_distance_full_matrix(store, i_added, j))
+    for j in range(i_added + 1, store.n):
+        dist_sums[j] += np.float64(get_distance_full_matrix(store, i_added, j))
+
+
+@numba.njit(UPDATE_SIGNATURE, cache=True)
+def remove(dist_sums: NDArray[np.float64], store: DistanceStore, i_removed: np.int32) -> None:
+    """Update distance sums of each item wrt selection after removing i_removed."""
+    for j in range(i_removed):
+        dist_sums[j] -= np.float64(get_distance_full_matrix(store, i_removed, j))
+    for j in range(i_removed + 1, store.n):
+        dist_sums[j] -= np.float64(get_distance_full_matrix(store, i_removed, j))

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_lazy.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_lazy.py
@@ -1,0 +1,53 @@
+"""Mean-distance calculations for a lazy store.
+
+One of three interchangeable modules — see this package's `__init__` for the pattern and why the backend is
+chosen once per tracker rather than tested inside these loops.  Each module defines the same
+three calculations over the same signatures, differing only in how a distance is read.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numba
+import numpy as np
+
+from max_div._core.metrics._distance import get_distance_lazy
+
+from .._signatures import ELEMENTS_SIGNATURE, UPDATE_SIGNATURE
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+    from max_div._core.metrics._distance import DistanceStore
+
+
+@numba.njit(ELEMENTS_SIGNATURE, cache=True)
+def elements(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
+    """Fill the given elements of `out` with each item's mean distance to all others."""
+    den = np.float64(max(store.n - 1, 1))
+    for idx in indices:
+        row_sum = np.float64(0.0)
+        for j in range(idx):
+            row_sum += np.float64(get_distance_lazy(store, idx, j))
+        for j in range(idx + 1, store.n):
+            row_sum += np.float64(get_distance_lazy(store, idx, j))
+        out[idx] = np.float32(row_sum / den)
+
+
+@numba.njit(UPDATE_SIGNATURE, cache=True)
+def add(dist_sums: NDArray[np.float64], store: DistanceStore, i_added: np.int32) -> None:
+    """Update distance sums of each item wrt selection after adding i_added."""
+    for j in range(i_added):
+        dist_sums[j] += np.float64(get_distance_lazy(store, i_added, j))
+    for j in range(i_added + 1, store.n):
+        dist_sums[j] += np.float64(get_distance_lazy(store, i_added, j))
+
+
+@numba.njit(UPDATE_SIGNATURE, cache=True)
+def remove(dist_sums: NDArray[np.float64], store: DistanceStore, i_removed: np.int32) -> None:
+    """Update distance sums of each item wrt selection after removing i_removed."""
+    for j in range(i_removed):
+        dist_sums[j] -= np.float64(get_distance_lazy(store, i_removed, j))
+    for j in range(i_removed + 1, store.n):
+        dist_sums[j] -= np.float64(get_distance_lazy(store, i_removed, j))

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_signatures.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_signatures.py
@@ -1,0 +1,15 @@
+"""The interface every mean-distance backend implements.
+
+Shared so the three backend modules are interchangeable by construction: a function that does
+not match cannot be registered, and a signature change lands in one place rather than nine.
+
+Sums accumulate in float64: entries undergo long add/subtract chains over solver iterations, and
+float32 drift there would change scores with iteration count.
+"""
+
+import numba
+
+from max_div._core.metrics._distance import DISTANCE_STORE_TYPE
+
+ELEMENTS_SIGNATURE = numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32[::1])
+UPDATE_SIGNATURE = numba.void(numba.float64[::1], DISTANCE_STORE_TYPE, numba.int32)

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_tracker.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_tracker.py
@@ -1,59 +1,18 @@
+"""The mean-distance tracker: contribution = mean distance to the selected items."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numba
 import numpy as np
 
-from max_div._core.metrics._distance import DISTANCE_STORE_TYPE, DistanceStore, get_distance
-
-from ._base import DiversityContributionTracker
+from .._base import DiversityContributionTracker
+from ._backends import backend_for
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-
-# =================================================================================================
-#  Distance sums
-# =================================================================================================
-# Per-point sums of distances to a selection — the pairwise-distance counterpart of the separation
-# kernels above.  Sums accumulate in float64: entries undergo long add/subtract chains over solver
-# iterations, and float32 drift there would change scores with iteration count.  Distances of a
-# point to itself are 0, so a point's own entry never needs special-casing: it always equals the
-# sum of its distances to the *other* selected points.
-@numba.njit(numba.void(numba.float32[::1], DISTANCE_STORE_TYPE, numba.int32[::1]), cache=True)
-def compute_mean_distance_elements(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
-    """Fill the given elements of `out` with each item's mean distance to all others.
-
-    Each element requires scanning that item's full row of the pairwise-distance matrix; elements
-    are independent, so any subset can be computed in any order.  Per element: a float64 sum over
-    partners in ascending index (so sums stay bit-equal across store layouts), one divide by
-    (n-1), one cast to float32.
-    """
-    n = store.n
-    den = np.float64(max(n - 1, 1))
-    for idx in indices:
-        row_sum = np.float64(0.0)
-        for j in np.arange(n, dtype=np.int32):
-            if j != idx:
-                row_sum += np.float64(get_distance(store, idx, j))
-        out[idx] = np.float32(row_sum / den)
-
-
-@numba.njit(numba.void(numba.float64[::1], DISTANCE_STORE_TYPE, numba.int32), cache=True)
-def update_distance_sums_add(dist_sums: NDArray[np.float64], store: DistanceStore, i_added: np.int32) -> None:
-    """Update distance sums of each item wrt selection, given the distance store, after adding i_added."""
-    for j in np.arange(store.n, dtype=np.int32):
-        if j != i_added:
-            dist_sums[j] += np.float64(get_distance(store, i_added, j))
-
-
-@numba.njit(numba.void(numba.float64[::1], DISTANCE_STORE_TYPE, numba.int32), cache=True)
-def update_distance_sums_remove(dist_sums: NDArray[np.float64], store: DistanceStore, i_removed: np.int32) -> None:
-    """Update distance sums of each item wrt selection, given the distance store, after removing i_removed."""
-    for j in np.arange(store.n, dtype=np.int32):
-        if j != i_removed:
-            dist_sums[j] -= np.float64(get_distance(store, i_removed, j))
+    from max_div._core.metrics._distance import DistanceStore
 
 
 # =================================================================================================
@@ -91,6 +50,10 @@ class MeanDistanceTracker(DiversityContributionTracker):
                           enables copies without recomputation.
         """
         self._store = store  # READ-ONLY
+        # the layout is a property of the store, so which calculations apply is settled here
+        # rather than tested inside them; see `_backends` for why that test cannot live in
+        # compiled code
+        self._backend = backend_for(store)
         if contribution_wrt_dataset is not None:
             self._contribution_wrt_dataset = contribution_wrt_dataset
         else:
@@ -140,7 +103,7 @@ class MeanDistanceTracker(DiversityContributionTracker):
         """Compute any not-yet-computed global-contribution elements among `indices`."""
         missing = indices[np.isnan(self._contribution_wrt_dataset[indices])]
         if missing.size > 0:
-            compute_mean_distance_elements(
+            self._backend.elements(
                 self._contribution_wrt_dataset, self._store, np.ascontiguousarray(missing, dtype=np.int32)
             )
 
@@ -149,14 +112,14 @@ class MeanDistanceTracker(DiversityContributionTracker):
     # -------------------------------------------------------------------------
     def add(self, index: np.int32) -> None:
         """Update distance sums after adding point `index` to the selection."""
-        update_distance_sums_add(self._dist_sums, self._store, index)
+        self._backend.add(self._dist_sums, self._store, index)
 
     def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
         """Update distance sums after removing point `index`.
 
         `new_selection` is not needed by this tracker: removal is exact subtraction.
         """
-        update_distance_sums_remove(self._dist_sums, self._store, index)
+        self._backend.remove(self._dist_sums, self._store, index)
 
     # -------------------------------------------------------------------------
     #  Snapshot

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -7,9 +7,7 @@ from max_div._core.metrics import DistanceMetric
 from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.solver._diversity_contribution import MeanDistanceTracker
 from max_div._core.solver._diversity_contribution._mean_distance import (
-    compute_mean_distance_elements,
-    update_distance_sums_add,
-    update_distance_sums_remove,
+    backend_for,
 )
 
 # =================================================================================================
@@ -225,7 +223,8 @@ def test_compute_mean_distance_elements_partial_fill():
     requested = np.array([0, 7, 29, 13], dtype=np.int32)
 
     # --- act ---------------------------------------------
-    compute_mean_distance_elements(out, DistanceStore.condensed(d, n=m), requested)
+    store = DistanceStore.condensed(d, n=m)
+    backend_for(store).elements(out, store, requested)
 
     # --- assert ------------------------------------------
     np.testing.assert_allclose(out[requested], expected[requested], rtol=1e-6)
@@ -252,12 +251,14 @@ def test_update_distance_sums_add_remove():
 
     # --- act / assert ------------------------------------
     for index in [3, 17, 0, 9, 12]:
-        update_distance_sums_add(dist_sums, DistanceStore.condensed(d, n=m), np.int32(index))
+        store = DistanceStore.condensed(d, n=m)
+        backend_for(store).add(dist_sums, store, np.int32(index))
         selection.append(index)
         np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
 
     for index in [0, 3, 12]:
-        update_distance_sums_remove(dist_sums, DistanceStore.condensed(d, n=m), np.int32(index))
+        store = DistanceStore.condensed(d, n=m)
+        backend_for(store).remove(dist_sums, store, np.int32(index))
         selection.remove(index)
         np.testing.assert_allclose(dist_sums, expected_sums(), rtol=1e-6)
 
@@ -272,12 +273,56 @@ def test_update_distance_sums_own_entry_untouched():
     dist_sums = np.zeros(m, dtype=np.float64)
 
     # selection {1}: point 1's own entry stays 0 (no other selected points yet)
-    update_distance_sums_add(dist_sums, DistanceStore.condensed(d, n=m), np.int32(1))
+    store = DistanceStore.condensed(d, n=m)
+    backend_for(store).add(dist_sums, store, np.int32(1))
     assert dist_sums[1] == 0.0
 
     # --- act ---------------------------------------------
     # selection {1, 2}: point 2's own entry must equal its distance to point 1 only
-    update_distance_sums_add(dist_sums, DistanceStore.condensed(d, n=m), np.int32(2))
+    backend_for(store).add(dist_sums, store, np.int32(2))
 
     # --- assert ------------------------------------------
     assert dist_sums[2] == pytest.approx(squareform(d)[2, 1])
+
+
+# =================================================================================================
+#  Backend equivalence
+# =================================================================================================
+# One backend module per storage layout means the same logic exists three times, so a fix applied
+# to two of them would pass review looking complete.  Driving every backend through the same
+# operations against a brute-force recompute is the guard against that.
+@pytest.mark.parametrize("backend", ["full_matrix", "condensed", "lazy"])
+def test_backend_matches_brute_force_over_random_operations(backend: str):
+    """Random add/remove sequences must match a brute-force recompute, on every layout."""
+
+    # --- arrange -----------------------------------------
+    rng = random.default_rng(20260805)
+    vectors = rng.random((N, 3)).astype(np.float32)
+    condensed = compute_pdist(vectors, DistanceMetric.L2_EUCLIDEAN)
+    store = {
+        "full_matrix": DistanceStore.full_matrix_from_vectors(vectors, DistanceMetric.L2_EUCLIDEAN),
+        "condensed": DistanceStore.condensed(condensed, n=N),
+        "lazy": DistanceStore.lazy(vectors, DistanceMetric.L2_EUCLIDEAN),
+    }[backend]
+    tracker = MeanDistanceTracker(store)
+    selection: list[int] = []
+
+    # --- act / assert ------------------------------------
+    for _ in range(120):
+        must_remove = len(selection) == N  # nothing left to add once everything is selected
+        if selection and (must_remove or rng.random() < 0.4):
+            index = int(rng.choice(selection))
+            selection.remove(index)
+            tracker.remove(np.int32(index), new_selection=np.array(selection, dtype=np.int32))
+        else:
+            index = int(rng.choice([i for i in range(N) if i not in selection]))
+            tracker.add(np.int32(index))
+            selection.append(index)
+
+        selected, n_selected = _selection_args(selection)
+        np.testing.assert_allclose(
+            tracker.contribution_wrt_selection(selected, n_selected),
+            _brute_force_contribution(condensed, selection),
+            rtol=1e-5,
+            err_msg=f"{backend} diverged",
+        )


### PR DESCRIPTION
**TL;DR**: The distance-sum calculations get the same per-layout treatment the separation family just received, so both trackers read distances through loops that vectorize.

## Description

### Problem addressed

The mean-distance tracker read every distance through the generic `get_distance`, and so carried the same two tests that keep such a loop from vectorizing — one comparing `i` against `j`, one selecting the storage layout.

Leaving this family behind would have made per-layout cost depend on **which objective a problem uses**: identical work, differing by up to an order of magnitude according to whether a solve tracks separations or distance sums. That irregularity is what the accompanying separation change set out to remove.

### Implementation

**The same shape, applied to the three distance-sum calculations.** Each covers a range that excludes its own index rather than testing for it, which lets it read through the distinct-items readers, and each layout gets its own module in a `_backends/` package implementing signatures shared at the package level. A `MeanDistanceBackend` lookup keyed by store kind selects one, in Python, once per tracker.

**Accumulation order is unchanged.** The sums are float64 precisely because they undergo long add/subtract chains across solver iterations, and they are summed over partners in ascending index so they stay bit-equal across layouts. Splitting a range into the part below the index and the part above preserves that order exactly.

## Attention points

- **Nothing new is introduced here** — the readers, the package shape, and the lookup all arrive with the separation change; this applies them to the second family.
- **Simpler than the separation family**, which is worth knowing when comparing the two: this tracker removes by exact subtraction, so it has no rescan and no helper — three calculations per layout and nothing else.
- **The self-pair skip was already redundant arithmetically** (a point's self-distance is zero, so adding it would change nothing), but it stays skipped, so behavior is unchanged rather than merely equivalent.

## Tests / Spikes

- **TEST:** full suite green, including the golden master and cross-backend suites **unregenerated** — this changes which code runs, not what is computed.
- **Adds backend-equivalence tests**, matching the separation family: every layout driven through random add/remove sequences against a brute-force recompute.

## Changelog entry

None: covered by the entry the separation change adds, which is refined at release to describe the version as a whole.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
