### PR TITLE
chore: solve one problem in several worker processes

### DIFF
--- a/src/max_div/_core/solver/_parallel/__init__.py
+++ b/src/max_div/_core/solver/_parallel/__init__.py
@@ -1,0 +1,23 @@
+"""Solving one problem in several processes at once, and picking the best of what they find.
+
+Every worker reads the same distances out of shared memory and runs its own search over them, so
+what varies between workers is the search, never the objective.  The pieces:
+
+  - `_coordinator` is the seam a worker reaches at each batch boundary.  Independent workers do
+    nothing there, and a mode that shares an incumbent would do it in that one place.
+  - `_result` is what a worker sends back, and the rule that picks a winner among several.
+  - `_executor` starts the workers, collects what they report, and shuts them down.
+"""
+
+from ._coordinator import IndependentCoordinator, WorkerCoordinator
+from ._executor import run_portfolio, solve_in_worker
+from ._result import WorkerResult, best_result
+
+__all__ = [
+    "IndependentCoordinator",
+    "WorkerCoordinator",
+    "WorkerResult",
+    "best_result",
+    "run_portfolio",
+    "solve_in_worker",
+]

--- a/src/max_div/_core/solver/_parallel/__init__.py
+++ b/src/max_div/_core/solver/_parallel/__init__.py
@@ -1,11 +1,7 @@
-"""Several worker processes solve one problem at once, and the best result they find wins.
+"""Several worker processes — a portfolio — solve one problem at once, and the best result wins.
 
 Every worker reads the same distances out of shared memory and runs its own search over them, so
-what varies between workers is the search, never the objective.  The pieces:
-
-  - `_coordinator` is what a worker calls at each batch boundary.
-  - `_result` is what a worker sends back, and the rule that picks a winner.
-  - `_executor` starts the workers, collects what they report, and shuts them down.
+what varies between workers is the search, never the objective.
 """
 
 from ._coordinator import IndependentCoordinator, WorkerCoordinator

--- a/src/max_div/_core/solver/_parallel/__init__.py
+++ b/src/max_div/_core/solver/_parallel/__init__.py
@@ -1,11 +1,10 @@
-"""Solving one problem in several processes at once, and picking the best of what they find.
+"""Several worker processes solve one problem at once, and the best result they find wins.
 
 Every worker reads the same distances out of shared memory and runs its own search over them, so
 what varies between workers is the search, never the objective.  The pieces:
 
-  - `_coordinator` is the seam a worker reaches at each batch boundary.  Independent workers do
-    nothing there, and a mode that shares an incumbent would do it in that one place.
-  - `_result` is what a worker sends back, and the rule that picks a winner among several.
+  - `_coordinator` is what a worker calls at each batch boundary.
+  - `_result` is what a worker sends back, and the rule that picks a winner.
   - `_executor` starts the workers, collects what they report, and shuts them down.
 """
 

--- a/src/max_div/_core/solver/_parallel/_coordinator.py
+++ b/src/max_div/_core/solver/_parallel/_coordinator.py
@@ -1,7 +1,7 @@
-"""A worker calls its coordinator at each batch boundary, whether or not it has anything to say.
+"""A worker calls its coordinator at every batch boundary.
 
-The call happens on every batch even when it does nothing, so a worker with something to share
-reaches the others through a path that already runs.
+Even a worker with nothing to share makes the call, so the path a sharing worker would use already
+runs.
 """
 
 from abc import ABC, abstractmethod

--- a/src/max_div/_core/solver/_parallel/_coordinator.py
+++ b/src/max_div/_core/solver/_parallel/_coordinator.py
@@ -1,7 +1,7 @@
 """A worker calls its coordinator at each batch boundary, whether or not it has anything to say.
 
-The call happens on every batch even when it does nothing, so the one place a worker could reach
-the rest of the portfolio from is a path that runs rather than one that merely exists.
+The call happens on every batch even when it does nothing, so a worker with something to share
+reaches the others through a path that already runs.
 """
 
 from abc import ABC, abstractmethod
@@ -14,14 +14,14 @@ class WorkerCoordinator(ABC):
 
     @abstractmethod
     def at_batch_boundary(self, state: SolverState) -> None:
-        """React to a worker finishing a batch, with the state it holds at that moment.
+        """React to a worker finishing a batch, with the state the worker holds at that moment.
 
         Called on every batch of every optimization step, so keep an implementation cheap.
         """
 
 
 class IndependentCoordinator(WorkerCoordinator):
-    """Workers that share nothing hold this coordinator, and every call on it does nothing."""
+    """Workers that share nothing hold this coordinator."""
 
     def at_batch_boundary(self, state: SolverState) -> None:
         """Do nothing: an independent worker has nobody to tell and nothing to ask."""

--- a/src/max_div/_core/solver/_parallel/_coordinator.py
+++ b/src/max_div/_core/solver/_parallel/_coordinator.py
@@ -1,0 +1,37 @@
+"""The handle a worker holds on the rest of the portfolio, called at every batch boundary.
+
+Workers reach this seam whether or not they use it.  Independent workers never exchange anything,
+so the coordinator they hold does nothing — but the call still happens on every batch, which keeps
+the seam exercised rather than merely present, and leaves one place for a mode that does share to
+publish its selection or consult someone else's.
+
+The batch boundary is where the optimization step already pauses to record a score checkpoint, so
+sharing costs a worker no additional interruption.
+"""
+
+from abc import ABC, abstractmethod
+
+from max_div._core.solver._solver_state import SolverState
+
+
+class WorkerCoordinator(ABC):
+    """What a worker may tell the rest of the portfolio, and ask of it, between batches."""
+
+    @abstractmethod
+    def at_batch_boundary(self, state: SolverState) -> None:
+        """React to a worker reaching the end of a batch, with its current state in hand.
+
+        Called on every batch of every optimization step, so an implementation that does real work
+        is responsible for its own cost.
+        """
+
+
+class IndependentCoordinator(WorkerCoordinator):
+    """The coordinator of workers that share nothing: every call is a no-op.
+
+    Independent solving is the whole of what this class expresses — each worker runs its own seeded
+    search start to finish, and the portfolio compares only the results.
+    """
+
+    def at_batch_boundary(self, state: SolverState) -> None:
+        """Do nothing: an independent worker has nobody to tell and nothing to ask."""

--- a/src/max_div/_core/solver/_parallel/_coordinator.py
+++ b/src/max_div/_core/solver/_parallel/_coordinator.py
@@ -1,12 +1,7 @@
-"""The handle a worker holds on the rest of the portfolio, called at every batch boundary.
+"""A worker calls its coordinator at each batch boundary, whether or not it has anything to say.
 
