### PR TITLE
feat: add a farthest-point-sampling initialization strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- A farthest-point-sampling initialization strategy (`InitializationStrategy.farthest_point()`): the greedy construction farthest-point-sampling tools use, computed from the solver's own distance store, selectable on the builder
+- A farthest-point-sampling initialization strategy (`InitializationStrategy.farthest_point()`): the greedy construction farthest-point-sampling tools use, computed from the solver's own distance store, selectable via `MaxDivSolverBuilder.set_initialization_strategy`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- A farthest-point-sampling initialization strategy (`InitializationStrategy.farthest_point()`): the greedy construction FPS pickers use, computed from the solver's own distance store, selectable on the builder
+- A farthest-point-sampling initialization strategy (`InitializationStrategy.farthest_point()`): the greedy construction farthest-point-sampling tools use, computed from the solver's own distance store, selectable on the builder
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- A farthest-point-sampling initialization strategy (`InitializationStrategy.farthest_point()`): the greedy construction FPS pickers use, computed from the solver's own distance store, selectable on the builder
 
 ### Changed
 

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -28,8 +28,9 @@ speed vs quality of the starting point:
 |----------|-------------|
 | `random_one_shot` | Selects all `k` items in one batch, with probabilities biased by global separation. **Default for all presets.** |
 | `random_batched` | Selects in batches of `b`, re-evaluating separations between batches. |
+| `farthest_point` | A seeded random start item, then greedily adds the item farthest from the selection (farthest-point sampling; the greedy max-sum construction under mean pairwise distance). Constraint-unaware. |
 | `eager` | Evaluates `nc` random candidates per step, picks the best. Slower but higher quality. |
-| `fast` | Deterministic greedy: always picks the item maximizing separation. Fast but seed-independent. |
+| `fast` | Selects the first `k` items. Trivial deterministic baseline for testing and benchmarking. |
 
 ## Optimization Strategies
 

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -28,7 +28,7 @@ speed vs quality of the starting point:
 |----------|-------------|
 | `random_one_shot` | Selects all `k` items in one batch, with probabilities biased by global separation. **Default for all presets.** |
 | `random_batched` | Selects in batches of `b`, re-evaluating separations between batches. |
-| `farthest_point` | A seeded random start item, then greedily adds the item farthest from the selection (farthest-point sampling; the greedy max-sum construction under mean pairwise distance). Constraint-unaware. |
+| `farthest_point` | A seeded random start item, then greedily adds the item farthest from the selection (farthest-point sampling; under `MEAN_PAIRWISE_DISTANCE`, greedily maximizes mean distance to the selection). Constraint-unaware. |
 | `eager` | Evaluates `nc` random candidates per step, picks the best. Slower but higher quality. |
 | `fast` | Selects the first `k` items. Trivial deterministic baseline for testing and benchmarking. |
 

--- a/src/max_div/_core/solver/_strategies/_initialization/_base.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_base.py
@@ -60,10 +60,7 @@ class InitializationStrategy(StrategyBase, ABC):
     def farthest_point(cls) -> InitFarthestPoint:
         """Farthest-point-sampling initialization: a seeded random start item, then greedy picks.
 
-        Each pick adds the item with the highest diversity contribution wrt the current selection —
-        classical farthest-point sampling under the separation-family metrics, the greedy max-sum
-        construction under ``MEAN_PAIRWISE_DISTANCE``.  Constraint-unaware by design; the
-        optimization phase repairs feasibility.
+        See `InitFarthestPoint` for the per-metric interpretation and constraint handling.
         """
         from ._init_farthest_point import InitFarthestPoint
 

--- a/src/max_div/_core/solver/_strategies/_initialization/_base.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_base.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
     from max_div._core.solver._solver_state import SolverState
 
     from ._init_eager import InitEager
+    from ._init_farthest_point import InitFarthestPoint
     from ._init_fast import InitFast
     from ._init_random_batched import InitRandomBatched
     from ._init_random_one_shot import InitRandomOneShot
@@ -23,8 +24,8 @@ if TYPE_CHECKING:
 class InitializationStrategy(StrategyBase, ABC):
     """Base class for strategies that produce an initial selection of ``k`` items.
 
-    Use the factory methods (`fast`, `random_one_shot`, `random_batched`,
-    `eager`) to create instances.
+    Use the factory methods (`fast`, `farthest_point`, `random_one_shot`,
+    `random_batched`, `eager`) to create instances.
     """
 
     @abstractmethod
