### PR TITLE
chore: batch dependabot majors separately and lengthen the cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,11 +36,12 @@ updates:
       actions-major:  # majors batch separately and wait for review
         patterns: ["*"]
         update-types: ["major"]
-    # Let releases age before PRs open: auto-merged patch/minor bumps then sit
-    # long enough for upstream compromises to surface before they can land.
-    # (semver-specific cooldowns are not supported for github-actions.)
+    # Matches the 14 days the uv entry uses, for consistency rather than for the same reason:
+    # PyPI's file-addition window has no counterpart here, since action bumps resolve to a commit
+    # SHA. What the wait buys is the weaker but still useful property that a compromised or broken
+    # release has time to surface upstream before a bump can auto-merge.
     cooldown:
-      default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
+      default-days: 14  # covers every semver level; no per-level override needed
 
   - package-ecosystem: "uv"
     # Refreshes uv.lock for the runtime + dev/lint/type tooling the lockfile
@@ -68,6 +69,10 @@ updates:
       python-major:  # majors batch separately and wait for review
         patterns: ["*"]
         update-types: ["major"]
+    # 14 days, chosen to match PyPI's own window rather than as a general soak: a PyPI release
+    # rejects new files once it is 14 days old, a rule aimed squarely at poisoning an existing
+    # release with compromised publishing credentials. Resolving only past that point means the
+    # file set installed is the one the release is stuck with — a shorter wait leaves the loophole
+    # of picking up a file added days after the release looked settled.
     cooldown:
-      default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
-      semver-major-days: 14
+      default-days: 14  # covers every semver level; no per-level override needed

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,16 @@ updates:
     # title check needs no Dependabot exemption.
     commit-message:
       prefix: "chore"
+    # Split by update type rather than one batch for everything: auto-merge is decided per PR
+    # from its update type, and a batch containing a single major resolves to major — so one
+    # major bump parks every minor and patch alongside it until a human gets to them.
     groups:
-      actions:  # one batched PR for all action bumps
+      actions:  # minor/patch batch: auto-merges once checks pass
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      actions-major:  # majors batch separately and wait for review
+        patterns: ["*"]
+        update-types: ["major"]
     # Let releases age before PRs open: auto-merged patch/minor bumps then sit
     # long enough for upstream compromises to surface before they can land.
     # (semver-specific cooldowns are not supported for github-actions.)
@@ -51,9 +58,16 @@ updates:
     # a deliberate compatibility contract (earliest release shipping a wheel),
     # not something to ratchet up to the latest version.
     versioning-strategy: lockfile-only
+    # Split by update type, as on the github-actions entry above and for the same reason. Here
+    # it also lets the longer major cooldown below do its job: a mixed batch would hold the
+    # minor and patch bumps back for the major's cooldown too.
     groups:
-      python:  # one batched PR for all Python-dependency bumps
+      python:  # minor/patch batch: auto-merges once checks pass
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+      python-major:  # majors batch separately and wait for review
+        patterns: ["*"]
+        update-types: ["major"]
     cooldown:
       default-days: 7  # zizmor's dependabot-cooldown floor; ~no-op at weekly cadence anyway
       semver-major-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,5 +74,9 @@ updates:
     # release with compromised publishing credentials. Resolving only past that point means the
     # file set installed is the one the release is stuck with — a shorter wait leaves the loophole
     # of picking up a file added days after the release looked settled.
+    #   https://blog.pypi.org/posts/2026-07-22-releases-now-reject-new-files-after-14-days/
+    # That announcement is the reference because there is no other: the rule has no page under
+    # docs.pypi.org, its formal semantics being left to PEP 694. Re-check it before changing this
+    # number, since the two are meant to stay equal.
     cooldown:
       default-days: 14  # covers every semver level; no per-level override needed


### PR DESCRIPTION
**Problem**: Two unrelated weaknesses in the update configuration — one major bump blocked the auto-merge of every minor and patch batched with it, and the 7-day cooldown was short enough to still resolve a file added to a release after it looked settled.

**Solution**: Group majors separately from minor/patch on both ecosystems, so routine bumps auto-merge on their own; and raise the cooldown to 14 days, matching the window PyPI itself enforces.

- **Why 14 specifically:** PyPI rejects new files on a release once it is 14 days old, a rule aimed at poisoning an existing release with compromised publishing credentials. Waiting out that window means the file set installed is the one the release is stuck with; a 7-day cooldown left the loophole open. The config cites [the announcement](https://blog.pypi.org/posts/2026-07-22-releases-now-reject-new-files-after-14-days/), which is the only reference — the rule has no docs.pypi.org page, its formal semantics being left to PEP 694.
- **Attention:** cooldown never delays security updates — GitHub applies it to version updates only — so the longer wait costs latency on routine bumps and nothing on vulnerability fixes.
- **Attention:** the actions entry gets 14 days for consistency, not for the same reason. Action bumps resolve to a commit SHA, so PyPI's window has no counterpart; what the wait buys there is the weaker property that a bad release has time to surface.
- **Attention:** existing open update PRs are unaffected — both settings apply when Dependabot next opens one.
- **Attention:** a comment claiming semver-specific cooldowns are unsupported for GitHub Actions was stale (the current documentation lists them as supported). It is gone rather than corrected, since `default-days` now covers every level and the per-level major override on the Python entry became redundant.

**Changelog** (none): repository automation, no user-facing behavior.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