-Workers reach this seam whether or not they use it.  Independent workers never exchange anything,
-so the coordinator they hold does nothing — but the call still happens on every batch, which keeps
-the seam exercised rather than merely present, and leaves one place for a mode that does share to
-publish its selection or consult someone else's.
-
-The batch boundary is where the optimization step already pauses to record a score checkpoint, so
-sharing costs a worker no additional interruption.
+The call happens on every batch even when it does nothing, so the one place a worker could reach
+the rest of the portfolio from is a path that runs rather than one that merely exists.
 """
 
 from abc import ABC, abstractmethod
@@ -15,23 +10,18 @@ from max_div._core.solver._solver_state import SolverState
 
 
 class WorkerCoordinator(ABC):
-    """What a worker may tell the rest of the portfolio, and ask of it, between batches."""
+    """A worker uses its coordinator to reach the other workers solving the same problem."""
 
     @abstractmethod
     def at_batch_boundary(self, state: SolverState) -> None:
-        """React to a worker reaching the end of a batch, with its current state in hand.
+        """React to a worker finishing a batch, with the state it holds at that moment.
 
-        Called on every batch of every optimization step, so an implementation that does real work
-        is responsible for its own cost.
+        Called on every batch of every optimization step, so keep an implementation cheap.
         """
 
 
 class IndependentCoordinator(WorkerCoordinator):
-    """The coordinator of workers that share nothing: every call is a no-op.
-
-    Independent solving is the whole of what this class expresses — each worker runs its own seeded
-    search start to finish, and the portfolio compares only the results.
-    """
+    """Workers that share nothing hold this coordinator, and every call on it does nothing."""
 
     def at_batch_boundary(self, state: SolverState) -> None:
         """Do nothing: an independent worker has nobody to tell and nothing to ask."""

--- a/src/max_div/_core/solver/_parallel/_executor.py
+++ b/src/max_div/_core/solver/_parallel/_executor.py
@@ -33,13 +33,12 @@ def run_portfolio(
 ) -> list[WorkerResult]:
     """Solve one configuration per worker over the published store, and return what each reported.
 
-    Returns in worker order rather than arrival order, so the caller sees the same list whichever
-    worker happens to finish first.  A worker that dies without reporting is left out rather than
-    fatal; `best_result` raises when none came back.
+    Results come back in worker order rather than arrival order, so the caller sees the same list
+    whichever worker happens to finish first.  A worker that dies without reporting is left out rather than
+    treated as an error; `best_result` raises when none came back.
 
     :param configs: one solver configuration per worker, in worker order.
-    :param spec: the published store every worker attaches to.
-    :param coordinator: the `WorkerCoordinator` handed to every worker.
+    :param spec: where the published store lives; every worker attaches to it.
     """
     context = multiprocessing.get_context("spawn")
     results: Queue = context.Queue()
@@ -65,8 +64,8 @@ def solve_in_worker(
 ) -> None:
     """Solve one configuration in this process and report the result, then release the store.
 
-    The entry point of a spawned worker, so it must stay importable by name — a spawned child
-    reconstructs it from the module path rather than inheriting it.
+    This function is the entry point of a spawned worker, so it must stay importable by name — a
+    spawned child reconstructs the function from its module path rather than inheriting it.
     """
     with attached_distance_store(spec) as store:
         solution = config.build_solver(store).solve(verbosity=0, coordinator=coordinator)

--- a/src/max_div/_core/solver/_parallel/_executor.py
+++ b/src/max_div/_core/solver/_parallel/_executor.py
@@ -1,0 +1,116 @@
+"""Running one solver per worker process over a single shared store, and collecting what they find.
+
+Workers are **spawned, never forked**.  The parent runs numba parallel code while building the
+distance store, and numba's threading layer does not survive a fork — a forked child deadlocks on
+its first parallel call.
+
+Each worker is a process rather than a thread because the search is Python-level and would contend
+on the interpreter lock.  Only the distances are shared; every worker allocates its own trackers,
+which are small next to the distances.
+"""
+
+import multiprocessing
+import queue as queue_module
+from collections.abc import Sequence
+from multiprocessing.process import BaseProcess
+from multiprocessing.queues import Queue
+
+from max_div._core.metrics._distance import SharedStoreSpec, attached_distance_store
+from max_div._core.solver._solver_config import SolverConfig
+
+from ._coordinator import WorkerCoordinator
+from ._result import WorkerResult
+
+# How long to wait on the result queue before checking again whether any worker is still alive.
+_POLL_SECONDS = 0.2
+
+# How long to wait for a worker that has reported its result to exit on its own.
+_JOIN_SECONDS = 30.0
+
+
+def run_portfolio(
+    configs: list[SolverConfig], spec: SharedStoreSpec, coordinator: WorkerCoordinator
+) -> list[WorkerResult]:
+    """Solve one configuration per worker over the published store, and return what each reported.
+
+    Returns in worker order rather than arrival order, so the caller sees the same list whichever
+    worker happens to finish first.  A worker that dies without reporting is absent from the result
+    rather than fatal: the portfolio is worth what its survivors found, and `best_result` is what
+    decides whether anything usable came back.
+
+    :param configs: one solver configuration per worker, in worker order.
+    :param spec: the published store every worker attaches to.
+    :param coordinator: handle each worker reaches at its batch boundaries.
+    """
+    context = multiprocessing.get_context("spawn")
+    results: Queue = context.Queue()
+    workers = [
+        context.Process(target=solve_in_worker, args=(index, config, spec, coordinator, results), daemon=True)
+        for index, config in enumerate(configs)
+    ]
+    for worker in workers:
+        worker.start()
+    try:
+        collected = _collect(results, workers)
+    finally:
+        _shut_down(workers)
+    return sorted(collected, key=lambda result: result.worker_index)
+
+
+def solve_in_worker(
+    worker_index: int,
+    config: SolverConfig,
+    spec: SharedStoreSpec,
+    coordinator: WorkerCoordinator,
+    results: Queue,
+) -> None:
+    """Solve one configuration in this process and report the result, then release the store.
+
+    The entry point of a spawned worker, so it must stay importable by name — a spawned child
+    reconstructs it from the module path rather than inheriting it.
+    """
+    with attached_distance_store(spec) as store:
+        solution = config.build_solver(store).solve(verbosity=0, coordinator=coordinator)
+        results.put(
+            WorkerResult(
+                worker_index=worker_index,
+                i_selected=solution.i_selected,
+                score=solution.score,
+                elapsed=solution.duration,
+                seed=config.seed,
+            )
+        )
+
+
+def _collect(results: Queue, workers: Sequence[BaseProcess]) -> list[WorkerResult]:
+    """Take results off the queue until every worker has reported or none is left alive."""
+    collected: list[WorkerResult] = []
+    while len(collected) < len(workers):
+        try:
+            collected.append(results.get(timeout=_POLL_SECONDS))
+        except queue_module.Empty:
+            if not any(worker.is_alive() for worker in workers):
+                # one last look: a worker can exit with its result still in flight through the queue
+                collected.extend(_drain(results, limit=len(workers) - len(collected)))
+                break
+    return collected
+
+
+def _drain(results: Queue, limit: int) -> list[WorkerResult]:
+    """Take whatever is already on the queue, up to `limit` results."""
+    drained: list[WorkerResult] = []
+    for _ in range(limit):
+        try:
+            drained.append(results.get(timeout=_POLL_SECONDS))
+        except queue_module.Empty:
+            break
+    return drained
+
+
+def _shut_down(workers: Sequence[BaseProcess]) -> None:
+    """Wait for each worker to exit, killing any that will not."""
+    for worker in workers:
+        worker.join(timeout=_JOIN_SECONDS)
+        if worker.is_alive():
+            worker.terminate()
+            worker.join(timeout=_JOIN_SECONDS)