@@ -47,15 +48,26 @@ class InitializationStrategy(StrategyBase, ABC):
     # -------------------------------------------------------------------------
     @classmethod
     def fast(cls) -> InitFast:
-        """Deterministic greedy initialization.
+        """Trivial initialization that selects the first ``k`` items (indices 0 to k-1).
 
-        Selects items one-by-one, always picking the one that maximizes the diversity contribution wrt the
-        current selection.
-        Fast but seed-independent.
+        Deterministic and effectively free; mainly a baseline for testing and benchmarking.
         """
         from ._init_fast import InitFast
 
         return InitFast()
+
+    @classmethod
+    def farthest_point(cls) -> InitFarthestPoint:
+        """Farthest-point-sampling initialization: a seeded random start item, then greedy picks.
+
+        Each pick adds the item with the highest diversity contribution wrt the current selection —
+        classical farthest-point sampling under the separation-family metrics, the greedy max-sum
+        construction under ``MEAN_PAIRWISE_DISTANCE``.  Constraint-unaware by design; the
+        optimization phase repairs feasibility.
+        """
+        from ._init_farthest_point import InitFarthestPoint
+
+        return InitFarthestPoint()
 
     @classmethod
     def random_one_shot(cls, uniform: bool = False, ignore_constraints: bool = False) -> InitRandomOneShot:

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
@@ -1,0 +1,37 @@
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div._core._random import P_UNIFORM, randint
+from max_div._core.solver._solver_state import SolverState
+
+from ._base import InitializationStrategy
+
+
+class InitFarthestPoint(InitializationStrategy):
+    """Initialize by farthest-point sampling: a seeded random start item, then greedy picks.
+
+    After the start item, each step adds the not-yet-selected item with the highest diversity
+    contribution wrt the current selection.  Under the separation-family metrics that is the item
+    farthest from its nearest selected neighbor — classical farthest-point sampling (FPS); under
+    `MEAN_PAIRWISE_DISTANCE` it is the item with the highest mean distance to the selection — the
+    greedy max-sum construction.  The random start item keeps runs seed-dependent.
+
+    Constraints are ignored by design: greedy picks are constraint-unaware, and the optimization
+    phase repairs feasibility afterwards (the same posture the solver presets take when
+    initializing).
+
+    Suggested use: when the strongest possible starting point is desired, e.g. at short time
+    budgets.  The greedy construction matches the quality of dedicated single-shot FPS pickers.
+
+    Time Complexity:
+       - ~O(k * n) contribution reads, on top of the tracker updates any initialization incurs.
+    """
+
+    def get_next_samples(self, state: SolverState, k_remaining: int | np.int32) -> NDArray[np.int32]:
+        if state.n_selected == 0:
+            # seeded random start item
+            return randint(n=state.n, k=np.int32(1), replace=False, p=P_UNIFORM, rng_state=self._rng_state)
+        # greedy pick: the not-selected item with the highest contribution wrt the selection
+        # (both arrays below are ascending-index, so positions align)
+        contributions = state.not_selected_contribution_array
+        return np.array([state.not_selected_index_array[np.argmax(contributions)]], dtype=np.int32)

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
@@ -10,19 +10,21 @@ from ._base import InitializationStrategy
 class InitFarthestPoint(InitializationStrategy):
     """Initialize by farthest-point sampling: a seeded random start item, then greedy picks.
 
-    After the start item, each step adds the not-yet-selected item with the highest diversity
-    contribution wrt the current selection.  Under the separation-family metrics that is the item
-    farthest from its nearest selected neighbor — classical farthest-point sampling (FPS); under
-    `MEAN_PAIRWISE_DISTANCE` it is the item with the highest mean distance to the selection — the
-    greedy max-sum construction.  The random start item keeps runs seed-dependent.
+    Each pick adds the not-yet-selected item with the highest diversity contribution wrt the
+    current selection:
 
-    Constraints are ignored by design: greedy picks are constraint-unaware, and the optimization
-    phase repairs feasibility afterwards (the solver presets also ignore constraints during
-    initialization).
+    - separation-family metrics: the item farthest from its nearest selected neighbor
+      (classical farthest-point sampling);
+    - `MEAN_PAIRWISE_DISTANCE`: the item with the highest mean distance to the selection
+      (the greedy max-sum construction).
+
+    Constraints are ignored by design; feasibility is left to the optimization steps.
 
     Suggested use: when the strongest possible starting point is desired, e.g. at short time
