### PR TITLE
chore: drop the format targets and let lint apply ruff's fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,8 @@ repos:
         pass_filenames: true
       - id: ruff
         name: ruff check
-        entry: uv run --no-default-groups --group lint ruff check
+        # --fix lets pre-commit be run to fix; it still blocks, since it detects rewritten files.
+        entry: uv run --no-default-groups --group lint ruff check --fix
         language: system
         types: [python]
         files: ^(src/max_div|tests|scripts)/|^\.github/scripts/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,7 @@ This syncs dev dependencies via `uv` and installs pre-commit hooks.
 
 ```bash
 make test            # Run the test suite (pytest)
-make format          # Format and auto-fix with ruff
-make lint            # Run the full pre-commit hook suite over all files
+make lint            # Run the full pre-commit hook suite over all files, formatting and applying ruff fixes
 make coverage        # Run the test suite with an HTML coverage report
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-file_path=
-
 # --- how the package suite is installed and run ------------
 # Single definition, shared by every target below AND by the CI test matrix, which calls these
 # targets rather than repeating the command. That is the point: the interpreter, the resolution
@@ -21,7 +19,7 @@ UV_RUN = uv run --exact --python $(PY) --resolution $(RESOLUTION) --no-default-g
 # to pass coverage flags, and deliberately keeps the warnings visible.
 PYTEST_ARGS ?= --disable-warnings
 
-.PHONY: help build test collect-test-ids check-capability-data build-capability-data coverage test-and-coverage format format-single-file lint dev-setup release splash docs show-coverage show-docs update-internal-benchmarks update-solver-strategies-benchmarks update-all-benchmarks update-solver-benchmark-figures
+.PHONY: help build test collect-test-ids check-capability-data build-capability-data coverage test-and-coverage lint dev-setup release splash docs show-coverage show-docs update-internal-benchmarks update-solver-strategies-benchmarks update-all-benchmarks update-solver-benchmark-figures
 
 help:
 	@echo 'Commands:'
@@ -37,9 +35,7 @@ help:
 	@echo '  coverage                               Generate test coverage report. (./reports/coverage)'
 	@echo '  test-and-coverage                      Run unit tests (=with numba) + generate coverage report (=without numba).'
 	@echo ''
-	@echo '  format                                 Format source code using ruff.'
-	@echo '  format-single-file                     Format single file using ruff. Useful in e.g. PyCharm to automatically trigger formatting on file save.'
-	@echo '  lint                                   Run all pre-commit hooks on all files.'
+	@echo '  lint                                   Run all pre-commit hooks on all files. Formats and applies ruff fixes as it goes.'
 	@echo '  dev-setup                              Sync dev environment & install pre-commit hooks.'
 	@echo ''
 	@echo '  release                                Release a new version. Usage: make release VERSION=X.Y.Z'
@@ -57,7 +53,6 @@ help:
 	@echo ''
 	@echo 'Options:'
 	@echo ''
-	@echo '  format-single-file             - accepts `file_path=<path>` to pass the relative path of the file to be formatted.'
 	@echo '  test / collect-test-ids / coverage'
 	@echo '                                 - accept `PY=<version>` and `RESOLUTION=highest|lowest-direct` to pick the'
 	@echo '                                   interpreter and uv resolution strategy, and `PYTEST_ARGS=<flags>` to replace'
@@ -105,17 +100,6 @@ coverage:
 test-and-coverage:
 	$(MAKE) test;
 	$(MAKE) coverage;
-
-# The two format targets name the lint group but deliberately do NOT pass --exact: they are wired
-# to editor save actions, and pruning the environment on every keystroke-triggered format would
-# yank packages out from under a docs server or test run in another terminal.
-format:
-	uv run --no-default-groups --group lint ruff format .;
-	uv run --no-default-groups --group lint ruff check --fix .;
-
-format-single-file:
-	uv run --no-default-groups --group lint ruff format ${file_path};
-	uv run --no-default-groups --group lint ruff check --fix ${file_path};
 
 lint:
 	uv run --exact --no-default-groups --group lint pre-commit run --all-files


### PR DESCRIPTION
**Problem**: `make format` ran ruff over the whole repository while the pre-commit hooks enforce four directories, so it rewrote markdown code blocks and trees nothing verifies. Scoping it would have fixed that, but it mostly duplicated the hooks in the first place.

**Solution**: Delete `format` and `format-single-file`, and move their one unique contribution — `ruff check --fix` — onto the ruff hook. `make lint` already reformatted; it now applies the fixable lint rules too, so a single target does everything the deleted ones did.

- **Attention:** `make lint` rewrites files, and always did — the format hook's entry is `ruff format`, not `--check`. The `--fix` here widens what it repairs; it does not make a read-only target mutating.
- **Attention:** pre-commit reads the git index, so a file that has never been staged is invisible to `make lint` where `make format` would have caught it. `pre-commit run --files <path>` covers that case.
- **TEST:** A tracked file with bad spacing and an unused import: before, `make lint` reformatted it but left `import os`. Now both go.
- **TEST:** The gate still fails when it repairs something — first run exits 2, second exits 0. That is what keeps CI honest, since ruff exits 0 once it has fixed everything.
- **TEST:** Full hook suite passes on the tree; `make help` renders without the removed entries.

**Changelog** (none): developer tooling only, with no user-facing effect.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