--- a/src/max_div/_core/solver/_parallel/_executor.py
+++ b/src/max_div/_core/solver/_parallel/_executor.py
@@ -1,12 +1,12 @@
-"""Running one solver per worker process over a single shared store, and collecting what they find.
+"""One solver runs per worker process over a single shared store, and the executor collects the results.
 
 Workers are **spawned, never forked**.  The parent runs numba parallel code while building the
 distance store, and numba's threading layer does not survive a fork — a forked child deadlocks on
 its first parallel call.
 
 Each worker is a process rather than a thread because the search is Python-level and would contend
-on the interpreter lock.  Only the distances are shared; every worker allocates its own trackers,
-which are small next to the distances.
+on the interpreter lock.  Only the distances are shared; every worker allocates its own bookkeeping,
+which is small next to the distances.
 """
 
 import multiprocessing
@@ -34,13 +34,12 @@ def run_portfolio(
     """Solve one configuration per worker over the published store, and return what each reported.
 
     Returns in worker order rather than arrival order, so the caller sees the same list whichever
-    worker happens to finish first.  A worker that dies without reporting is absent from the result
-    rather than fatal: the portfolio is worth what its survivors found, and `best_result` is what
-    decides whether anything usable came back.
+    worker happens to finish first.  A worker that dies without reporting is left out rather than
+    fatal; `best_result` raises when none came back.
 
     :param configs: one solver configuration per worker, in worker order.
     :param spec: the published store every worker attaches to.
-    :param coordinator: handle each worker reaches at its batch boundaries.
+    :param coordinator: the `WorkerCoordinator` handed to every worker.
     """
     context = multiprocessing.get_context("spawn")
     results: Queue = context.Queue()
@@ -97,7 +96,7 @@ def _collect(results: Queue, workers: Sequence[BaseProcess]) -> list[WorkerResul
 
 
 def _drain(results: Queue, limit: int) -> list[WorkerResult]:
-    """Take whatever is already on the queue, up to `limit` results."""
+    """Take up to `limit` more results, giving each a short wait before giving up."""
     drained: list[WorkerResult] = []
     for _ in range(limit):
         try:

--- a/src/max_div/_core/solver/_parallel/_executor.py
+++ b/src/max_div/_core/solver/_parallel/_executor.py
@@ -39,6 +39,7 @@ def run_portfolio(
 
     :param configs: one solver configuration per worker, in worker order.
     :param spec: where the published store lives; every worker attaches to it.
+    :param coordinator: reached by every worker at each batch boundary; an independent one shares nothing.
     """
     context = multiprocessing.get_context("spawn")
     results: Queue = context.Queue()

--- a/src/max_div/_core/solver/_parallel/_result.py
+++ b/src/max_div/_core/solver/_parallel/_result.py
@@ -11,7 +11,7 @@ from max_div._core.solver._score import Score
 
 @dataclass(frozen=True)
 class WorkerResult:
-    """A result records one worker's selection, what it scored, and what it cost."""
+    """A result records what one worker selected, what the selection scored, and what the search cost."""
 
     worker_index: int
     i_selected: NDArray[np.int32]
@@ -23,7 +23,7 @@ class WorkerResult:
 def best_result(results: list[WorkerResult]) -> WorkerResult:
     """Return the highest-scoring result, ties going to the lowest worker index.
 
-    Ties break by index rather than by arrival, so the same seeds give the same winner every run.
+    The same seeds give the same winner every run, whichever worker reports first.
 
     :param results: what each worker reported; workers that failed are simply absent.
     :raises ValueError: If no results were collected, which means every worker failed.

--- a/src/max_div/_core/solver/_parallel/_result.py
+++ b/src/max_div/_core/solver/_parallel/_result.py
@@ -1,0 +1,40 @@
+"""What a worker sends back, and how the best of several is chosen.
+
+The payload is the selection and its score rather than a whole solution: a mode that shares an
+incumbent mid-run sends this same record far more often, so it is kept to what a receiver can act
+on.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from max_div._core.solver._duration import Elapsed
+from max_div._core.solver._score import Score
+
+
+@dataclass(frozen=True)
+class WorkerResult:
+    """One worker's selection, what it scored, and what it cost to get there."""
+
+    worker_index: int
+    i_selected: NDArray[np.int32]
+    score: Score
+    elapsed: Elapsed
+    seed: int
+
+
+def best_result(results: list[WorkerResult]) -> WorkerResult:
+    """Return the winning result: the highest score, and among equal scores the lowest worker index.
+
+    Breaking ties by index rather than by arrival makes the winner a property of the results instead
+    of a race between processes, so a portfolio run twice over the same seeds returns the same
+    selection both times.
+
+    Raises:
+        ValueError: If no results were collected, which means every worker failed.
+    """
+    if not results:
+        raise ValueError("A portfolio returned no results at all; every worker failed to report one.")
+    return max(results, key=lambda result: (result.score, -result.worker_index))

--- a/src/max_div/_core/solver/_parallel/_result.py
+++ b/src/max_div/_core/solver/_parallel/_result.py
@@ -1,9 +1,4 @@
-"""What a worker sends back, and how the best of several is chosen.
-
-The payload is the selection and its score rather than a whole solution: a mode that shares an
-incumbent mid-run sends this same record far more often, so it is kept to what a receiver can act
-on.
-"""
+"""A worker sends back a result, and `best_result` picks the winner among several."""
 
 from dataclasses import dataclass
 
@@ -16,7 +11,7 @@ from max_div._core.solver._score import Score
 
 @dataclass(frozen=True)
 class WorkerResult:
-    """One worker's selection, what it scored, and what it cost to get there."""
+    """A result records one worker's selection, what it scored, and what it cost."""
 
     worker_index: int
     i_selected: NDArray[np.int32]
@@ -26,14 +21,12 @@ class WorkerResult:
 
 
 def best_result(results: list[WorkerResult]) -> WorkerResult:
-    """Return the winning result: the highest score, and among equal scores the lowest worker index.
+    """Return the highest-scoring result, ties going to the lowest worker index.
 
-    Breaking ties by index rather than by arrival makes the winner a property of the results instead
-    of a race between processes, so a portfolio run twice over the same seeds returns the same
-    selection both times.
+    Ties break by index rather than by arrival, so the same seeds give the same winner every run.
 
-    Raises:
-        ValueError: If no results were collected, which means every worker failed.
+    :param results: what each worker reported; workers that failed are simply absent.
+    :raises ValueError: If no results were collected, which means every worker failed.
     """
     if not results:
         raise ValueError("A portfolio returned no results at all; every worker failed to report one.")

--- a/src/max_div/_core/solver/_solver.py
+++ b/src/max_div/_core/solver/_solver.py
@@ -14,7 +14,7 @@ from ._solver_state import SolverState
 from ._solver_step import SolverStep, SolverStepResult
 
 if TYPE_CHECKING:
-    from max_div._core.solver._parallel import WorkerCoordinator
+    from ._parallel import WorkerCoordinator
 
 
 class MaxDivSolver:
@@ -85,8 +85,8 @@ class MaxDivSolver:
                                    23  -->  fastest updates  (spacing increasing with  1%).
 
                                    25  -->  debug mode       (1% spacing + debug info column)
-        :param coordinator: reached at each batch boundary, so a worker solving alongside others has
-                            one place to share from.  A solve on its own passes nothing.
+        :param coordinator: a `WorkerCoordinator` the solver calls at each batch boundary, so a worker
+                            running alongside others has one place to reach them from.
         :return: A MaxDivSolution object representing the solution found.
         """
         # --- Init ----------------------------------------

