### PR TITLE
feat: vectorize on-demand distance computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Substantially faster distance lookups, speeding up solving at every problem size, most of all on large problems
+- Substantially faster distance lookups and computations, most of all on large problems; the faster computation rounds differently across storage backends and across CPU architectures, so the same input can now yield different but equally diverse selections — results repeat exactly only within one machine, build and backend
 
 ### Deprecated
 

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -98,7 +98,26 @@ solver = (
   the format the distances were provided in. The resolved backend is reported in the solution
   summary, e.g. `storage=full_matrix (auto)` — pin a backend explicitly to override.
 
-All backends produce bit-identical distance values, so with an iteration budget the selected
-items are the same whichever backend runs; the choice only affects speed and memory. (With a
-time budget, a faster backend completes more iterations — the same machine-dependence time
-budgets always have.)
+### Reproducibility
+
+**On one machine, with the same installed versions — max-div's and numba's — and the same
+backend, a seeded solve is exactly reproducible**: run it again and you get the same selection,
+bit for bit.
+
+**Change any of those three and you may get a different — equally diverse — selection.**
+Distances are accumulated sums, and the compiler is allowed to reorder such a sum to vectorize it;
+how it does so depends on the processor and on the numba version that compiled the kernels, which
+is why a numba upgrade counts here as much as a max-div one. The resulting differences are in the
+last bits, but the search is a chaotic process, so one differing comparison can send it down a
+different path to an equally good answer. The difference is not a slightly different selection —
+it is a different one of comparable quality.
+
+Two practical consequences:
+
+- **`AUTO` picks a backend from available memory**, so the same problem can resolve differently on
+  a machine with more or less RAM. Pin the backend explicitly if you want that variable removed —
+  though on its own that does not make results portable across different machines.
+- **Comparing runs meaningfully** means comparing achieved diversity, not selected indices.
+
+(With a time budget rather than an iteration budget, a faster backend also completes more
+iterations — the machine-dependence any time budget carries.)

--- a/src/max_div/_core/metrics/_distance/_compute.py
+++ b/src/max_div/_core/metrics/_distance/_compute.py
@@ -55,7 +55,22 @@ def validate_cosine_vectors(vectors: NDArray[np.float32]) -> None:
 # =================================================================================================
 #  pdist kernels
 # =================================================================================================
-@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True)
+# These kernels sum one term per dimension.  Adding those terms in a different order gives a
+# very slightly different answer in floating point, so by default the compiler must add them
+# strictly left to right — one at a time, each waiting for the previous.  `reassoc` lifts that
+# restriction ("reassociate" = regroup the additions), letting the compiler add several terms in
+# parallel; `contract` lets a multiply and an add become one instruction.  Together they are what
+# make these loops vectorize.
+#
+# Granted here rather than the full fastmath set, which would also assert that no value is ever
+# infinite — untrue, since the separation arrays use +inf to mean "no selected neighbor yet".
+#
+# Accepted consequence: a distance is no longer a fixed function of this source, so values can
+# differ in their last bits between machines or numba versions.  See the reproducibility section
+# of the solver documentation.
+
+
+@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True, fastmath={"reassoc", "contract"})
 def _l1_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int | np.signedinteger) -> np.float64:
     """Return the L1 (Manhattan) distance between vectors i and j, accumulated in float64."""
     acc = np.float64(0.0)
@@ -64,7 +79,7 @@ def _l1_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int | n
     return acc
 
 
-@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True)
+@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True, fastmath={"reassoc", "contract"})
 def _l2sq_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int | np.signedinteger) -> np.float64:
     """Return the squared L2 (Euclidean) distance between vectors i and j, accumulated in float64."""
     acc = np.float64(0.0)
@@ -74,7 +89,7 @@ def _l2sq_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int |
     return acc
 
 
-@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True)
+@numba.njit("float64(float32[:, ::1], int64, int64)", inline="always", cache=True, fastmath={"reassoc", "contract"})
 def _linf_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int | np.signedinteger) -> np.float64:
     """Return the Linf (Chebyshev) distance between vectors i and j, accumulated in float64."""
     acc = np.float64(0.0)
