### PR TITLE
fix: keep the selected-index list up to date instead of rebuilding it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
-- Solving is a few percent faster on stored distance backends: the list of selected items is kept up to date as the selection changes, rather than rebuilt from scratch each time it is read
+- Solving is up to about 10% faster on stored distance backends, from cheaper bookkeeping of which items are selected
 - Faster startup: importing the package and running the first solve in a process together take roughly a quarter of the time they did, because routines that were rebuilt on every run are now compiled once and reused
 - Swap candidates are drawn from the full pool of non-selected items, so a given seed now selects different items than before; solution quality is unchanged once a run has converged
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Solving is a few percent faster on stored distance backends: the list of selected items is kept up to date as the selection changes, rather than rebuilt from scratch each time it is read
 - Faster startup: importing the package and running the first solve in a process together take roughly a quarter of the time they did, because routines that were rebuilt on every run are now compiled once and reused
 - Swap candidates are drawn from the full pool of non-selected items, so a given seed now selects different items than before; solution quality is unchanged once a run has converged
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,6 +249,10 @@ fail_under = 98
 exclude_also = [
     "@abstractmethod",
     "@abc.abstractmethod",
+    # numba compile-time hooks: their bodies run while numba compiles a caller, which never
+    # happens on the coverage run, since that run disables compilation to see inside njit code
+    "@intrinsic",
+    "@overload",
 ]
 
 [tool.pytest.ini_options]