--- a/src/max_div/_core/solver/_solver.py
+++ b/src/max_div/_core/solver/_solver.py
@@ -85,8 +85,7 @@ class MaxDivSolver:
                                    23  -->  fastest updates  (spacing increasing with  1%).
 
                                    25  -->  debug mode       (1% spacing + debug info column)
-        :param coordinator: a `WorkerCoordinator` the solver calls at each batch boundary, so a worker
-                            running alongside others has one place to reach them from.
+        :param coordinator: a `WorkerCoordinator` the solver calls at each batch boundary.
         :return: A MaxDivSolution object representing the solution found.
         """
         # --- Init ----------------------------------------

--- a/src/max_div/_core/solver/_solver.py
+++ b/src/max_div/_core/solver/_solver.py
@@ -1,3 +1,5 @@
+from typing import TYPE_CHECKING
+
 from max_div._core._utils import Timer, deterministic_hash, ljust_str_list
 from max_div._core.constraints import Constraint
 from max_div._core.constraints._constraints import _np_con_count_satisfied
@@ -10,6 +12,9 @@ from ._progress_reporting import ProgressReporter
 from ._solution import MaxDivSolution
 from ._solver_state import SolverState
 from ._solver_step import SolverStep, SolverStepResult
+
+if TYPE_CHECKING:
+    from max_div._core.solver._parallel import WorkerCoordinator
 
 
 class MaxDivSolver:
@@ -67,7 +72,7 @@ class MaxDivSolver:
     # -------------------------------------------------------------------------
     #  API
     # -------------------------------------------------------------------------
-    def solve(self, verbosity: int = 10) -> MaxDivSolution:
+    def solve(self, verbosity: int = 10, coordinator: "WorkerCoordinator | None" = None) -> MaxDivSolution:
         """Solve the maximum diversity problem with the given configuration.
 
         :param verbosity: (int) The verbosity level.
@@ -80,6 +85,8 @@ class MaxDivSolver:
                                    23  -->  fastest updates  (spacing increasing with  1%).
 
                                    25  -->  debug mode       (1% spacing + debug info column)
+        :param coordinator: reached at each batch boundary, so a worker solving alongside others has
+                            one place to share from.  A solve on its own passes nothing.
         :return: A MaxDivSolution object representing the solution found.
         """
         # --- Init ----------------------------------------
@@ -138,7 +145,7 @@ class MaxDivSolver:
         for step_name, step_seed, step in zip(step_names[1:], step_seeds, self._solver_steps):
             progress_reporter.solver_step_started(step_name)
             step.set_seed(step_seed)
-            step_results[step_name.strip()] = step.run(state, progress_reporter)
+            step_results[step_name.strip()] = step.run(state, progress_reporter, coordinator)
 
         # --- Construct result ----------------------------
         return self._construct_final_solution(state, step_results)

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -13,6 +13,7 @@ from ._distance_storage import (
 from ._duration import TargetDuration
 from ._presets import SolverPreset, get_preset_strategies
 from ._solver import MaxDivSolver
+from ._solver_config import SolverConfig
 from ._solver_step import InitializationStep, OptimizationStep, SolverStep
 from ._strategies import InitializationStrategy
 
@@ -159,12 +160,21 @@ class MaxDivSolverBuilder:
         return []
 
     def build(self) -> MaxDivSolver:
+        """Build the distance store this configuration calls for, and a solver reading it."""
+        resolved, config = self.resolve()
+        return config.build_solver(build_distance_store(self._problem, resolved))
+
+    def resolve(self) -> tuple[DistanceStorage, SolverConfig]:
+        """Return the backend this configuration resolves to, and the solver config over it.
+
+        The two halves of `build` kept apart, for callers that produce the distances themselves —
+        a portfolio builds one store into shared memory and assembles a solver per worker over it,
+        where `build` would produce a store per solver.
+        """
         resolved = resolve_distance_storage(self._problem, self._distance_storage, total_physical_memory_bytes())
         label = resolved.value + (" (auto)" if self._distance_storage == DistanceStorage.AUTO else "")
-        return MaxDivSolver(
+        return resolved, SolverConfig(
             n=self._n,
-            store=build_distance_store(self._problem, resolved),
-            distance_storage_label=label,
             k=self._k,
             diversity_metric=self._diversity_metric,
             diversity_tie_breakers=self._determine_diversity_tie_breakers(),
@@ -172,4 +182,5 @@ class MaxDivSolverBuilder:
             solver_steps=self._solver_steps,
             seed=self._seed,
             constraint_penalty=self._constraint_penalty,
+            distance_storage_label=label,
         )

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -161,15 +161,15 @@ class MaxDivSolverBuilder:
 
     def build(self) -> MaxDivSolver:
         """Build the distance store this configuration calls for, and a solver reading it."""
-        resolved, config = self.resolve()
+        resolved, config = self.resolve_storage_and_config()
         return config.build_solver(build_distance_store(self._problem, resolved))
 
-    def resolve(self) -> tuple[DistanceStorage, SolverConfig]:
+    def resolve_storage_and_config(self) -> tuple[DistanceStorage, SolverConfig]:
         """Return the backend this configuration resolves to, and the solver config over it.
 
-        `build` runs these two halves together.  Keeping them apart lets a caller produce the
-        distances once and assemble a solver per worker over them, where `build` would produce a
-        store per solver.
+        `build` resolves the backend and builds the store in one call.  Keeping the two apart lets
+        a caller produce the distances once and assemble a solver per worker over them, where
+        `build` would produce a store per solver.
         """
         resolved = resolve_distance_storage(self._problem, self._distance_storage, total_physical_memory_bytes())
         label = resolved.value + (" (auto)" if self._distance_storage == DistanceStorage.AUTO else "")

--- a/src/max_div/_core/solver/_solver_builder.py
+++ b/src/max_div/_core/solver/_solver_builder.py
@@ -167,9 +167,9 @@ class MaxDivSolverBuilder:
     def resolve(self) -> tuple[DistanceStorage, SolverConfig]:
         """Return the backend this configuration resolves to, and the solver config over it.
 