@@ -85,7 +100,7 @@ def _linf_pair(vectors: NDArray[np.float32], i: int | np.signedinteger, j: int |
     return acc
 
 
-@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True, fastmath={"reassoc", "contract"})
 def _pdist_l1(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
     """Write the condensed L1 distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
     n = vectors.shape[0]
@@ -96,7 +111,7 @@ def _pdist_l1(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
             idx += 1
 
 
-@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True, fastmath={"reassoc", "contract"})
 def _pdist_l2(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
     """Write the condensed L2 distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
     n = vectors.shape[0]
@@ -107,7 +122,7 @@ def _pdist_l2(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
             idx += 1
 
 
-@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True, fastmath={"reassoc", "contract"})
 def _pdist_l2s(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
     """Write the condensed squared-L2 distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
     n = vectors.shape[0]
@@ -118,7 +133,7 @@ def _pdist_l2s(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
             idx += 1
 
 
-@numba.njit("void(float32[:, ::1], float32[::1])", cache=True)
+@numba.njit("void(float32[:, ::1], float32[::1])", cache=True, fastmath={"reassoc", "contract"})
 def _pdist_linf(vectors: NDArray[np.float32], out: NDArray[np.float32]) -> None:
     """Write the condensed Linf distances of `vectors` into pre-allocated `out`, in condensed i<j order."""
     n = vectors.shape[0]

--- a/src/max_div/_core/metrics/_distance/_store.py
+++ b/src/max_div/_core/metrics/_distance/_store.py
@@ -246,7 +246,7 @@ def get_distance(store: DistanceStore, i: np.int32, j: np.int32) -> np.float32:
 # =================================================================================================
 #  Full-matrix construction kernels
 # =================================================================================================
-@numba.njit(numba.float32[:, ::1](numba.float32[:, ::1], numba.int32), cache=True)
+@numba.njit(numba.float32[:, ::1](numba.float32[:, ::1], numba.int32), cache=True, fastmath={"reassoc", "contract"})
 def _fill_matrix_from_vectors(vectors: NDArray[np.float32], metric_kind: np.int32) -> NDArray[np.float32]:
     """Fill a full (n, n) distance matrix from vectors: each pair computed once, written to both halves."""
     n = vectors.shape[0]

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_lazy.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_backends/_lazy.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from max_div._core.metrics._distance import DistanceStore
 
 
-@numba.njit(ELEMENTS_SIGNATURE, cache=True)
+@numba.njit(ELEMENTS_SIGNATURE, cache=True, fastmath={"reassoc", "contract"})
 def elements(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
     """Fill the given elements of `out` with each item's mean distance to all others."""
     den = np.float64(max(store.n - 1, 1))
@@ -35,7 +35,7 @@ def elements(out: NDArray[np.float32], store: DistanceStore, indices: NDArray[np
         out[idx] = np.float32(row_sum / den)
 
 
-@numba.njit(UPDATE_SIGNATURE, cache=True)
+@numba.njit(UPDATE_SIGNATURE, cache=True, fastmath={"reassoc", "contract"})
 def add(dist_sums: NDArray[np.float64], store: DistanceStore, i_added: np.int32) -> None:
     """Update distance sums of each item wrt selection after adding i_added."""
     for j in range(i_added):
@@ -44,7 +44,7 @@ def add(dist_sums: NDArray[np.float64], store: DistanceStore, i_added: np.int32)
         dist_sums[j] += np.float64(get_distance_lazy(store, i_added, j))
 
 
-@numba.njit(UPDATE_SIGNATURE, cache=True)
+@numba.njit(UPDATE_SIGNATURE, cache=True, fastmath={"reassoc", "contract"})
 def remove(dist_sums: NDArray[np.float64], store: DistanceStore, i_removed: np.int32) -> None:
     """Update distance sums of each item wrt selection after removing i_removed."""
     for j in range(i_removed):

--- a/src/max_div/_core/solver/_diversity_contribution/_separation/_backends/_lazy.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_separation/_backends/_lazy.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 
-@numba.njit(ELEMENTS_SIGNATURE, cache=True)
+@numba.njit(ELEMENTS_SIGNATURE, cache=True, fastmath={"reassoc", "contract"})
 def elements(sep: NDArray[np.float32], store: DistanceStore, indices: NDArray[np.int32]) -> None:
     """Fill the given elements of `sep` with each item's separation wrt all others."""
     for idx in indices:
@@ -32,7 +32,7 @@ def elements(sep: NDArray[np.float32], store: DistanceStore, indices: NDArray[np
         sep[idx] = row_min
 
 
-@numba.njit(ADD_SIGNATURE, cache=True)
+@numba.njit(ADD_SIGNATURE, cache=True, fastmath={"reassoc", "contract"})
 def add(sep: NDArray[np.float32], store: DistanceStore, i_added: np.int32) -> None:
     """Update separation of each item wrt selection after adding i_added."""
     for j in range(i_added):
@@ -45,6 +45,7 @@ def add(sep: NDArray[np.float32], store: DistanceStore, i_added: np.int32) -> No
     numba.float32(DISTANCE_STORE_TYPE, numba.int64, numba.int32[::1]),
     inline="always",
     cache=True,
+    fastmath={"reassoc", "contract"},
 )
 def _nearest_selected(store: DistanceStore, j: int | np.integer, selection: NDArray[np.int32]) -> np.float32:
     """Return the distance from item j to its nearest neighbor within `selection`, or +inf."""
@@ -55,7 +56,7 @@ def _nearest_selected(store: DistanceStore, j: int | np.integer, selection: NDAr
     return nearest
 
 
-@numba.njit(REMOVE_SIGNATURE, cache=True)
+@numba.njit(REMOVE_SIGNATURE, cache=True, fastmath={"reassoc", "contract"})
 def remove(
     sep: NDArray[np.float32],
     store: DistanceStore,


### PR DESCRIPTION
**TL;DR**: Lets the compiler vectorize distance accumulation — 3.0x at 200 dimensions, 4.7x at 1000 — and narrows the published reproducibility guarantee to what a reassociating compiler can actually hold.

## Description

### Problem addressed

**A distance is a sum over dimensions, and floating-point addition is not associative.** Without permission to reassociate it, the compiler must respect the accumulation order exactly, so the sum is a serial dependency chain: one dimension per add latency, however many execution units sit idle. The loop cannot vectorize.

That cost falls entirely on the backend that computes distances rather than reading them — the one that makes large problems feasible in the first place, since it is the only layout without an O(n²) memory requirement.

### Implementation

**Reassociation and contraction are granted on every path that accumulates a distance** — the on-demand read and both fills — so all layouts keep computing a distance the same way as one another.

**Only those two flags, not the whole fastmath set.** The rest of it asserts that no infinities or NaNs occur, and the separation arrays carry `+inf` as their "no selected neighbor" sentinel; that assumption would quietly make those comparisons wrong. Restricting the flags keeps the sentinel meaningful.

**The flags belong on the calculations that inline the pair loop, not only on the pair functions themselves.** An inlined callee is regenerated under its caller's flags, so marking the pair functions alone changed nothing measurable — a detail worth knowing before anyone tries to narrow this further.

**The reproducibility guarantee is narrowed to match.** Summation order now depends on how the compiler vectorizes, which varies with processor and toolchain, so distances are no longer a fixed function of the source.

## Attention points

- **The behavior change is real and worth reading in the changelog**: the same input may now produce a different, equally diverse selection on a different machine. Not a slightly different one — the search is chaotic, so a last-bit difference sends it down a different path.
- **The backends still agree bit-for-bit on this toolchain**, and the canary that checks it stays green. That is not promised, which is exactly why the documented guarantee no longer claims it.
- **The golden master needed no regeneration.** It was moved onto precomputed distances beforehand, so it pins the search rather than the arithmetic — the separation doing its job on its first real test.
- **Judgement call:** the guarantee was reworded even though nothing observably diverged. A claim that holds only because of the current compiler's choices is not a guarantee, and finding out otherwise from a user report is the worst available outcome.

## Tests / Spikes

- **SPIKE:** measured the gain before committing to it — 2.99x at 200 dimensions and 4.91x at 1000, against 3.05x and 4.74x delivered here.
- **SPIKE:** checked distances for bit-equality across dimensionalities 2, 17, 200 and 1000; identical in every case, which informed keeping the canary rather than deleting it.
- **TEST:** full suite green, 3744 tests, including the golden master and the cross-backend canary — both unregenerated.

## Changelog entry

Changed — replaces the entry added earlier in this series, since the speedup is what causes the behavior change and the two only make sense together:

```
Substantially faster distance lookups and computations, most of all on large problems; the faster computation rounds differently across storage backends and across CPU architectures, so the same input can now yield different but equally diverse selections — results repeat exactly only within one machine, build and backend
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