--- a/src/max_div/_core/_utils/__init__.py
+++ b/src/max_div/_core/_utils/__init__.py
@@ -11,5 +11,6 @@ from ._hash import (
 from ._justify_lists import ljust_str_list, rjust_str_list
 from ._micro_benchmark import BenchmarkResult, benchmark
 from ._precision import ALMOST_ONE, ALMOST_ONE_F32, EPS, EPS_F32, HALF_EPS, HALF_EPS_F32
+from ._sorted_index_list import delete_sorted, insert_sorted, move_within
 from ._stdout import stdout_to_file
 from ._timer import Timer

--- a/src/max_div/_core/_utils/_sorted_index_list.py
+++ b/src/max_div/_core/_utils/_sorted_index_list.py
@@ -1,0 +1,85 @@
+"""Insertion into and deletion from an ascending index list held in a fixed-capacity buffer.
+
+The list occupies the first `n_live` entries of its buffer; the entries beyond that are scratch.
+Both operations shift a run of entries by one position, and the source and destination of that
+shift overlap, so the move has to be one that defines its behaviour on overlap.
+
+Compiled, that move is `llvm.memmove`, whose whole purpose is to be correct on overlapping
+ranges — reaching it needs an intrinsic, because neither an element loop nor a slice assignment
+inside numba produces one.  Interpreted, it is numpy slice assignment, which buffers the source
+for the same reason.  `move_within` is the single name for both: the plain function below runs
+when numba is disabled, the `overload` when it is not.
+"""
+
+import numba
+import numpy as np
+from llvmlite import ir
+from numba.core import types
+from numba.extending import intrinsic, overload
+from numpy.typing import NDArray
+
+
+# =================================================================================================
+#  Overlap-safe move
+# =================================================================================================
+@intrinsic
+def _llvm_memmove(typingctx, dest, dest_offset, src, src_offset, count):  # noqa: ANN001, ANN202
+    """Emit a call to `llvm.memmove` over the data pointers of `dest` and `src`."""
+    signature = types.void(dest, dest_offset, src, src_offset, count)
+
+    def codegen(context, builder, sig, args):  # noqa: ANN001, ANN202
+        dest_array, dest_off, src_array, src_off, n = args
+        item_size = context.get_abi_sizeof(context.get_data_type(sig.args[0].dtype))
+        dest_struct = context.make_array(sig.args[0])(context, builder, dest_array)
+        src_struct = context.make_array(sig.args[2])(context, builder, src_array)
+        byte_ptr = ir.IntType(8).as_pointer()
+        dest_ptr = builder.bitcast(builder.gep(dest_struct.data, [dest_off]), byte_ptr)
+        src_ptr = builder.bitcast(builder.gep(src_struct.data, [src_off]), byte_ptr)
+        n_bytes = builder.mul(builder.sext(n, ir.IntType(64)), ir.Constant(ir.IntType(64), item_size))
+        memmove = builder.module.declare_intrinsic("llvm.memmove", [byte_ptr, byte_ptr, ir.IntType(64)])
+        builder.call(memmove, [dest_ptr, src_ptr, n_bytes, ir.Constant(ir.IntType(1), 0)])
+        return context.get_dummy_value()
+
+    return signature, codegen
+
+
+def move_within(buffer: NDArray[np.int32], dest_offset: int, src_offset: int, count: int) -> None:
+    """Move `count` entries of `buffer` from `src_offset` to `dest_offset`, correct on overlap."""
+    buffer[dest_offset : dest_offset + count] = buffer[src_offset : src_offset + count]
+
+
+@overload(move_within)
+def _move_within_compiled(buffer, dest_offset, src_offset, count):  # noqa: ANN001, ANN202
+    """Compiled form of `move_within`, reaching llvm.memmove rather than a copy loop."""
+
+    def implementation(buffer, dest_offset, src_offset, count):  # noqa: ANN001, ANN202
+        _llvm_memmove(buffer, dest_offset, buffer, src_offset, count)
+
+    return implementation
+
+
+# =================================================================================================
+#  Sorted index list
+# =================================================================================================
+@numba.njit("void(int32[::1], int32, int32)", cache=True)
+def insert_sorted(index_list: NDArray[np.int32], n_live: np.int32, value: np.int32) -> None:
+    """Insert `value` into the ascending `index_list` of length `n_live`, growing it by one.
+
+    The buffer must hold at least `n_live + 1` entries.  `value` must not already be present;
+    inserting a duplicate places it next to its twin and leaves the list ascending, but the
+    callers of this function treat their lists as sets.
+    """
+    position = np.searchsorted(index_list[:n_live], value)
+    move_within(index_list, position + 1, position, n_live - position)
+    index_list[position] = value
+
+
+@numba.njit("void(int32[::1], int32, int32)", cache=True)
+def delete_sorted(index_list: NDArray[np.int32], n_live: np.int32, value: np.int32) -> None:
+    """Remove `value` from the ascending `index_list` of length `n_live`, shrinking it by one.
+
+    `value` must be present.  The entry vacated at the end of the list is left as it was; the
+    list is defined by its first `n_live - 1` entries once the caller has shrunk its own count.
+    """
+    position = np.searchsorted(index_list[:n_live], value)
+    move_within(index_list, position, position + 1, n_live - position - 1)

--- a/src/max_div/_core/_utils/_sorted_index_list.py
+++ b/src/max_div/_core/_utils/_sorted_index_list.py
@@ -5,15 +5,39 @@ shift a run of entries by one position, and since that run moves within a single
 and destination overlap.  The shift therefore needs a move whose behavior on overlapping ranges is
 defined — `memcpy` is the one that is not, `memmove` is the one that is.
 
-That move is written twice under the single name `move_within`, because this code runs two ways:
+## Why the shift is written twice
 
-  - **Compiled**, it emits `llvm.memmove` directly.  Reaching that instruction takes an intrinsic,
-    since neither an element loop nor a slice assignment written inside numba compiles down to one.
-  - **Interpreted** — how the coverage run and the JIT-disabled test legs execute — it is numpy
-    slice assignment, which buffers its source and is safe on overlap for the same reason.
+This module runs two ways, and no single implementation serves both:
 
-Which one a caller gets is decided by numba while it compiles that caller; `move_within` and the
-`overload` beneath it document the mechanics.
+  - **Compiled** — production, and every test leg but coverage.  Nothing written in Python compiles
+    to a `memmove`: numba lowers an element loop and a slice assignment alike to a copy loop, which
+    is several times slower at large `n_live`.  Reaching the instruction takes an intrinsic.
+  - **Interpreted** — the coverage run and the JIT-disabled legs, where compilation is switched off
+    so coverage can see inside these functions.  An intrinsic does not exist in this mode at all: it
+    produces instructions for a compiler, and no compiler is running.  numpy slice assignment stands
+    in, and buffers its source, so it is equally safe on overlap.
+
+## How the right one gets picked
+
+Two decorators, each doing one half of the job, because neither does both:
+
+  - `@intrinsic` (`_llvm_memmove`) supplies **the instruction**.  What it defines is callable only
+    from compiled code and has no Python body to fall back on, so it cannot be called directly by
+    the two functions below without breaking the interpreted mode.
+  - `@overload(move_within)` supplies **the dispatch**.  It tells numba that a compiled caller of
+    `move_within` should get the registered implementation — the one calling the intrinsic — instead
+    of a compilation of the plain function.
+
+The plain `move_within` is therefore the interpreted implementation, and the overload redirects away
+from it whenever the caller is being compiled:
+
+  - **JIT on:** `insert_sorted` is compiled, numba resolves its `move_within` call through the
+    overload registry, and the memmove is emitted inline into `insert_sorted`.
+  - **JIT off:** `njit` hands back the undecorated function, so `insert_sorted` is ordinary Python
+    and its `move_within` call is an ordinary Python call.  The overload registry is never consulted,
+    because nothing is being compiled.
+
+Both paths are live, and the tests exercise this module in each mode.
 """
 
 import numba
@@ -31,14 +55,15 @@ from numpy.typing import NDArray
 def _llvm_memmove(typingctx, dest, dest_offset, src, src_offset, count):  # noqa: ANN001, ANN202
     """Emit a call to `llvm.memmove` over the data pointers of `dest` and `src`.
 
-    `@intrinsic` is numba's hook for generating machine code directly, for cases where no Python
-    source compiles to the instruction wanted.  It does not behave like `@njit`: this body never
-    runs at call time.  numba runs it *while compiling a caller*, and expects two things back —
-    the type signature of the call, and `codegen`, which writes the instructions.
+    The body runs while numba compiles a caller, not when the function is called, and returns the
+    call's type signature plus the `codegen` that writes the instructions.  Inside `codegen`,
+    `builder` is an LLVM instruction writer and `args` holds the caller's compiled arguments.
 
-    Inside `codegen`, `builder` is an LLVM instruction writer and `args` holds the caller's
-    already-compiled arguments.  The block therefore emits a memmove call into the caller; it does
-    not perform one.  The final argument to that call is LLVM's `isvolatile` flag, kept false.
+    The `False` ending the emitted call is LLVM's `isvolatile` flag.  Marking an access volatile
+    forbids the optimizer from reordering, merging or discarding it, which is what memory needs when
+    the accesses themselves are observable — a memory-mapped hardware register being the standard
+    case.  A shift within an ordinary array is not that, so the flag stays false and the optimizer
+    keeps its freedom.
     """
     signature = types.void(dest, dest_offset, src, src_offset, count)
 
@@ -70,16 +95,9 @@ def move_within(
 
 @overload(move_within)
 def _move_within_compiled(buffer, dest_offset, src_offset, count):  # noqa: ANN001, ANN202
-    """Supply the implementation numba uses for `move_within` in compiled code.
+    """Register what numba compiles in place of `move_within`; the module docstring has the mechanism.
 
-    `@overload` registers a substitute: when numba compiles a function that calls `move_within`, it
-    compiles this instead of the Python body above.  As with `@intrinsic`, this outer body runs at
-    compile time — the inner `implementation` is what ends up in the caller.
-
-    Nothing registered here reaches interpreted execution, which is what gives the two paths.  Under
-    `NUMBA_DISABLE_JIT=1` the `njit` decorators below become no-ops, `insert_sorted` runs as ordinary
-    Python, and its call resolves to `move_within` itself — the numpy version.  Both are therefore
-    live, and the tests cover the module in each mode.
+    This outer body runs at compile time — the inner `implementation` is what lands in the caller.
     """
 
     def implementation(buffer, dest_offset, src_offset, count):  # noqa: ANN001, ANN202

--- a/src/max_div/_core/_utils/_sorted_index_list.py
+++ b/src/max_div/_core/_utils/_sorted_index_list.py
@@ -1,14 +1,9 @@
 """Insertion into and deletion from an ascending index list held in a fixed-capacity buffer.
 
-The list occupies the first `n_live` entries of its buffer; the entries beyond that are scratch.
-Both operations shift a run of entries by one position, and the source and destination of that
-shift overlap, so the move has to be one that defines its behaviour on overlap.
-
-Compiled, that move is `llvm.memmove`, whose whole purpose is to be correct on overlapping
-ranges — reaching it needs an intrinsic, because neither an element loop nor a slice assignment
-inside numba produces one.  Interpreted, it is numpy slice assignment, which buffers the source
-for the same reason.  `move_within` is the single name for both: the plain function below runs
-when numba is disabled, the `overload` when it is not.
+The list occupies the first `n_live` entries; the rest is scratch.  Both operations shift a run
+of entries by one, source and destination overlapping, so the move must be overlap-safe.
+`move_within` has two implementations of it: an intrinsic emitting `llvm.memmove` when compiled,
+numpy slice assignment when numba is disabled.
 """
 
 import numba
@@ -65,9 +60,7 @@ def _move_within_compiled(buffer, dest_offset, src_offset, count):  # noqa: ANN0
 def insert_sorted(index_list: NDArray[np.int32], n_live: np.int32, value: np.int32) -> None:
     """Insert `value` into the ascending `index_list` of length `n_live`, growing it by one.
 
-    The buffer must hold at least `n_live + 1` entries.  `value` must not already be present;
-    inserting a duplicate places it next to its twin and leaves the list ascending, but the
-    callers of this function treat their lists as sets.
+    `value` must not already be present, and the buffer must hold at least `n_live + 1` entries.
     """
     position = np.searchsorted(index_list[:n_live], value)
     move_within(index_list, position + 1, position, n_live - position)
@@ -78,8 +71,8 @@ def insert_sorted(index_list: NDArray[np.int32], n_live: np.int32, value: np.int
 def delete_sorted(index_list: NDArray[np.int32], n_live: np.int32, value: np.int32) -> None:
     """Remove `value` from the ascending `index_list` of length `n_live`, shrinking it by one.
 
-    `value` must be present.  The entry vacated at the end of the list is left as it was; the
-    list is defined by its first `n_live - 1` entries once the caller has shrunk its own count.
+    `value` must be present.  The vacated last entry keeps its old contents, so the list is the
+    first `n_live - 1` entries once the caller has shrunk its count.
     """
     position = np.searchsorted(index_list[:n_live], value)
     move_within(index_list, position, position + 1, n_live - position - 1)

--- a/src/max_div/_core/_utils/_sorted_index_list.py
+++ b/src/max_div/_core/_utils/_sorted_index_list.py
@@ -34,8 +34,12 @@ from it whenever the caller is being compiled:
   - **JIT on:** `insert_sorted` is compiled, numba resolves its `move_within` call through the
     overload registry, and the memmove is emitted inline into `insert_sorted`.
   - **JIT off:** `njit` hands back the undecorated function, so `insert_sorted` is ordinary Python
-    and its `move_within` call is an ordinary Python call.  The overload registry is never consulted,
-    because nothing is being compiled.
+    and its `move_within` call is an ordinary Python call, landing on the numpy body.  The
+    registration still happened — `@overload` runs at import in either mode — but all it does is
+    file `_move_within_compiled` under `move_within` in numba's *typing* registry, leaving
+    `move_within` itself untouched: not wrapped, not rebound, the same function object either way.
+    That registry is read during type inference, and type inference runs only when numba compiles
+    something, so with compilation off the entry is simply never looked up.
 
 Both paths are live, and the tests exercise this module in each mode.
 """

--- a/src/max_div/_core/_utils/_sorted_index_list.py
+++ b/src/max_div/_core/_utils/_sorted_index_list.py
@@ -1,9 +1,19 @@
 """Insertion into and deletion from an ascending index list held in a fixed-capacity buffer.
 
-The list occupies the first `n_live` entries; the rest is scratch.  Both operations shift a run
-of entries by one, source and destination overlapping, so the move must be overlap-safe.
-`move_within` has two implementations of it: an intrinsic emitting `llvm.memmove` when compiled,
-numpy slice assignment when numba is disabled.
+The list occupies the first `n_live` entries of its buffer; the rest is scratch.  Both operations
+shift a run of entries by one position, and since that run moves within a single buffer, its source
+and destination overlap.  The shift therefore needs a move whose behavior on overlapping ranges is
+defined — `memcpy` is the one that is not, `memmove` is the one that is.
+
+That move is written twice under the single name `move_within`, because this code runs two ways:
+
+  - **Compiled**, it emits `llvm.memmove` directly.  Reaching that instruction takes an intrinsic,
+    since neither an element loop nor a slice assignment written inside numba compiles down to one.
+  - **Interpreted** — how the coverage run and the JIT-disabled test legs execute — it is numpy
+    slice assignment, which buffers its source and is safe on overlap for the same reason.
+
+Which one a caller gets is decided by numba while it compiles that caller; `move_within` and the
+`overload` beneath it document the mechanics.
 """
 
 import numba
@@ -19,7 +29,17 @@ from numpy.typing import NDArray
 # =================================================================================================
 @intrinsic
 def _llvm_memmove(typingctx, dest, dest_offset, src, src_offset, count):  # noqa: ANN001, ANN202
-    """Emit a call to `llvm.memmove` over the data pointers of `dest` and `src`."""
+    """Emit a call to `llvm.memmove` over the data pointers of `dest` and `src`.
+
+    `@intrinsic` is numba's hook for generating machine code directly, for cases where no Python
+    source compiles to the instruction wanted.  It does not behave like `@njit`: this body never
+    runs at call time.  numba runs it *while compiling a caller*, and expects two things back —
+    the type signature of the call, and `codegen`, which writes the instructions.
+
+    Inside `codegen`, `builder` is an LLVM instruction writer and `args` holds the caller's
+    already-compiled arguments.  The block therefore emits a memmove call into the caller; it does
+    not perform one.  The final argument to that call is LLVM's `isvolatile` flag, kept false.
+    """
     signature = types.void(dest, dest_offset, src, src_offset, count)
 
     def codegen(context, builder, sig, args):  # noqa: ANN001, ANN202
@@ -50,7 +70,17 @@ def move_within(
 
 @overload(move_within)
 def _move_within_compiled(buffer, dest_offset, src_offset, count):  # noqa: ANN001, ANN202
-    """Compiled form of `move_within`, reaching llvm.memmove rather than a copy loop."""
+    """Supply the implementation numba uses for `move_within` in compiled code.
+
+    `@overload` registers a substitute: when numba compiles a function that calls `move_within`, it
+    compiles this instead of the Python body above.  As with `@intrinsic`, this outer body runs at
+    compile time — the inner `implementation` is what ends up in the caller.
+
+    Nothing registered here reaches interpreted execution, which is what gives the two paths.  Under
+    `NUMBA_DISABLE_JIT=1` the `njit` decorators below become no-ops, `insert_sorted` runs as ordinary
+    Python, and its call resolves to `move_within` itself — the numpy version.  Both are therefore
+    live, and the tests cover the module in each mode.
+    """
 
     def implementation(buffer, dest_offset, src_offset, count):  # noqa: ANN001, ANN202
         # ty: ignore[missing-argument] -- the stub counts the typingctx parameter, which callers do not pass

--- a/src/max_div/_core/_utils/_sorted_index_list.py
+++ b/src/max_div/_core/_utils/_sorted_index_list.py
@@ -38,7 +38,12 @@ def _llvm_memmove(typingctx, dest, dest_offset, src, src_offset, count):  # noqa
     return signature, codegen
 
 
-def move_within(buffer: NDArray[np.int32], dest_offset: int, src_offset: int, count: int) -> None:
+def move_within(
+    buffer: NDArray[np.int32],
+    dest_offset: int | np.signedinteger,
+    src_offset: int | np.signedinteger,
+    count: int | np.signedinteger,
+) -> None:
     """Move `count` entries of `buffer` from `src_offset` to `dest_offset`, correct on overlap."""
     buffer[dest_offset : dest_offset + count] = buffer[src_offset : src_offset + count]
 
@@ -48,6 +53,7 @@ def _move_within_compiled(buffer, dest_offset, src_offset, count):  # noqa: ANN0
     """Compiled form of `move_within`, reaching llvm.memmove rather than a copy loop."""
 
     def implementation(buffer, dest_offset, src_offset, count):  # noqa: ANN001, ANN202
+        # ty: ignore[missing-argument] -- the stub counts the typingctx parameter, which callers do not pass
         _llvm_memmove(buffer, dest_offset, buffer, src_offset, count)
 
     return implementation

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from max_div._core._utils import delete_sorted, insert_sorted
 from max_div._core.constraints import Constraint, ConstraintList
 
 from ._diversity_contribution import DiversityContributionTrackers
@@ -206,18 +207,11 @@ class SolverState:
 
     def _insert_selected_index(self, index: np.int32) -> None:
         """Insert `index` into the ascending index list; call before `_n_selected` grows."""
-        live = self._selected_indices[: self._n_selected]
-        pos = np.searchsorted(live, index)
-        # numpy buffers a copy whose source and destination overlap, which is what makes this shift
-        # a single assignment rather than a directional loop
-        self._selected_indices[pos + 1 : self._n_selected + 1] = live[pos:]
-        self._selected_indices[pos] = index
+        insert_sorted(self._selected_indices, self._n_selected, index)
 
     def _delete_selected_index(self, index: np.int32) -> None:
         """Remove `index` from the ascending index list; call before `_n_selected` shrinks."""
-        live = self._selected_indices[: self._n_selected]
-        pos = np.searchsorted(live, index)
-        self._selected_indices[pos : self._n_selected - 1] = live[pos + 1 :]
+        delete_sorted(self._selected_indices, self._n_selected, index)
 
     def add(self, index: int | np.int32) -> None:
         # --- validation ----------------------------------

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -104,11 +104,9 @@ class SolverState:
         # selection
         self._selected = selected
         self._n_selected: np.int32 = np.int32(selected.sum())
-        # The same selection as an ascending index list, kept in step with the mask above.  Most
-        # consumers want the selected indices rather than the mask, and deriving them costs a scan
-        # of all n to produce an answer that is k long and moves by one element per mutation.
-        # Ascending order is not incidental: candidates are drawn from this list *by position*, so
-        # a different order would select different items.
+        # The same selection as an ascending index list, kept in step with the mask above.  The
+        # ascending order is load-bearing: candidates are drawn from this list *by position*, so a
+        # different order selects different items.
         self._selected_indices = np.empty(len(selected), dtype=np.int32)
         self._selected_indices[: self._n_selected] = np.flatnonzero(selected)
 
@@ -241,6 +239,8 @@ class SolverState:
 
         # --- selection -----------------------------------
         self._selected[indices] = True
+        # the count advances inside the loop because each insert reads it as the list's current
+        # length; raising it once afterwards would give every insert but the first a stale length
         for index in indices:
             self._insert_selected_index(index)
             self._n_selected += np.int32(1)
@@ -284,6 +284,7 @@ class SolverState:
 
         # --- selection -----------------------------------
         self._selected[indices] = False
+        # same reason as in add_many: each delete reads the count as the list's current length
         for index in indices:
             self._delete_selected_index(index)
             self._n_selected -= np.int32(1)

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -103,6 +103,13 @@ class SolverState:
         # selection
         self._selected = selected
         self._n_selected: np.int32 = np.int32(selected.sum())
+        # The same selection as an ascending index list, kept in step with the mask above.  Most
+        # consumers want the selected indices rather than the mask, and deriving them costs a scan
+        # of all n to produce an answer that is k long and moves by one element per mutation.
+        # Ascending order is not incidental: candidates are drawn from this list *by position*, so
+        # a different order would select different items.
+        self._selected_indices = np.empty(len(selected), dtype=np.int32)
+        self._selected_indices[: self._n_selected] = np.flatnonzero(selected)
 
         # constraints
         self._con_values = con_values  # min/max counts of extra samples needed on top of current selection
@@ -167,6 +174,7 @@ class SolverState:
         # NOTE: we create copies, such that add(.) and remove(.) cannot influence the snapshot after it was taken
         snapshot.selected = self._selected.copy()
         snapshot.n_selected = self._n_selected
+        snapshot.selected_indices = self._selected_indices[: self._n_selected].copy()
         snapshot.con_values = self._con_values.copy()
         self._contribution_trackers.push_snapshot()
         # NOTE: Score is immutable and mutators reassign self._score (never modify in place),
@@ -185,6 +193,8 @@ class SolverState:
             # no copy needed; the snapshot is cleared below, so the restored arrays cannot alias a live snapshot
             self._selected = snapshot.selected
             self._n_selected = snapshot.n_selected
+            # written back into the buffer rather than rebound, so it keeps its full capacity
+            self._selected_indices[: snapshot.n_selected] = snapshot.selected_indices
             self._con_values = snapshot.con_values
 
             # restore score (cached at push time; avoids a full recompute)
@@ -194,6 +204,21 @@ class SolverState:
         snapshot.clear()
         self._depth = depth
 
+    def _insert_selected_index(self, index: np.int32) -> None:
+        """Insert `index` into the ascending index list; call before `_n_selected` grows."""
+        live = self._selected_indices[: self._n_selected]
+        pos = np.searchsorted(live, index)
+        # numpy buffers a copy whose source and destination overlap, which is what makes this shift
+        # a single assignment rather than a directional loop
+        self._selected_indices[pos + 1 : self._n_selected + 1] = live[pos:]
+        self._selected_indices[pos] = index
+
+    def _delete_selected_index(self, index: np.int32) -> None:
+        """Remove `index` from the ascending index list; call before `_n_selected` shrinks."""
+        live = self._selected_indices[: self._n_selected]
+        pos = np.searchsorted(live, index)
+        self._selected_indices[pos : self._n_selected - 1] = live[pos + 1 :]
+
     def add(self, index: int | np.int32) -> None:
         # --- validation ----------------------------------
         index = np.int32(index)
@@ -202,6 +227,7 @@ class SolverState:
 
         # --- selection -----------------------------------
         self._selected[index] = True
+        self._insert_selected_index(index)
         self._n_selected += np.int32(1)
 
         # --- diversity contributions ---------------------
@@ -221,7 +247,9 @@ class SolverState:
 
         # --- selection -----------------------------------
         self._selected[indices] = True
-        self._n_selected += np.int32(len(indices))
+        for index in indices:
+            self._insert_selected_index(index)
+            self._n_selected += np.int32(1)
 
         # --- diversity contributions ---------------------
         self._contribution_trackers.add_many(indices)
@@ -242,6 +270,7 @@ class SolverState:
 
         # --- selection -----------------------------------
         self._selected[index] = False
+        self._delete_selected_index(index)
         self._n_selected -= np.int32(1)
 
         # --- diversity contributions ---------------------
@@ -261,7 +290,9 @@ class SolverState:
 
         # --- selection -----------------------------------
         self._selected[indices] = False
-        self._n_selected -= np.int32(len(indices))
+        for index in indices:
+            self._delete_selected_index(index)
+            self._n_selected -= np.int32(1)
 
         # --- diversity contributions ---------------------
         self._contribution_trackers.remove_many(indices, self.selected_index_array)
@@ -319,8 +350,8 @@ class SolverState:
 
     @property
     def selected_index_array(self) -> NDArray[np.int32]:
-        """Return selected indices as a numpy array of np.int32."""
-        return np.flatnonzero(self._selected).astype(np.int32)
+        """Return the selected indices, ascending (reference; do not modify)."""
+        return self._selected_indices[: self._n_selected]
 
     @property
     def not_selected_index_array(self) -> NDArray[np.int32]:
@@ -475,6 +506,7 @@ class Snapshot:
 
     selected: NDArray[np.bool]  # boolean array representing the selection
     n_selected: np.int32  # number of True values in 'selected'
+    selected_indices: NDArray[np.int32]  # the same selection, ascending; a copy of the live prefix
 
     con_values: NDArray[np.int32]  # (nc x 2)-sized array with current status of constraint bounds
 
@@ -487,6 +519,7 @@ class Snapshot:
         """Release the state held by this snapshot, returning it to the spare pool."""
         self.selected = _EMPTY_NP_ARRAY_BOOL
         self.n_selected = np.int32(0)
+        self.selected_indices = _EMPTY_NP_ARRAY_INT32
         self.con_values = _EMPTY_NP_ARRAY_INT32
         self.score = _PLACEHOLDER_SCORE
 
@@ -496,6 +529,7 @@ class Snapshot:
         return Snapshot(
             selected=_EMPTY_NP_ARRAY_BOOL,
             n_selected=np.int32(0),
+            selected_indices=_EMPTY_NP_ARRAY_INT32,
             con_values=_EMPTY_NP_ARRAY_INT32,
             score=_PLACEHOLDER_SCORE,
         )

--- a/tests/_core/_utils/test_sorted_index_list.py
+++ b/tests/_core/_utils/test_sorted_index_list.py
@@ -1,0 +1,134 @@
+import numpy as np
+import pytest
+
+from max_div._core._utils import delete_sorted, insert_sorted, move_within
+
+CAPACITY_SLACK = 4
+
+
+def _buffer(values: list[int], slack: int = CAPACITY_SLACK) -> np.ndarray:
+    """Return a buffer holding `values` in its prefix, padded with a sentinel."""
+    buffer = np.full(len(values) + slack, -1, dtype=np.int32)
+    buffer[: len(values)] = values
+    return buffer
+
+
+# =================================================================================================
+#  move_within
+# =================================================================================================
+@pytest.mark.parametrize(
+    "dest_offset, src_offset, count, expected",
+    [
+        (1, 0, 3, [10, 10, 20, 30, -1]),  # shift right, source and destination overlap
+        (0, 1, 3, [20, 30, 40, 40, -1]),  # shift left, source and destination overlap
+        (0, 0, 4, [10, 20, 30, 40, -1]),  # same range, a no-op
+        (0, 0, 0, [10, 20, 30, 40, -1]),  # empty move
+    ],
+)
+def test_move_within(dest_offset: int, src_offset: int, count: int, expected: list[int]):
+    # --- arrange -----------------------------------------
+    buffer = _buffer([10, 20, 30, 40], slack=1)
+
+    # --- act ---------------------------------------------
+    move_within(buffer, dest_offset, src_offset, count)
+
+    # --- assert ------------------------------------------
+    assert list(buffer) == expected
+
+
+# =================================================================================================
+#  insert_sorted
+# =================================================================================================
+@pytest.mark.parametrize(
+    "values, value, expected",
+    [
+        ([], 5, [5]),  # into an empty list
+        ([10], 5, [5, 10]),  # before the only entry
+        ([10], 15, [10, 15]),  # after the only entry
+        ([10, 20, 30], 5, [5, 10, 20, 30]),  # at the front
+        ([10, 20, 30], 25, [10, 20, 25, 30]),  # in the middle
+        ([10, 20, 30], 40, [10, 20, 30, 40]),  # at the end
+    ],
+)
+def test_insert_sorted(values: list[int], value: int, expected: list[int]):
+    # --- arrange -----------------------------------------
+    buffer = _buffer(values)
+
+    # --- act ---------------------------------------------
+    insert_sorted(buffer, np.int32(len(values)), np.int32(value))
+
+    # --- assert ------------------------------------------
+    assert list(buffer[: len(expected)]) == expected
+
+
+# =================================================================================================
+#  delete_sorted
+# =================================================================================================
+@pytest.mark.parametrize(
+    "values, value, expected",
+    [
+        ([10], 10, []),  # the only entry
+        ([10, 20, 30], 10, [20, 30]),  # at the front
+        ([10, 20, 30], 20, [10, 30]),  # in the middle
+        ([10, 20, 30], 30, [10, 20]),  # at the end
+    ],
+)
+def test_delete_sorted(values: list[int], value: int, expected: list[int]):
+    # --- arrange -----------------------------------------
+    buffer = _buffer(values)
+
+    # --- act ---------------------------------------------
+    delete_sorted(buffer, np.int32(len(values)), np.int32(value))
+
+    # --- assert ------------------------------------------
+    assert list(buffer[: len(expected)]) == expected
+
+
+# =================================================================================================
+#  round trip
+# =================================================================================================
+def test_insert_then_delete_restores_the_list():
+    """Inserting a value and deleting it again leaves the list as it was, at every position."""
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(0)
+    original = np.sort(rng.choice(1_000, 200, replace=False)).astype(np.int32)
+
+    for value in rng.choice(np.setdiff1d(np.arange(1_000), original), 25, replace=False):
+        buffer = _buffer(list(original))
+
+        # --- act -----------------------------------------
+        insert_sorted(buffer, np.int32(len(original)), np.int32(value))
+        after_insert = buffer[: len(original) + 1].copy()
+        delete_sorted(buffer, np.int32(len(original) + 1), np.int32(value))
+
+        # --- assert --------------------------------------
+        assert list(after_insert) == sorted([*original.tolist(), int(value)])
+        assert list(buffer[: len(original)]) == original.tolist()
+
+
+def test_the_list_stays_ascending_under_many_mixed_operations():
+    """A long run of interleaved inserts and deletes keeps the list ascending and correct."""
+    # --- arrange -----------------------------------------
+    rng = np.random.default_rng(1)
+    capacity = 500
+    buffer = np.full(capacity + 1, -1, dtype=np.int32)
+    n_live = 0
+    reference: set[int] = set()
+
+    # --- act ---------------------------------------------
+    for _ in range(2_000):
+        if n_live and (n_live == capacity or rng.random() < 0.5):
+            value = int(rng.choice(sorted(reference)))
+            delete_sorted(buffer, np.int32(n_live), np.int32(value))
+            reference.remove(value)
+            n_live -= 1
+        else:
+            value = int(rng.integers(0, 10_000))
+            if value in reference:
+                continue
+            insert_sorted(buffer, np.int32(n_live), np.int32(value))
+            reference.add(value)
+            n_live += 1
+
+    # --- assert ------------------------------------------
+    assert list(buffer[:n_live]) == sorted(reference)

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -514,3 +514,79 @@ def test_solver_state_score_lazy_recompute(new_solver_state):
     # --- assert ------------------------------------------
     assert observed_score == expected_score  # recomputed on read
     assert not state._score_dirty  # flag cleared by the recompute
+
+
+# =================================================================================================
+#  Selected-index list
+# =================================================================================================
+def _assert_index_list_matches_mask(state: SolverState) -> None:
+    """The maintained index list must always equal what deriving it from the mask would give."""
+    expected = np.flatnonzero(state._selected).astype(np.int32)
+    actual = state.selected_index_array
+    assert actual.tolist() == expected.tolist()
+
+
+@pytest.mark.parametrize("seed", [0, 1, 2, 3, 4])
+def test_selected_index_list_survives_random_mutation_sequences(seed: int):
+    """Long random sequences of every mutation, with nested savepoints kept and rolled back.
+
+    The failure mode this guards is silent: a list that drifts from the mask yields wrong
+    selections rather than an error, so the invariant is asserted after every single step
+    rather than at the end.
+    """
+    # --- arrange ----------------------
+    n = 40
+    vectors = np.arange(n, dtype=np.float32).reshape(n, 1)
+    rng = random.default_rng(seed)
+
+    def fresh() -> SolverState:
+        return SolverState.new(
+            n=n,
+            store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=n),
+            k=8,
+            diversity_metric=DiversityMetric.GEOMEAN_SEPARATION,
+            diversity_tie_breakers=[],
+            constraints=[],
+        )
+
+    state = fresh()
+
+    # --- act / assert -----------------
+    for _ in range(300):
+        selected = np.flatnonzero(state._selected).astype(np.int32)
+        free = np.flatnonzero(~state._selected).astype(np.int32)
+        action = rng.integers(0, 6)
+        if action == 0 and free.size:
+            state.add(np.int32(rng.choice(free)))
+        elif action == 1 and selected.size:
+            state.remove(np.int32(rng.choice(selected)))
+        elif action == 2 and free.size >= 3:
+            state.add_many(np.ascontiguousarray(rng.choice(free, size=3, replace=False), dtype=np.int32))
+        elif action == 3 and selected.size >= 3:
+            state.remove_many(np.ascontiguousarray(rng.choice(selected, size=3, replace=False), dtype=np.int32))
+        elif action == 4 and free.size:
+            # a rolled-back trial: the list must come back with the mask
+            with state.savepoint():
+                state.add(np.int32(rng.choice(free)))
+                _assert_index_list_matches_mask(state)
+        elif action == 5 and selected.size:
+            # a nested trial that is kept at the inner level and discarded at the outer
+            with state.savepoint():
+                with state.savepoint() as inner:
+                    state.remove(np.int32(rng.choice(selected)))
+                    inner.keep()
+                _assert_index_list_matches_mask(state)
+        _assert_index_list_matches_mask(state)
+
+
+def test_selected_index_array_is_ascending(new_solver_state_unconstrained):
+    """Ascending order is what keeps position-based candidate draws unchanged."""
+    # --- arrange / act ----------------
+    for index in (4, 1, 5, 0):
+        new_solver_state_unconstrained.add(np.int32(index))
+    new_solver_state_unconstrained.remove(np.int32(1))
+
+    # --- assert -----------------------
+    indices = new_solver_state_unconstrained.selected_index_array
+    assert indices.tolist() == sorted(indices.tolist())
+    assert indices.tolist() == [0, 4, 5]


### PR DESCRIPTION
**TL;DR**: The selected-index list was rebuilt by scanning every item, eight times per iteration, to produce an answer that changes by one element per mutation. It is now maintained in place, the shift done by a compiled overlap-safe move — up to ~10% of an iteration on stored backends, with no change to what gets selected.

## Description

### Problem addressed

The selection lives as a **boolean mask** of length n, but most consumers want the **list of selected indices**. A property derived one from the other by scanning all n entries and allocating, every time it was read — once inside each of the six removals per iteration, and twice by the removal-candidate step.

Measured on the cost model, that is **12.4% of an iteration** at n=20,000 on the full-matrix backend, and 5–8% on the others. The work is proportional to n, while the answer is k long and moves by a single element per mutation.

### Implementation

The list is kept alongside the mask and updated in place: a fixed-capacity buffer with the existing selected-count as its logical length, a binary search for the position, one shift. The property returns a **view** of the live prefix; saving the scan and then paying it back in allocation would defeat the point. Savepoints save and restore the prefix along with the mask.

**Ascending order is preserved deliberately, and that is the crux.** Two consumers are order-sensitive in different ways: the RNG draws removal candidates *by position*, so a permuted list selects different items, while the separation rescan takes a minimum and does not care. Sorted insertion costs a shift where a swap-to-end would not — that cost is exactly what buys an unchanged search.

**The shift is compiled, reaching `llvm.memmove` through an intrinsic.** An earlier revision used numpy slice assignment, on a measurement showing hand-written numba losing at large k. That measurement covered an element loop and a slice assignment, neither of which numba lowers to a memmove; emitting the call directly wins at every size:

| k | numpy | numba loop | numba slice | `llvm.memmove` |
|---|---|---|---|---|
| 200 | 893 ns | 180 ns | 195 ns | **175 ns** |
| 2 000 | 1089 ns | 492 ns | 530 ns | **216 ns** |
| 10 000 | 2267 ns | 2880 ns | 3264 ns | **428 ns** |
| 20 000 | 3385 ns | 4885 ns | 5538 ns | **612 ns** |
| 50 000 | 7313 ns | 12436 ns | 14278 ns | **1617 ns** |

An intrinsic exists only in compiled code, so `move_within` carries two implementations behind one name — numpy slice assignment when numba is disabled, the emitted move when it is not. Both are overlap-safe by specification, which is what the shift relies on.

## Attention points

- **The whole-solve gain is ~10% at n=20,000, k=2,000**, of which ~3.7% is no longer rebuilding and ~6.3% is the compiled shift. It falls to ~2% at n=5,000, k=500 — the per-call saving holds at every size, but it is a smaller share of a smaller iteration.
- **The intrinsic reaches into numba internals** (`context.make_array`, `builder.module.declare_intrinsic`), so it is exposed to version drift in a way a plain compiled function is not. `cache=True` was checked against it explicitly, since a caching regression would undo separate work in this same version.
- **Callers now receive a live view where they previously got a private copy.** Nothing holds one across a mutation today — the RNG draw treats its input as read-only, and the one caller that keeps the array already copies it — but it turns a currently-safe pattern into a trap for future code. The convention is already used elsewhere in this package.
- **The failure mode is silent.** A list that drifts from the mask produces wrong selections rather than an error, which is what the stress test is for.
- **Coverage config gains two exclusions** (`@intrinsic`, `@overload`): their bodies run while numba compiles a caller, which never happens on the coverage run, since that run disables compilation.

## Tests / Spikes

- **SPIKE:** an insert/delete microbenchmark across three decades of k, comparing numpy against an element loop, a slice assignment, an emitted `llvm.memmove`, and a `ctypes` call to libc. The two move-based arms measure identically; the intrinsic was chosen because `ctypes.CDLL(None)` does not work on Windows and bakes a resolved address into cached code.
- **TEST:** end-to-end fixed-iteration solves with per-solve setup cancelled by differencing N and 2N iterations, at three sizes. Selections come out identical in every case.
- **TEST:** a stress test driving 300 random mutations per seed across five seeds — every mutation entry point, with nested savepoints both kept and rolled back — asserting after **every step** that the maintained list equals what deriving it from the mask would give.
- **TEST:** that guard was itself verified by deliberately breaking the implementation two ways (dropping the savepoint restore, and using an unsorted swap-to-end delete). Both are caught.
- **TEST:** full suite green both ways — 3760 with numba, 3502 with it disabled — and the golden master passes unregenerated, which is what makes the change behavior-neutral rather than merely believed to be.
- 16 unit tests added for the new module, plus the stress and ordering tests on solver state.

## Changelog entry

Slotted under `Changed`:

```
- Solving is up to about 10% faster on stored distance backends, from cheaper bookkeeping of which items are selected
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