-        The two halves of `build` kept apart, for callers that produce the distances themselves —
-        a portfolio builds one store into shared memory and assembles a solver per worker over it,
-        where `build` would produce a store per solver.
+        `build` runs these two halves together.  Keeping them apart lets a caller produce the
+        distances once and assemble a solver per worker over them, where `build` would produce a
+        store per solver.
         """
         resolved = resolve_distance_storage(self._problem, self._distance_storage, total_physical_memory_bytes())
         label = resolved.value + (" (auto)" if self._distance_storage == DistanceStorage.AUTO else "")

--- a/src/max_div/_core/solver/_solver_config.py
+++ b/src/max_div/_core/solver/_solver_config.py
@@ -1,4 +1,4 @@
-"""A solver's configuration, held apart from the distances it will read.
+"""A solver's configuration is held apart from the distances it will read.
 
 A store and the rest of a solver are separated because a store is produced once and read by several
 processes, while each process assembles its own solver over that store from a copy of this record —

--- a/src/max_div/_core/solver/_solver_config.py
+++ b/src/max_div/_core/solver/_solver_config.py
@@ -1,8 +1,8 @@
 """A solver's configuration, held apart from the distances it will read.
 
-Everything `MaxDivSolver` needs except its store, in one record small enough to pickle.  Building a
-solver is two steps for that reason: the distances are produced once and can be shared between
-processes, while each process assembles its own solver over them from a copy of this record.
+Everything `MaxDivSolver` needs except its store.  The two are separated because a store is
+produced once and read by several processes, while each process assembles its own solver over it
+from a copy of this record — which is why the record must stay small enough to pickle.
 """
 
 from dataclasses import dataclass, replace
@@ -18,11 +18,7 @@ from ._solver_step import SolverStep
 
 @dataclass(frozen=True)
 class SolverConfig:
-    """Everything a solver needs apart from the distances it reads.
-
-    Holds no distances and no problem, so it stays small however large the problem is — which is
-    what lets it travel to a worker process while the distances travel through shared memory.
-    """
+    """A config holds everything a solver needs apart from the distances it reads."""
 
     n: int
     k: int

--- a/src/max_div/_core/solver/_solver_config.py
+++ b/src/max_div/_core/solver/_solver_config.py
@@ -1,0 +1,54 @@
+"""A solver's configuration, held apart from the distances it will read.
+
+Everything `MaxDivSolver` needs except its store, in one record small enough to pickle.  Building a
+solver is two steps for that reason: the distances are produced once and can be shared between
+processes, while each process assembles its own solver over them from a copy of this record.
+"""
+
+from dataclasses import dataclass, replace
+
+from max_div._core.constraints import Constraint
+from max_div._core.metrics import DiversityMetric
+from max_div._core.metrics._distance import DistanceStore
+
+from ._constraint_penalty import ConstraintPenalty
+from ._solver import MaxDivSolver
+from ._solver_step import SolverStep
+
+
+@dataclass(frozen=True)
+class SolverConfig:
+    """Everything a solver needs apart from the distances it reads.
+
+    Holds no distances and no problem, so it stays small however large the problem is — which is
+    what lets it travel to a worker process while the distances travel through shared memory.
+    """
+
+    n: int
+    k: int
+    diversity_metric: DiversityMetric
+    diversity_tie_breakers: list[DiversityMetric]
+    constraints: list[Constraint]
+    solver_steps: list[SolverStep]
+    seed: int
+    constraint_penalty: ConstraintPenalty
+    distance_storage_label: str
+
+    def build_solver(self, store: DistanceStore) -> MaxDivSolver:
+        """Return a solver configured as this record describes, reading the given store."""
+        return MaxDivSolver(
+            n=self.n,
+            store=store,
+            k=self.k,
+            diversity_metric=self.diversity_metric,
+            diversity_tie_breakers=self.diversity_tie_breakers,
+            constraints=self.constraints,
+            solver_steps=self.solver_steps,
+            seed=self.seed,
+            constraint_penalty=self.constraint_penalty,
+            distance_storage_label=self.distance_storage_label,
+        )
+
+    def with_seed(self, seed: int) -> "SolverConfig":
+        """Return a copy of this configuration carrying a different seed."""
+        return replace(self, seed=seed)

--- a/src/max_div/_core/solver/_solver_config.py
+++ b/src/max_div/_core/solver/_solver_config.py
@@ -1,8 +1,8 @@
 """A solver's configuration, held apart from the distances it will read.
 
-Everything `MaxDivSolver` needs except its store.  The two are separated because a store is
-produced once and read by several processes, while each process assembles its own solver over it
-from a copy of this record — which is why the record must stay small enough to pickle.
+A store and the rest of a solver are separated because a store is produced once and read by several
+processes, while each process assembles its own solver over that store from a copy of this record —
+which is why the record must stay small enough to pickle.
 """
 
 from dataclasses import dataclass, replace

--- a/src/max_div/_core/solver/_solver_step.py
+++ b/src/max_div/_core/solver/_solver_step.py
@@ -52,7 +52,7 @@ class SolverStep(ABC, Generic[S]):
         progress_reporter: ProgressReporter | None = None,
         coordinator: "WorkerCoordinator | None" = None,
     ) -> SolverStepResult:
-        """Executes the solver step by executing a strategy 1x or repeatedly and returns a SolverStepResult.
+        """Execute the solver step by running a strategy once or repeatedly, and return its result.
 
         :param coordinator: a `WorkerCoordinator` this step calls at each batch boundary; a step that
                             runs as a single batch ignores it.
@@ -168,7 +168,7 @@ class OptimizationStep(SolverStep[OptimizationStrategy]):
             # --- report progress to tracker ---
             tracker.report_iterations_done(n_iters)
 
-            # --- batch boundary ---------------------------
+            # --- batch boundary ---
             if coordinator is not None:
                 coordinator.at_batch_boundary(state)
 

--- a/src/max_div/_core/solver/_solver_step.py
+++ b/src/max_div/_core/solver/_solver_step.py
@@ -12,7 +12,7 @@ from ._solver_state import SolverState
 from ._strategies._base import StrategyBase
 
 if TYPE_CHECKING:
-    from max_div._core.solver._parallel import WorkerCoordinator
+    from ._parallel import WorkerCoordinator
 
 
 # =================================================================================================
@@ -54,9 +54,8 @@ class SolverStep(ABC, Generic[S]):
     ) -> SolverStepResult:
         """Executes the solver step by executing a strategy 1x or repeatedly and returns a SolverStepResult.
 