-    budgets.  Costs ~O(k * n) contribution reads on top of the tracker updates any initialization
-    incurs.
+    budgets.
+
+    Time Complexity:
+       - ~O(n * k), times d when distances are computed on demand from vectors.
     """
 
     def get_next_samples(self, state: SolverState, k_remaining: int | np.int32) -> NDArray[np.int32]:

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
@@ -17,21 +17,17 @@ class InitFarthestPoint(InitializationStrategy):
     greedy max-sum construction.  The random start item keeps runs seed-dependent.
 
     Constraints are ignored by design: greedy picks are constraint-unaware, and the optimization
-    phase repairs feasibility afterwards (the same posture the solver presets take when
-    initializing).
+    phase repairs feasibility afterwards (the solver presets also ignore constraints during
+    initialization).
 
     Suggested use: when the strongest possible starting point is desired, e.g. at short time
-    budgets.  The greedy construction matches the quality of dedicated single-shot FPS pickers.
-
-    Time Complexity:
-       - ~O(k * n) contribution reads, on top of the tracker updates any initialization incurs.
+    budgets.  Costs ~O(k * n) contribution reads on top of the tracker updates any initialization
+    incurs.
     """
 
     def get_next_samples(self, state: SolverState, k_remaining: int | np.int32) -> NDArray[np.int32]:
         if state.n_selected == 0:
-            # seeded random start item
             return randint(n=state.n, k=np.int32(1), replace=False, p=P_UNIFORM, rng_state=self._rng_state)
-        # greedy pick: the not-selected item with the highest contribution wrt the selection
-        # (both arrays below are ascending-index, so positions align)
+        # both arrays below are ascending-index, so positions align
         contributions = state.not_selected_contribution_array
         return np.array([state.not_selected_index_array[np.argmax(contributions)]], dtype=np.int32)

--- a/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
+++ b/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
@@ -1,0 +1,78 @@
+import numpy as np
+import pytest
+
+from max_div._core.solver._solver_step import InitializationStep
+from max_div._core.solver._strategies import InitializationStrategy
+
+from ._helpers import new_solver_state
+
+
+@pytest.mark.parametrize("problem_has_constraints", [True, False])
+def test_init_farthest_point(problem_has_constraints: bool):
+    # --- arrange -----------------------------------------
+    solver_state = new_solver_state(problem_has_constraints)
+    strategy = InitializationStrategy.farthest_point()
+    init_step = InitializationStep(strategy)
+
+    # --- act ---------------------------------------------
+    init_step.run(solver_state)
+    score = solver_state.score
+
+    # --- assert ------------------------------------------
+    assert score.size == 1.0, "Selection size should be equal to k after initialization"
+
+
+def test_init_farthest_point_first_pick_is_seeded():
+    """The start item comes from the strategy's seeded RNG, so different seeds can differ."""
+    # --- arrange -----------------------------------------
+    first_items = []
+    for seed in (0, 1, 2, 3):
+        solver_state = new_solver_state(has_constraints=False)
+        strategy = InitializationStrategy.farthest_point()
+        strategy.set_seed(seed)
+
+        # --- act -----------------------------------------
+        first_items.append(int(strategy.get_next_samples(solver_state, solver_state.k)[0]))
+
+    # --- assert ------------------------------------------
+    assert len(set(first_items)) > 1, "Different seeds should be able to produce different start items"
+
+
+def test_init_farthest_point_picks_are_greedy():
+    """Every pick after the first is the argmax of contribution wrt the current selection."""
+    # --- arrange -----------------------------------------
+    solver_state = new_solver_state(has_constraints=False)
+    strategy = InitializationStrategy.farthest_point()
+    solver_state.add(np.int32(0))
+
+    # --- act ---------------------------------------------
+    picked = int(strategy.get_next_samples(solver_state, solver_state.k)[0])
+
+    # --- assert ------------------------------------------
+    contributions = solver_state.not_selected_contribution_array
+    expected = int(solver_state.not_selected_index_array[np.argmax(contributions)])
+    assert picked == expected, "Pick should be the highest-contribution not-selected item"
+    assert picked != 0, "The already-selected item should never be picked again"
+
+
+def test_init_farthest_point_beats_random_init():
+    """The greedy construction should start from a better min-separation than a random draw."""
+    # --- arrange -----------------------------------------
+    state_fps = new_solver_state(has_constraints=False)
+    state_random = new_solver_state(has_constraints=False)
+
+    # --- act ---------------------------------------------
+    InitializationStep(InitializationStrategy.farthest_point()).run(state_fps)
+    InitializationStep(InitializationStrategy.random_one_shot(uniform=True)).run(state_random)
+
+    # --- assert ------------------------------------------
+    assert state_fps.score.diversity > state_random.score.diversity
+
+
+def test_init_farthest_point_name():
+    """Test that the strategy name is generated as expected."""
+    # --- arrange / act -----------------------------------
+    strategy = InitializationStrategy.farthest_point()
+
+    # --- assert ------------------------------------------
+    assert strategy.name == "InitFarthestPoint"

