### PR TITLE
fix: build the constraint index array without per-element python loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Distance-store construction is multi-threaded, roughly 7× faster (depending on CPU architecture) at large problem sizes; parallel builds are bit-identical to the single-threaded ones, and `MAXDIV_PARALLEL_BUILD=0` disables it
-- Constrained problems set up roughly 9× faster at large total constraint membership: the internal constraint arrays are built with numpy instead of per-element Python loops
+- Constrained problems set up roughly 9× faster when the constraints together contain many item indices: the internal constraint arrays are built with numpy instead of per-element Python loops
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Distance-store construction is multi-threaded, roughly 7× faster (depending on CPU architecture) at large problem sizes; parallel builds are bit-identical to the single-threaded ones, and `MAXDIV_PARALLEL_BUILD=0` disables it
+- Constrained problems set up roughly 9× faster at large total constraint membership: the internal constraint arrays are built with numpy instead of per-element Python loops
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Distance-store construction is multi-threaded, roughly 7× faster (depending on CPU architecture) at large problem sizes; parallel builds are bit-identical to the single-threaded ones, and `MAXDIV_PARALLEL_BUILD=0` disables it
-- Constrained problems set up roughly 9× faster when the constraints together contain many item indices: the internal constraint arrays are built with numpy instead of per-element Python loops
+- Constrained problems set up roughly 9× faster when the constraints together contain many item indices, via numpy vectorization of the internal constraint-array construction
 
 ### Deprecated
 

--- a/src/max_div/_core/constraints/_constraints.py
+++ b/src/max_div/_core/constraints/_constraints.py
@@ -110,8 +110,8 @@ def _build_array_repr(
         con_values[i, 0] = np.int32(con.min_count)
         con_values[i, 1] = np.int32(con.max_count)
 
-    # build con_indices  (per-element work stays in numpy: total membership can reach many
-    # millions, where a Python loop over the elements costs seconds)
+    # build con_indices  (per-element work stays in numpy: n_indices can reach many millions,
+    # where a Python loop over the elements costs seconds)
     i_start = 2 * m  # where we start filling in values from int_set for each constraint
     for i, con in enumerate(cons):
         i_end = i_start + len(con.int_set)

--- a/src/max_div/_core/constraints/_constraints.py
+++ b/src/max_div/_core/constraints/_constraints.py
@@ -110,14 +110,17 @@ def _build_array_repr(
         con_values[i, 0] = np.int32(con.min_count)
         con_values[i, 1] = np.int32(con.max_count)
 
-    # build con_indices
+    # build con_indices  (per-element work stays in numpy: total membership can reach many
+    # millions, where a Python loop over the elements costs seconds)
     i_start = 2 * m  # where we start filling in values from int_set for each constraint
     for i, con in enumerate(cons):
+        i_end = i_start + len(con.int_set)
         con_indices[2 * i] = np.int32(i_start)
-        con_indices[(2 * i) + 1] = np.int32(i_start + len(con.int_set))
-        for idx in sorted(con.int_set):
-            con_indices[i_start] = np.int32(idx)
-            i_start += 1
+        con_indices[(2 * i) + 1] = np.int32(i_end)
+        segment = np.fromiter(con.int_set, dtype=np.int32, count=len(con.int_set))
+        segment.sort()
+        con_indices[i_start:i_end] = segment
+        i_start = i_end
 
     return con_values, con_indices
 

--- a/src/max_div/_core/constraints/_constraints.py
+++ b/src/max_div/_core/constraints/_constraints.py
@@ -110,13 +110,13 @@ def _build_array_repr(
         con_values[i, 0] = np.int32(con.min_count)
         con_values[i, 1] = np.int32(con.max_count)
 
-    # build con_indices  (per-element work stays in numpy: n_indices can reach many millions,
-    # where a Python loop over the elements costs seconds)
+    # build con_indices
     i_start = 2 * m  # where we start filling in values from int_set for each constraint
     for i, con in enumerate(cons):
         i_end = i_start + len(con.int_set)
         con_indices[2 * i] = np.int32(i_start)
         con_indices[(2 * i) + 1] = np.int32(i_end)
+        # vectorize indices assignment for speed
         segment = np.fromiter(con.int_set, dtype=np.int32, count=len(con.int_set))
         segment.sort()
         con_indices[i_start:i_end] = segment


### PR DESCRIPTION
**Problem**: `_build_array_repr` filled `con_indices` by iterating every constraint member in Python with a per-element `np.int32` cast — ~1.9 s at 10M members, a fixed setup cost paid by every constrained solve and material at short solve budgets.

**Solution**: keep the per-constraint loop but move the per-element work into numpy — `np.fromiter` over each `int_set`, in-place sort, slice assignment. Output is bit-identical; ~0.22 s (~9×) on the same 10M-member problem.

- **TEST:** old vs new build compared on 200 randomized constraint sets — `con_values` and `con_indices` identical; existing format-pinning tests unchanged and green.

**Changelog** (Changed):
```
Constrained problems set up roughly 9× faster when the constraints together contain many item indices: the internal constraint arrays are built with numpy instead of per-element Python loops
```

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