-        :param coordinator: reached at each batch boundary when this step has batches, so a worker
-                            solving alongside others has one place to share from.  A step that runs
-                            as a single batch ignores it.
+        :param coordinator: a `WorkerCoordinator` this step calls at each batch boundary; a step that
+                            runs as a single batch ignores it.
         """
         raise NotImplementedError
 
@@ -169,7 +168,7 @@ class OptimizationStep(SolverStep[OptimizationStrategy]):
             # --- report progress to tracker ---
             tracker.report_iterations_done(n_iters)
 
-            # --- batch boundary: the one place a worker may share with the rest of a portfolio ---
+            # --- batch boundary ---------------------------
             if coordinator is not None:
                 coordinator.at_batch_boundary(state)
 

--- a/src/max_div/_core/solver/_solver_step.py
+++ b/src/max_div/_core/solver/_solver_step.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 from max_div._core._utils._timer import Timer
 from max_div._core.solver._strategies import InitializationStrategy, OptimizationStrategy
@@ -10,6 +10,9 @@ from ._progress_reporting import ProgressReporter, SilentProgressReporter
 from ._score import Score
 from ._solver_state import SolverState
 from ._strategies._base import StrategyBase
+
+if TYPE_CHECKING:
+    from max_div._core.solver._parallel import WorkerCoordinator
 
 
 # =================================================================================================
@@ -43,8 +46,18 @@ class SolverStep(ABC, Generic[S]):
         self._strategy.set_seed(seed)
 
     @abstractmethod
-    def run(self, state: SolverState, progress_reporter: ProgressReporter | None = None) -> SolverStepResult:
-        """Executes the solver step by executing a strategy 1x or repeatedly and returns a SolverStepResult."""
+    def run(
+        self,
+        state: SolverState,
+        progress_reporter: ProgressReporter | None = None,
+        coordinator: "WorkerCoordinator | None" = None,
+    ) -> SolverStepResult:
+        """Executes the solver step by executing a strategy 1x or repeatedly and returns a SolverStepResult.
+
+        :param coordinator: reached at each batch boundary when this step has batches, so a worker
+                            solving alongside others has one place to share from.  A step that runs
+                            as a single batch ignores it.
+        """
         raise NotImplementedError
 
     def get_debug_info(self) -> str:
@@ -63,7 +76,12 @@ class InitializationStep(SolverStep[InitializationStrategy]):
             )
         super().__init__(init_strategy)
 
-    def run(self, state: SolverState, progress_reporter: ProgressReporter | None = None) -> SolverStepResult:
+    def run(
+        self,
+        state: SolverState,
+        progress_reporter: ProgressReporter | None = None,
+        coordinator: "WorkerCoordinator | None" = None,
+    ) -> SolverStepResult:
         # --- set up progress tracking --------------------
         progress_reporter = progress_reporter or SilentProgressReporter()
         duration = TargetDuration.iterations(int(state.k))  # we need to select k items
@@ -117,7 +135,12 @@ class OptimizationStep(SolverStep[OptimizationStrategy]):
         super().__init__(optim_strategy)
         self._duration = duration
 
-    def run(self, state: SolverState, progress_reporter: ProgressReporter | None = None) -> SolverStepResult:
+    def run(
+        self,
+        state: SolverState,
+        progress_reporter: ProgressReporter | None = None,
+        coordinator: "WorkerCoordinator | None" = None,
+    ) -> SolverStepResult:
         # --- init ----------------------------------------
         progress_reporter = progress_reporter or SilentProgressReporter()
         tracker = self._duration.track()
@@ -145,6 +168,10 @@ class OptimizationStep(SolverStep[OptimizationStrategy]):
 
             # --- report progress to tracker ---
             tracker.report_iterations_done(n_iters)
+
+            # --- batch boundary: the one place a worker may share with the rest of a portfolio ---
+            if coordinator is not None:
+                coordinator.at_batch_boundary(state)
 
             # --- create checkpoint if needed ---
             if tracker.iter_count() >= next_checkpoint_iter_count:

--- a/tests/_core/solver/_parallel/test_coordinator.py
+++ b/tests/_core/solver/_parallel/test_coordinator.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+from max_div._core.problem import MaxDivProblem
+from max_div._core.solver._duration import iterations
+from max_div._core.solver._parallel import IndependentCoordinator, WorkerCoordinator
+from max_div._core.solver._presets import SolverPreset
+from max_div._core.solver._solver_builder import MaxDivSolverBuilder
+from max_div._core.solver._solver_state import SolverState
+
+
+class _RecordingCoordinator(WorkerCoordinator):
+    """A coordinator that counts the batch boundaries it is reached at."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+        self.sizes: list[int] = []
+
+    def at_batch_boundary(self, state: SolverState) -> None:
+        """Record the call, and the selection size the worker held at that moment."""
+        self.calls += 1
+        self.sizes.append(int(state.n_selected))
+
+
+def _solve_with(coordinator: WorkerCoordinator | None):
+    """Solve a small problem, passing the given coordinator down to the solver steps."""
+    rng = np.random.default_rng(4)
+    problem = MaxDivProblem.new(rng.random((50, 3)).astype(np.float32), k=5)
+    builder = MaxDivSolverBuilder(problem).with_preset(iterations(60), SolverPreset.SMART).with_seed(7)
+    return builder.build().solve(verbosity=0, coordinator=coordinator)
+
+
+def test_the_batch_boundary_is_reached_during_optimization():
+    """The seam is called while optimizing, so a sharing mode has a hook that actually runs."""
+    # --- arrange -----------------------------------------
+    coordinator = _RecordingCoordinator()
+
+    # --- act ---------------------------------------------
+    _solve_with(coordinator)
+
+    # --- assert ------------------------------------------
+    assert coordinator.calls > 0
+    assert all(size == 5 for size in coordinator.sizes)  # optimization swaps, never resizes
+
+
+def test_a_coordinator_does_not_change_the_search():
+    """Passing a coordinator that does nothing leaves the solution exactly as solving alone gives it."""
+    # --- arrange / act -----------------------------------
+    with_coordinator = _solve_with(IndependentCoordinator())
+    without = _solve_with(None)
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(np.sort(with_coordinator.i_selected), np.sort(without.i_selected))

--- a/tests/_core/solver/_parallel/test_coordinator.py
+++ b/tests/_core/solver/_parallel/test_coordinator.py
@@ -30,7 +30,7 @@ def _solve_with(coordinator: WorkerCoordinator | None):
 
 
 def test_the_batch_boundary_is_reached_during_optimization():
-    """The seam is called while optimizing, so a sharing mode has a hook that actually runs."""
+    """The coordinator is called during optimization, on a path that runs rather than merely exists."""
     # --- arrange -----------------------------------------
     coordinator = _RecordingCoordinator()
 

