### PR TITLE
refactor: pin the argument types of the Python-dispatched kernels

### DIFF
--- a/src/max_div/_core/_cli/bm_internal/modify_p_selectivity.py
+++ b/src/max_div/_core/_cli/bm_internal/modify_p_selectivity.py
@@ -10,7 +10,11 @@ from max_div._core._markdown import (
     TableTimeElapsed,
     h2,
 )
-from max_div._core._math.modify_p_selectivity import exponential_selectivity, modify_p_selectivity
+from max_div._core._math.modify_p_selectivity import (
+    DEFAULT_LOW_VALUE,
+    exponential_selectivity,
+    modify_p_selectivity,
+)
 from max_div._core._utils import benchmark, stdout_to_file
 
 MODIFY_P_METHODS = [np.int32(0), np.int32(10), np.int32(20), np.int32(100)]
@@ -87,7 +91,7 @@ def benchmark_modify_p_selectivity(speed: float = 0.0, markdown: bool = False, f
 
         # test order_based_selectivity
         def benchmark_fun(_idx: int) -> None:
-            exponential_selectivity(p_in, p_out, random_modifiers[_idx])
+            exponential_selectivity(p_in, p_out, random_modifiers[_idx], False, DEFAULT_LOW_VALUE)
 
         # run benchmark
         table_row.append(

--- a/src/max_div/_core/_math/modify_p_selectivity/__init__.py
+++ b/src/max_div/_core/_math/modify_p_selectivity/__init__.py
@@ -1,2 +1,2 @@
-from ._exponential import exponential_selectivity
+from ._exponential import DEFAULT_LOW_VALUE, exponential_selectivity
 from ._main import modify_p_selectivity

--- a/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
+++ b/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
@@ -4,62 +4,14 @@ from numpy.typing import NDArray
 
 from max_div._core._math.fast_log_exp import fast_exp2_f32
 
-
-@njit(inline="always", cache=True)
-def exponential_selectivity(
-    p_in: NDArray[np.float32],
-    p_out: NDArray[np.float32],
-    modifier: np.float32,
-    reverse: bool = False,
-    low_value: np.float32 = np.float32(0.1),  # noqa: B008 — numba needs a concrete typed default
-) -> None:
-    """Populate p_out with values depending exponentially on the non-normalized probabilities in p_in.
-
-    p_in is a float32-array of shape (n,) containing non-normalized probabilities in range [p_min, p_max].
-    p_out is populated with values exponentially depending on the corresponding p_in values, such that p_out values
-    are in range [1.0, low_value**t], where t is computed as in the other modification methods:
-
-            t = (1.0 + modifier) / (1.0 - modifier)
-
-    This then boils down to the following formulas:
-
-     - descending=False (default)    p_out[i] = low_value ** (t * (p_max - p_in[i]) / (p_max - p_min))
-     - descending=True               p_out[i] = low_value ** (t * (p_max - p_in[i]) / (p_max - p_min))
-
-    The approximate function fast_exp2(exponent * np.log2(base)) is used to compute the exponentiation efficiently,
-      taking into account that np.log2(low_value) can be precomputed outside the loop.
-
-    :param p_in: np.ndarray of shape (n,) containing the original probabilities.
-    :param p_out: np.ndarray of shape (n,) to be populated with the transformed probabilities.
-    :param modifier: float32 in (-1, 1) indicating how to modify selectivity
-    :param reverse: (bool, default False) if True, higher p_in values result in lower p_out values
-    :param low_value: (float, default 0.1) the lowest value in p_out
-    """
-    # --- init ----------------------------------
-    n = p_in.shape[0]
-    p_min = np.float32(np.inf)
-    p_max = np.float32(-np.inf)
-    for i in range(n):
-        pi = p_in[i]
-        p_min = min(p_min, pi)
-        p_max = max(p_max, pi)
-    p_range = p_max - p_min
-
-    # --- corner case ---------------------------
-    # Degenerate ranges fall back to uniform: all-equal inputs (p_range == 0) and
-    # non-finite inputs (e.g. the +inf contribution of a sole selected item, which
-    # makes p_range inf or nan) — the transform would emit NaNs for those.
-    # NOTE: this guard is why the function is not compiled with fastmath: fastmath
-    # lets LLVM assume no NaN/inf exists and optimize the isfinite check away.
-    if (p_range == 0.0) or (not np.isfinite(p_range)):
-        for i in range(n):
-            p_out[i] = np.float32(1.0)
-        return
-
-    # --- actual transformation -----------------
-    _exponential_transform(p_in, p_out, modifier, reverse, low_value, p_min, p_max, p_range)
+# The floor of the transformed range that the solver's sampling paths use.  It lives here rather
+# than as a parameter default because an eager signature declares an exact arity, so a call that
+# omits an argument has no matching definition; callers that want another floor still pass one.
+DEFAULT_LOW_VALUE = np.float32(0.1)
 
 
+# Defined ahead of its caller: the caller declares a signature, so it compiles when the
+# decorator runs and every function it calls has to exist by then.
 @njit(fastmath=True, inline="always", cache=True)
 def _exponential_transform(
     p_in: NDArray[np.float32],
@@ -89,3 +41,58 @@ def _exponential_transform(
         for i in range(n):
             exponent = (p_max - p_in[i]) * p_range_inv
             p_out[i] = fast_exp2_f32(exponent * t_times_log2_low_value)
+
+
+@njit("void(float32[::1], float32[::1], float32, boolean, float32)", inline="always", cache=True)
+def exponential_selectivity(
+    p_in: NDArray[np.float32],
+    p_out: NDArray[np.float32],
+    modifier: np.float32,
+    reverse: bool,
+    low_value: np.float32,
+) -> None:
+    """Populate p_out with values depending exponentially on the non-normalized probabilities in p_in.
+
+    p_in is a float32-array of shape (n,) containing non-normalized probabilities in range [p_min, p_max].
+    p_out is populated with values exponentially depending on the corresponding p_in values, such that p_out values
+    are in range [1.0, low_value**t], where t is computed as in the other modification methods:
+
+            t = (1.0 + modifier) / (1.0 - modifier)
+
+    This then boils down to the following formulas:
+
+     - descending=False (default)    p_out[i] = low_value ** (t * (p_max - p_in[i]) / (p_max - p_min))
+     - descending=True               p_out[i] = low_value ** (t * (p_max - p_in[i]) / (p_max - p_min))
+
+    The approximate function fast_exp2(exponent * np.log2(base)) is used to compute the exponentiation efficiently,
+      taking into account that np.log2(low_value) can be precomputed outside the loop.
+
+    :param p_in: np.ndarray of shape (n,) containing the original probabilities.
+    :param p_out: np.ndarray of shape (n,) to be populated with the transformed probabilities.
+    :param modifier: float32 in (-1, 1) indicating how to modify selectivity
+    :param reverse: (bool) if True, higher p_in values result in lower p_out values
+    :param low_value: (float32) the lowest value in p_out
+    """
+    # --- init ----------------------------------
+    n = p_in.shape[0]
+    p_min = np.float32(np.inf)
+    p_max = np.float32(-np.inf)
+    for i in range(n):
+        pi = p_in[i]
+        p_min = min(p_min, pi)
+        p_max = max(p_max, pi)
+    p_range = p_max - p_min
+
+    # --- corner case ---------------------------
+    # Degenerate ranges fall back to uniform: all-equal inputs (p_range == 0) and
+    # non-finite inputs (e.g. the +inf contribution of a sole selected item, which
+    # makes p_range inf or nan) — the transform would emit NaNs for those.
+    # NOTE: this guard is why the function is not compiled with fastmath: fastmath
+    # lets LLVM assume no NaN/inf exists and optimize the isfinite check away.
+    if (p_range == 0.0) or (not np.isfinite(p_range)):
+        for i in range(n):
+            p_out[i] = np.float32(1.0)
+        return
+
+    # --- actual transformation -----------------
+    _exponential_transform(p_in, p_out, modifier, reverse, low_value, p_min, p_max, p_range)

--- a/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
+++ b/src/max_div/_core/_math/modify_p_selectivity/_exponential.py
@@ -55,14 +55,14 @@ def exponential_selectivity(
 
     p_in is a float32-array of shape (n,) containing non-normalized probabilities in range [p_min, p_max].
     p_out is populated with values exponentially depending on the corresponding p_in values, such that p_out values
-    are in range [1.0, low_value**t], where t is computed as in the other modification methods:
+    all lie in the interval [low_value**t, 1.0], where t is computed as in the other modification methods:
 
             t = (1.0 + modifier) / (1.0 - modifier)
 
     This then boils down to the following formulas:
 
-     - descending=False (default)    p_out[i] = low_value ** (t * (p_max - p_in[i]) / (p_max - p_min))
-     - descending=True               p_out[i] = low_value ** (t * (p_max - p_in[i]) / (p_max - p_min))
+     - reverse=False    p_out[i] = low_value ** (t * (p_max - p_in[i]) / (p_max - p_min))
+     - reverse=True     p_out[i] = low_value ** (t * (p_in[i] - p_min) / (p_max - p_min))
 
     The approximate function fast_exp2(exponent * np.log2(base)) is used to compute the exponentiation efficiently,
       taking into account that np.log2(low_value) can be precomputed outside the loop.
@@ -71,7 +71,7 @@ def exponential_selectivity(
     :param p_out: np.ndarray of shape (n,) to be populated with the transformed probabilities.
     :param modifier: float32 in (-1, 1) indicating how to modify selectivity
     :param reverse: (bool) if True, higher p_in values result in lower p_out values
-    :param low_value: (float32) the lowest value in p_out
+    :param low_value: (float32) base of the exponential
     """
     # --- init ----------------------------------
     n = p_in.shape[0]

--- a/src/max_div/_core/_random/_distributions/_modified_power.py
+++ b/src/max_div/_core/_random/_distributions/_modified_power.py
@@ -28,26 +28,8 @@ from numpy.typing import NDArray
 from max_div._core._random._rng import rand_float32
 
 
-@njit(fastmath=True, inline="always", cache=True)
-def sample_modified_power_distribution(m: np.float32, rng_state: NDArray[np.uint64]) -> np.float32:
-    if m == 0.0:
-        return np.float32(0.0)
-    if m == 1.0:
-        return np.float32(1.0)
-    # we need to sample a uniform value u in [0, 1]
-    u = rand_float32(rng_state)
-
-    # now transform u to the desired distribution
-    if m == 0.5:
-        # uniform distribution, no transformation
-        return u
-    if m < 0.5:
-        return _modified_power_transform(u, m)
-    # NOTE: in principle we need to also use 1-u instead of u, but both are random uniform in [0,1],
-    #       so it's equivalent.
-    return np.float32(1.0) - _modified_power_transform(u, np.float32(1.0) - m)
-
-
+# Defined ahead of its caller: the caller declares a signature, so it compiles when the decorator
+# runs and every function it calls has to exist by then.
 @njit(fastmath=True, inline="always", cache=True)
 def _modified_power_transform(u: np.float32, m: np.float32) -> np.float32:
     """Transform a uniform value u in [0,1] to the modified power distribution with median m in (0,0.5).
@@ -66,3 +48,23 @@ def _modified_power_transform(u: np.float32, m: np.float32) -> np.float32:
     one_minus_m = np.float32(1.0) - m
     p = -np.log2(m / one_minus_m) + np.float32(1.0)
     return (m * u) + one_minus_m * (u**p)
+
+
+@njit("float32(float32, uint64[:])", fastmath=True, inline="always", cache=True)
+def sample_modified_power_distribution(m: np.float32, rng_state: NDArray[np.uint64]) -> np.float32:
+    if m == 0.0:
+        return np.float32(0.0)
+    if m == 1.0:
+        return np.float32(1.0)
+    # we need to sample a uniform value u in [0, 1]
+    u = rand_float32(rng_state)
+
+    # now transform u to the desired distribution
+    if m == 0.5:
+        # uniform distribution, no transformation
+        return u
+    if m < 0.5:
+        return _modified_power_transform(u, m)
+    # NOTE: in principle we need to also use 1-u instead of u, but both are random uniform in [0,1],
+    #       so it's equivalent.
+    return np.float32(1.0) - _modified_power_transform(u, np.float32(1.0) - m)

--- a/src/max_div/_core/_random/_distributions/_truncated_poisson.py
+++ b/src/max_div/_core/_random/_distributions/_truncated_poisson.py
@@ -5,7 +5,7 @@ from numpy.typing import NDArray
 from max_div._core._random import randint1
 
 
-@njit(fastmath=True, inline="always", cache=True)
+@njit("int32(int32, int32, float32, uint64[:])", fastmath=True, inline="always", cache=True)
 def sample_truncated_poisson(
     min_value: np.int32,
     max_value: np.int32,

--- a/src/max_div/_core/solver/_strategies/_sampling/add.py
+++ b/src/max_div/_core/solver/_strategies/_sampling/add.py
@@ -3,7 +3,7 @@ from enum import StrEnum
 import numpy as np
 from numpy.typing import NDArray
 
-from max_div._core._math.modify_p_selectivity import exponential_selectivity
+from max_div._core._math.modify_p_selectivity import DEFAULT_LOW_VALUE, exponential_selectivity
 from max_div._core._random import choice, choice_constrained
 from max_div._core.solver._solver_state import SolverState
 
@@ -74,6 +74,7 @@ def select_items_to_add(
         p_out=p,  # in-place
         modifier=np.float32(selectivity_modifier),
         reverse=False,  # for adding, we want to have items with high diversity contribution have higher probability
+        low_value=DEFAULT_LOW_VALUE,
     )
 
     # --- actual sampling ---------------------------------

--- a/src/max_div/_core/solver/_strategies/_sampling/remove.py
+++ b/src/max_div/_core/solver/_strategies/_sampling/remove.py
@@ -1,7 +1,7 @@
 import numpy as np
 from numpy.typing import NDArray
 
-from max_div._core._math.modify_p_selectivity import exponential_selectivity
+from max_div._core._math.modify_p_selectivity import DEFAULT_LOW_VALUE, exponential_selectivity
 from max_div._core._random import choice
 from max_div._core.solver._solver_state import SolverState
 
@@ -28,6 +28,7 @@ def select_items_to_remove(
         p_out=p,  # in-place
         modifier=np.float32(selectivity_modifier),
         reverse=True,  # for removal, we want to have items with small diversity contribution have higher probability
+        low_value=DEFAULT_LOW_VALUE,
     )
 
     # --- sample ---


### PR DESCRIPTION
**TL;DR**: Three compiled routines inferred their argument types from whatever arrived; declaring signatures turns the single specialization they already had into a guarantee. A safeguard, not a speed-up.

## Description

### Problem addressed

Most compiled routines here declare an exact signature, so a caller passing an unexpected type gets a **`TypeError` rather than a silently compiled second variant**. Three did not: the exponential selectivity transform and the two distribution samplers, all of which Python dispatches directly.

Measured across three diversity metrics and three presets, each settles on **exactly one** specialization — but that is an observation about today's callers, not a constraint on tomorrow's. A future caller handing over a float64 or a non-contiguous array would have quietly acquired its own compiled variant, which is both a hidden compilation cost and a silently different numeric path.

### Implementation

Signatures added to the three routines Python dispatches. **Deliberately not** to the private helpers alongside them: those are compiled into their callers rather than dispatched, so the callers' own signatures already constrain them, and typing them would force a standalone compilation at import that today never happens.

Two consequences fell out, both of them numba's rules rather than choices:

- **An eager signature and a defaulted parameter cannot coexist.** Numba matches the declared arity, so omitting an argument yields "No matching definition". `reverse` and `low_value` therefore became required, and the three call sites pass them — `low_value` via a named constant, since every production path wants the same floor while the tests deliberately vary it.
- **Eager compilation happens when the decorator runs**, so a routine's callees must already exist. Two private helpers moved above their callers; this is ordering only, no behavior.

## Attention points

- **The safeguard is exact for arrays, lenient for scalars.** A float64 *array* is now rejected, and so is a non-contiguous one; a float64 *scalar* is still accepted and converted. Numba's conversion rules own that distinction. The stated goal still holds either way: one specialization, never a silent second.
- **Import time is unchanged** (0.35 s to 0.37 s, within noise). Eager compilation moves work to import, but it is cached, so import loads it from disk rather than rebuilding.
- **The two private helpers left untyped are a conscious asymmetry**, on the reasoning above rather than oversight.

## Tests / Spikes

- **SPIKE:** confirmed against numba directly that a signature plus a defaulted argument fails on a call that omits the argument. That result is what forced the required-parameter change rather than a cosmetic preference.
- **TEST:** full suite green, 3744 tests, including the golden master **unregenerated**.
- **TEST:** wrong types now raise — float64 array and non-contiguous array both rejected — while all three routines still hold exactly **one** specialization after being called with float32, float64 and plain Python floats.
- **TEST:** no numba caching warnings after purging every `__pycache__`.
- No unit tests added: existing tests already exercise these routines across their parameter ranges, and they are what caught the ordering rule during development.

## Changelog entry

None: no user-facing effect. This makes a property the code already had explicit, and changes no behavior for any valid call.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