--- a/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
+++ b/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
@@ -9,6 +9,7 @@ from ._helpers import new_solver_state
 
 @pytest.mark.parametrize("problem_has_constraints", [True, False])
 def test_init_farthest_point(problem_has_constraints: bool):
+    """Initialization reaches the full selection size, with and without constraints."""
     # --- arrange -----------------------------------------
     solver_state = new_solver_state(problem_has_constraints)
     strategy = InitializationStrategy.farthest_point()
@@ -24,14 +25,12 @@ def test_init_farthest_point(problem_has_constraints: bool):
 
 def test_init_farthest_point_first_pick_is_seeded():
     """The start item comes from the strategy's seeded RNG, so different seeds can differ."""
-    # --- arrange -----------------------------------------
+    # --- arrange / act -----------------------------------
     first_items = []
     for seed in (0, 1, 2, 3):
         solver_state = new_solver_state(has_constraints=False)
         strategy = InitializationStrategy.farthest_point()
         strategy.set_seed(seed)
-
-        # --- act -----------------------------------------
         first_items.append(int(strategy.get_next_samples(solver_state, solver_state.k)[0]))
 
     # --- assert ------------------------------------------
@@ -56,7 +55,7 @@ def test_init_farthest_point_picks_are_greedy():
 
 
 def test_init_farthest_point_beats_random_init():
-    """The greedy construction should start from a better min-separation than a random draw."""
+    """The greedy construction should start from a better diversity score than a random draw."""
     # --- arrange -----------------------------------------
     state_fps = new_solver_state(has_constraints=False)
     state_random = new_solver_state(has_constraints=False)


### PR DESCRIPTION
**Problem**: The solver's presets initialize uniformly at random, so at short budgets on large problems it starts far below the greedy constructions dedicated single-shot pickers use — the published comparison benchmarks show it trailing every farthest-point picker at n=20000 around 1 s.

**Solution**: A new opt-in `InitializationStrategy.farthest_point()`: a seeded random start item, then k−1 greedy picks of the highest-contribution item, read from the separation tracker the solver already maintains. Under separation metrics that is classical farthest-point sampling; under `MEAN_PAIRWISE_DISTANCE` the same loop is the greedy max-sum construction. Constraint-unaware by design — the optimization phase repairs feasibility, as preset initialization already assumes.

- **Attention:** presets are untouched; this strategy is only active when selected on the builder, so existing selections and the golden master are unchanged.
- **Attention:** the `fast()` factory docstring and the concepts-page table described a greedy method `InitFast` never implemented (it selects the first k items); both corrected here.
- **SPIKE:** init-only runs on the four benchmark problems at n=20000: quality within ±0.3% of every farthest-point picker (ahead of all tools on the hardest problem), at ~0.1 s where those pickers spend 1.4–70 s, and above the solver's own recorded random-init quality at equal duration.
- **TEST:** 6 unit tests added — full-size initialization with/without constraints, seeded start-item variation, greedy-pick correctness against the tracker signal, quality vs. random init, and the strategy name.

**Changelog** (Added):
```
A farthest-point-sampling initialization strategy (`InitializationStrategy.farthest_point()`): the greedy construction farthest-point-sampling tools use, computed from the solver's own distance store, selectable via `MaxDivSolverBuilder.set_initialization_strategy`
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