--- a/tests/_core/solver/_parallel/test_executor.py
+++ b/tests/_core/solver/_parallel/test_executor.py
@@ -1,0 +1,73 @@
+import numpy as np
+import pytest
+
+from max_div._core.problem import MaxDivProblem
+from max_div._core.solver._distance_storage import build_shared_distance_store
+from max_div._core.solver._duration import iterations
+from max_div._core.solver._parallel import IndependentCoordinator, best_result, run_portfolio
+from max_div._core.solver._presets import SolverPreset
+from max_div._core.solver._solver_builder import MaxDivSolverBuilder
+
+_SEEDS = (11, 22, 33)
+
+
+def _builder() -> MaxDivSolverBuilder:
+    """Return a builder over a problem small enough to solve several times in a test."""
+    rng = np.random.default_rng(20260809)
+    problem = MaxDivProblem.new(rng.random((60, 3)).astype(np.float32), k=6)
+    return MaxDivSolverBuilder(problem).with_preset(iterations(50), SolverPreset.SMART)
+
+
+@pytest.fixture
+def portfolio_results():
+    """Run one portfolio over spawned workers, and hand back its results with the builder used."""
+    builder = _builder()
+    resolved, config = builder.resolve()
+    with build_shared_distance_store(builder._problem, resolved) as shared:
+        yield builder, run_portfolio([config.with_seed(seed) for seed in _SEEDS], shared.spec, IndependentCoordinator())
+
+
+def test_every_worker_reports_a_result(portfolio_results):
+    """A portfolio returns one result per configuration, each carrying a full selection."""
+    # --- arrange / act -----------------------------------
+    builder, results = portfolio_results
+
+    # --- assert ------------------------------------------
+    assert len(results) == len(_SEEDS)
+    assert all(result.i_selected.size == builder._k for result in results)
+
+
+def test_results_come_back_in_worker_order(portfolio_results):
+    """Results are ordered by worker rather than by who finished first."""
+    # --- arrange / act -----------------------------------
+    _, results = portfolio_results
+
+    # --- assert ------------------------------------------
+    assert [result.worker_index for result in results] == list(range(len(_SEEDS)))
+    assert [result.seed for result in results] == list(_SEEDS)
+
+
+def test_a_worker_reproduces_the_same_solve_run_alone(portfolio_results):
+    """A worker's selection is what the same configuration and seed produce in a single process.
+
+    The reproducibility contract of independent mode: sharing the distances changes where a worker
+    reads from, never what it searches.
+    """
+    # --- arrange -----------------------------------------
+    builder, results = portfolio_results
+
+    # --- act ---------------------------------------------
+    alone = builder.with_seed(_SEEDS[0]).build().solve(verbosity=0)
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(np.sort(results[0].i_selected), np.sort(alone.i_selected))
+
+
+def test_the_best_reported_result_wins(portfolio_results):
+    """The winner is the best-scoring worker, which is the whole point of running several."""
+    # --- arrange / act -----------------------------------
+    _, results = portfolio_results
+    winner = best_result(results)
+
+    # --- assert ------------------------------------------
+    assert winner.score == max(result.score for result in results)

--- a/tests/_core/solver/_parallel/test_executor.py
+++ b/tests/_core/solver/_parallel/test_executor.py
@@ -48,11 +48,7 @@ def test_results_come_back_in_worker_order(portfolio_results):
 
 
 def test_a_worker_reproduces_the_same_solve_run_alone(portfolio_results):
-    """A worker's selection is what the same configuration and seed produce in a single process.
-
-    The reproducibility contract of independent mode: sharing the distances changes where a worker
-    reads from, never what it searches.
-    """
+    """A worker's selection is what the same configuration and seed produce in a single process."""
     # --- arrange -----------------------------------------
     builder, results = portfolio_results
 
@@ -64,7 +60,7 @@ def test_a_worker_reproduces_the_same_solve_run_alone(portfolio_results):
 
 
 def test_the_best_reported_result_wins(portfolio_results):
-    """The winner is the best-scoring worker, which is the whole point of running several."""
+    """The winner is the best-scoring worker."""
     # --- arrange / act -----------------------------------
     _, results = portfolio_results
     winner = best_result(results)

--- a/tests/_core/solver/_parallel/test_executor.py
+++ b/tests/_core/solver/_parallel/test_executor.py
@@ -22,7 +22,7 @@ def _builder() -> MaxDivSolverBuilder:
 def portfolio_results():
     """Run one portfolio over spawned workers, and hand back its results with the builder used."""
     builder = _builder()
-    resolved, config = builder.resolve()
+    resolved, config = builder.resolve_storage_and_config()
     with build_shared_distance_store(builder._problem, resolved) as shared:
         yield builder, run_portfolio([config.with_seed(seed) for seed in _SEEDS], shared.spec, IndependentCoordinator())
 
@@ -60,7 +60,7 @@ def test_a_worker_reproduces_the_same_solve_run_alone(portfolio_results):
 
 
 def test_the_best_reported_result_wins(portfolio_results):
-    """The winner is the best-scoring worker."""
+    """The winner is the best-scoring worker, not the first to report."""
     # --- arrange / act -----------------------------------
     _, results = portfolio_results
     winner = best_result(results)

--- a/tests/_core/solver/_parallel/test_result.py
+++ b/tests/_core/solver/_parallel/test_result.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pytest
+
+from max_div._core.solver._duration import Elapsed
+from max_div._core.solver._parallel import WorkerResult, best_result
+from max_div._core.solver._score import Score
+
+
+def _result(worker_index: int, diversity: float) -> WorkerResult:
+    """Return a result carrying the given diversity, with everything else held equal."""
+    return WorkerResult(
+        worker_index=worker_index,
+        i_selected=np.array([worker_index], dtype=np.int32),
+        score=Score(size=1.0, constraints=1.0, diversity=diversity, div_tie_breakers=()),
+        elapsed=Elapsed(t_elapsed_sec=1.0, n_iterations=10),
+        seed=worker_index,
+    )
+
+
+def test_best_result_picks_the_highest_score():
+    """The winner is the worker that scored best, wherever it sits in the list."""
+    # --- arrange / act -----------------------------------
+    winner = best_result([_result(0, 0.1), _result(1, 0.9), _result(2, 0.5)])
+
+    # --- assert ------------------------------------------
+    assert winner.worker_index == 1
+
+
+def test_best_result_breaks_ties_by_lowest_worker_index():
+    """Equal scores resolve to the lowest index, so the winner never depends on who finished first."""
+    # --- arrange -----------------------------------------
+    tied = [_result(2, 0.7), _result(0, 0.7), _result(1, 0.7)]
+
+    # --- act ---------------------------------------------
+    winner = best_result(tied)
+
+    # --- assert ------------------------------------------
+    assert winner.worker_index == 0
+    assert best_result(list(reversed(tied))).worker_index == 0  # and not on list order either
+
+
+def test_best_result_rejects_an_empty_portfolio():
+    """No results means every worker failed, which is an error rather than an empty answer."""
+    # --- arrange / act / assert --------------------------
+    with pytest.raises(ValueError, match="every worker failed"):
+        best_result([])

--- a/tests/_core/solver/test_solver_config.py
+++ b/tests/_core/solver/test_solver_config.py
@@ -1,0 +1,70 @@
+import numpy as np
+
+from max_div._core.metrics import DiversityMetric
+from max_div._core.problem import MaxDivProblem
+from max_div._core.solver._distance_storage import DistanceStorage, build_distance_store
+from max_div._core.solver._duration import iterations
+from max_div._core.solver._presets import SolverPreset
+from max_div._core.solver._solver import MaxDivSolver
+from max_div._core.solver._solver_builder import MaxDivSolverBuilder
+
+
+def _builder() -> MaxDivSolverBuilder:
+    """Return a builder over a small problem, configured enough to resolve."""
+    rng = np.random.default_rng(1234)
+    problem = MaxDivProblem.new(rng.random((40, 3)).astype(np.float32), k=4)
+    return MaxDivSolverBuilder(problem).with_preset(iterations(20), SolverPreset.SMART)
+
+
+def test_resolve_returns_the_backend_and_a_config_over_it():
+    """Resolving hands back the chosen backend and a config carrying the builder's settings."""
+    # --- arrange -----------------------------------------
+    builder = _builder().with_seed(99)
+
+    # --- act ---------------------------------------------
+    resolved, config = builder.resolve()
+
+    # --- assert ------------------------------------------
+    assert resolved != DistanceStorage.AUTO  # AUTO is resolved to something concrete
+    assert config.seed == 99
+    assert config.k == 4
+    assert config.diversity_metric == DiversityMetric.GEOMEAN_SEPARATION  # the problem's own metric
+
+
+def test_a_config_builds_a_solver_over_any_store():
+    """A config plus a store is a solver, which is what lets several processes share one store."""
+    # --- arrange -----------------------------------------
+    builder = _builder()
+    resolved, config = builder.resolve()
+
+    # --- act ---------------------------------------------
+    solver = config.build_solver(build_distance_store(builder._problem, resolved))
+
+    # --- assert ------------------------------------------
+    assert isinstance(solver, MaxDivSolver)
+    assert solver.solve(verbosity=0).i_selected.size == 4
+
+
+def test_with_seed_changes_only_the_seed():
+    """Reseeding a config leaves every other setting alone, so workers differ in search only."""
+    # --- arrange -----------------------------------------
+    _, config = _builder().with_seed(1).resolve()
+
+    # --- act ---------------------------------------------
+    reseeded = config.with_seed(2)
+
+    # --- assert ------------------------------------------
+    assert reseeded.seed == 2
+    assert config.seed == 1  # the original is untouched
+    assert reseeded.solver_steps is config.solver_steps
+    assert reseeded.distance_storage_label == config.distance_storage_label
+
+
+def test_build_still_produces_a_working_solver():
+    """The two-step split leaves the one-step build behaving as it did."""
+    # --- arrange / act -----------------------------------
+    solution = _builder().with_seed(5).build().solve(verbosity=0)
+
+    # --- assert ------------------------------------------
+    assert solution.i_selected.size == 4
+    assert solution.score.diversity > 0.0

