### PR TITLE
chore: stop dependabot bumping benchmark and unresolvable dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,26 @@ updates:
     # a deliberate compatibility contract (earliest release shipping a wheel),
     # not something to ratchet up to the latest version.
     versioning-strategy: lockfile-only
+    ignore:
+      # Comparison-harness dependencies. They move when benchmarks are regenerated, not weekly —
+      # ignored here, not frozen: a campaign still upgrades them by hand. Several also cap what
+      # the rest of the lockfile can reach, so a weekly bump attempt fails the whole run.
+      - dependency-name: "matplotlib"
+      - dependency-name: "fpsample"
+      - dependency-name: "skmatter"
+      - dependency-name: "rdkit"
+      - dependency-name: "apricot-select"
+      - dependency-name: "kmedoids"
+      - dependency-name: "networkx"
+      - dependency-name: "scikit-learn"
+      - dependency-name: "ortools"
+      - dependency-name: "pyscipopt"
+      - dependency-name: "qc-selector"
+      # numpy 2.5 dropped Python 3.11, which this package still supports, so every release from
+      # 2.5 on is unresolvable here. Patches to 2.4.x still come through. Delete this entry when
+      # the 3.11 floor goes.
+      - dependency-name: "numpy"
+        versions: [">=2.5"]
     # Split by update type, as on the github-actions entry above and for the same reason. Here
     # it also lets the longer major cooldown below do its job: a mixed batch would hold the
     # minor and patch bumps back for the major's cooldown too.


### PR DESCRIPTION
**Problem**: The weekly lockfile refresh fails outright. A resolution failure is all-or-nothing — Dependabot bumps to the newest release past the cooldown, and if that cannot resolve it crashes rather than falling back — so one unreachable package takes the whole run with it.

**Solution**: Ignore the packages that cannot be bumped automatically. Two groups, for two different reasons.

- **The comparison harness's dependencies** (11 of them, including the GPL-only one) are ignored outright. They belong to a benchmark suite that is never part of the published package, and they move when benchmark results are regenerated rather than weekly. Several of them also cap what the rest of the lockfile can reach: `skmatter` requires `scikit-learn>=1.8,<1.9`, so every attempt at 1.9 fails.
- **numpy** is ignored from 2.5 upward only. numpy 2.5 dropped Python 3.11, which this package still supports, making every release from there unresolvable. Patches to 2.4.x still come through, and the entry is deletable the moment the 3.11 floor moves.

- **Attention:** ignored is not frozen. Nothing stops a benchmarking campaign upgrading these by hand; the entry only says the weekly job should leave them alone.
- **Attention:** a bare `ignore` also suppresses security update PRs for those packages. Accepted here — the audit gate exports with `--no-dev`, so benchmark dependencies were already outside its scope, and none of them ship to users.
- **Attention:** the numpy entry is version-scoped rather than a bare ignore precisely so that this does *not* apply to it; 2.4.x security patches are unaffected.

**Changelog** (none): repository automation, no user-facing behavior.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