--- a/tests/_core/solver/test_solver_config.py
+++ b/tests/_core/solver/test_solver_config.py
@@ -32,7 +32,7 @@ def test_resolve_returns_the_backend_and_a_config_over_it():
 
 
 def test_a_config_builds_a_solver_over_any_store():
-    """A config plus a store is a solver, which is what lets several processes share one store."""
+    """A config plus a store is a solver."""
     # --- arrange -----------------------------------------
     builder = _builder()
     resolved, config = builder.resolve()
@@ -60,8 +60,8 @@ def test_with_seed_changes_only_the_seed():
     assert reseeded.distance_storage_label == config.distance_storage_label
 
 
-def test_build_still_produces_a_working_solver():
-    """The two-step split leaves the one-step build behaving as it did."""
+def test_build_produces_a_working_solver():
+    """`build` returns a solver that solves the problem."""
     # --- arrange / act -----------------------------------
     solution = _builder().with_seed(5).build().solve(verbosity=0)
 

--- a/tests/_core/solver/test_solver_config.py
+++ b/tests/_core/solver/test_solver_config.py
@@ -22,7 +22,7 @@ def test_resolve_returns_the_backend_and_a_config_over_it():
     builder = _builder().with_seed(99)
 
     # --- act ---------------------------------------------
-    resolved, config = builder.resolve()
+    resolved, config = builder.resolve_storage_and_config()
 
     # --- assert ------------------------------------------
     assert resolved != DistanceStorage.AUTO  # AUTO is resolved to something concrete
@@ -35,7 +35,7 @@ def test_a_config_builds_a_solver_over_any_store():
     """A config plus a store is a solver."""
     # --- arrange -----------------------------------------
     builder = _builder()
-    resolved, config = builder.resolve()
+    resolved, config = builder.resolve_storage_and_config()
 
     # --- act ---------------------------------------------
     solver = config.build_solver(build_distance_store(builder._problem, resolved))
@@ -48,7 +48,7 @@ def test_a_config_builds_a_solver_over_any_store():
 def test_with_seed_changes_only_the_seed():
     """Reseeding a config leaves every other setting alone, so workers differ in search only."""
     # --- arrange -----------------------------------------
-    _, config = _builder().with_seed(1).resolve()
+    _, config = _builder().with_seed(1).resolve_storage_and_config()
 
     # --- act ---------------------------------------------
     reseeded = config.with_seed(2)
@@ -61,7 +61,7 @@ def test_with_seed_changes_only_the_seed():
 
 
 def test_build_produces_a_working_solver():
-    """`build` returns a solver that solves the problem."""
+    """`build` produces a solver over a store it built itself."""
     # --- arrange / act -----------------------------------
     solution = _builder().with_seed(5).build().solve(verbosity=0)
 


### PR DESCRIPTION
**TL;DR**: N worker processes now solve one problem over a single shared distance store, and the best result wins. Internal only — no public API yet, so nothing user-facing changes.

## Description

### Problem addressed

The shared distance store landed with nothing to read it. A solve is still one process, so a user wanting insurance against a bad seed runs N solves by hand and picks the best, paying N× the wall clock while N−1 cores sit idle.

Two things stood in the way beyond the executor itself. **A worker cannot call `build()`**, because that builds a distance store — one per worker is exactly what sharing exists to avoid. And a worker that runs an opaque `solve()` has nowhere to reach the other workers from, which forecloses any mode where they exchange anything.

### Implementation

**Building a solver splits in two.** The builder resolves a backend and a configuration; the configuration turns *any* store into a solver. `build()` is those two run together; a portfolio builds one store into shared memory and assembles a solver per worker over it. The configuration holds no problem and no distances, so it stays small enough to pickle however large the problem is.

**Workers are spawned, never forked.** The parent runs numba parallel code while building the store, and numba's threading layer does not survive a fork — a forked child deadlocks on its first parallel call.

**Every worker holds a coordinator and calls it at each batch boundary**, where the optimization loop already pauses between batches. Independent workers do nothing there, but the call still happens on every batch, so the one place a worker could reach the others from is a path that runs rather than one that merely exists.

**The winner is the best score, ties going to the lowest worker index** — a property of the results rather than of who finished first.

## Attention points

- **A worker reproduces what the same configuration and seed produce alone.** Sharing the distances changes where a worker reads from, never what it searches. There is a test pinning exactly that.
- **A worker that dies without reporting is left out rather than treated as an error.** The portfolio returns what survivors found, and selecting a winner from nothing raises.
- **The result payload is the selection and its score, not a whole solution.** A mode that exchanges results more often would send this same record, so it is kept to what a receiver can act on.
- **`_parallel` imports modules sitting beside it**, which the newly written dependency rule forbids. `_strategies/` and `_presets/` already do the same throughout `_core/solver/`, so this follows the package's existing shape; conforming would mean promoting `_solver_state`, `_score`, `_duration` and `_solver_config` to sibling packages, which is a repo-wide move rather than one this branch should make.
- **Queue collection is bounded rather than blocking.** Workers are polled with a timeout and a final drain, because a worker that dies mid-solve would otherwise hang the parent forever.

## Tests / Spikes

- **TEST:** a portfolio of three spawned workers over one published store — every worker reports, results come back in worker order, and worker 0's selection matches a single-process solve at the same seed.
- **TEST:** a recording coordinator confirms the batch boundary is reached during optimization, and that passing one changes nothing about the search.
- **13 test cases added** across winner selection and its tie-break, the coordinator seam, the two-step build, and the cross-process round trip.

## Changelog entry

None: no user-facing surface. The executor has no public entry point yet, so there is nothing for a reader deciding whether to upgrade.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
