### PR TITLE
docs: describe solving in parallel

### DIFF
--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -196,8 +196,9 @@ Running several configurations of one solver concurrently and keeping the best i
 algorithm portfolio, an idea introduced by Huberman, Lukose and Hogg (1997) and developed by Gomes
 and Selman (2001).
 
-The term is also used for per-instance algorithm *selection*, where features of the instance pick a
-single algorithm to run; max-div's sense is the concurrent one.
+The word also names a different technique, **algorithm selection**: reading a problem's features to
+predict, and then run, the single algorithm best suited to it. That is not max-div's sense — max-div
+runs several at once and keeps the best.
 
 Portfolio workers may run independently or share what they learn as they go — ManySAT (Hamadi,
 Jabbour and Sais, 2009) shares. max-div's workers are independent: they never exchange information.

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -125,57 +125,77 @@ iterations — the machine-dependence any time budget carries.)
 
 ## Solving in Parallel
 
-`ParallelMaxDivSolverBuilder` runs several workers on one problem at once and keeps the best result
-each of them reached. The workers share one copy of the distances, so running eight of them costs
-eight processes but not eight distance matrices.
+`ParallelMaxDivSolverBuilder` runs several workers on one problem at once — an **algorithm
+portfolio** — and keeps the best result any of them reached. The workers share one copy of the
+distances, so N workers cost N processes but only one copy.
 
-**The purpose is variance reduction, not speed.** A run's quality depends on its seed, and the
-spread between good and bad seeds does not shrink as the budget grows — a bad-seed long run can lose
-to a good-seed short one. Running several seeds at once and keeping the best is insurance against
-drawing a bad one. It does not make any single search faster, and it does not substitute for a
-larger budget.
+```python
+from max_div.solver import ParallelMaxDivSolverBuilder, SolverPreset, WorkerConfig, seconds
 
-### What varies per worker, and what cannot
+solution = (
+    ParallelMaxDivSolverBuilder(problem)
+    .with_seed(42)
+    .with_workers(seconds(60), 8)          # or one WorkerConfig per worker
+    .build()
+    .solve()
+)
+```
 
-Each worker is configured by a `WorkerConfig`: the preset it runs, and optionally the initialization
-strategy it starts from. That second field is what lets two workers run the same preset from
+### Why Run Several
+
+**The purpose is variance reduction, not speed.** A run's quality depends on its seed, and running
+several seeds at once and keeping the best is insurance against drawing a bad one. It does not make
+any single search faster, and it does not substitute for a larger budget.
+
+How much it buys depends on the budget. The published preset quantiles show the seed spread
+narrowing sharply as budgets grow — roughly tenfold over the first stretch — and then flattening
+rather than vanishing. Even at that floor the bands of neighboring budgets overlap, so an unlucky
+seed with more budget can still finish below a lucky one with less.
+
+### What Varies Per Worker
+
+Each worker is configured by a `WorkerConfig`: the preset it runs, and optionally the
+initialization strategy it starts from. `init_strategy` lets two workers run the same preset from
 different starting points.
 
-Everything that decides **which selection is better** — the diversity metric, its tie-breakers, the
-constraint penalty — is set once, on the portfolio. Comparing what workers found requires a single
-answer to that question, so those settings cannot vary between them. Distance storage is fixed for
-a different reason: the workers read one shared buffer.
+Everything that decides **which selection is better** is fixed for the whole portfolio, whether it
+comes from the problem (the diversity metric, the constraints) or from the builder (the
+tie-breakers, the constraint penalty). Comparing what workers found requires a single answer to that
+question.
 
-### Seeds and reproducibility
+Distance storage is fixed for a different reason: the workers read one shared buffer.
 
-The portfolio takes one seed and derives a seed per worker from it. So a portfolio is reproducible
-as a whole from a single number, while its workers still search differently. Each worker's derived
-seed is reported back, next to the configuration it ran, which is enough to replay that worker on
-its own with `MaxDivSolverBuilder`.
+### Seeds And Reproducibility
 
-The reproducibility limits above apply unchanged: exact repetition holds within one machine, build
-and backend.
+The portfolio takes one seed and derives a seed per worker from it, so a portfolio is reproducible
+as a whole from a single number while its workers still search differently.
 
-### Reading the result
+Each worker's `WorkerSummary` carries its derived seed next to the configuration it ran, which is
+enough to replay that worker on its own with `MaxDivSolverBuilder`. The limits described in the
+Reproducibility section apply unchanged.
 
-The returned solution is an ordinary `MaxDivSolution` — the winner's — with a summary of every
-worker attached. The number worth looking at is `n_workers_with_best_score`:
+### Reading The Result
+
+`solve()` returns a `ParallelMaxDivSolution`: the winning worker's solution, with a `WorkerSummary`
+per worker attached. The number worth looking at is `n_workers_with_best_score`:
 
 - **Well below the worker count**: seeds mattered on this problem, and the portfolio earned its
   cost.
 - **Equal to the worker count**: every worker tied, so the portfolio found nothing a single one
   would not have. Lower the worker count or solve once.
 
-### On the word "portfolio"
+A `ParallelSolvingWarning` is raised for configurations that cannot help — a single worker, or more
+workers than the machine has cores.
+
+### On The Word "Portfolio"
 
 Running several configurations of one solver concurrently and keeping the best is known as an
-**algorithm portfolio**, an idea introduced by Huberman, Lukose and Hogg (1997) and developed by
-Gomes and Selman (2001). The term is also used for per-instance algorithm *selection*, where
-features of the instance pick a single algorithm to run; max-div's sense is the concurrent one.
+algorithm portfolio, an idea introduced by Huberman, Lukose and Hogg (1997) and developed by Gomes
+and Selman (2001). The term is also used for per-instance algorithm *selection*, where features of
+the instance pick a single algorithm to run; max-div's sense is the concurrent one.
 
-Portfolio workers may run independently or exchange information as they go — clause-sharing SAT
-solvers such as ManySAT (Hamadi, Jabbour and Sais, 2009) do the latter. max-div's workers are
-independent, which is why the strategy is named for independence rather than for being a portfolio.
+Portfolio workers may run independently or share what they learn as they go — ManySAT (Hamadi,
+Jabbour and Sais, 2009) shares. max-div's workers are independent: they never exchange information.
 
 **References**
 

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -122,3 +122,66 @@ Two practical consequences:
 
 (With a time budget rather than an iteration budget, a faster backend also completes more
 iterations — the machine-dependence any time budget carries.)
+
+## Solving in Parallel
+
+`ParallelMaxDivSolverBuilder` runs several workers on one problem at once and keeps the best result
+each of them reached. The workers share one copy of the distances, so running eight of them costs
+eight processes but not eight distance matrices.
+
+**The purpose is variance reduction, not speed.** A run's quality depends on its seed, and the
+spread between good and bad seeds does not shrink as the budget grows — a bad-seed long run can lose
+to a good-seed short one. Running several seeds at once and keeping the best is insurance against
+drawing a bad one. It does not make any single search faster, and it does not substitute for a
+larger budget.
+
+### What varies per worker, and what cannot
+
+Each worker is configured by a `WorkerConfig`: the preset it runs, and optionally the initialization
+strategy it starts from. That second field is what lets two workers run the same preset from
+different starting points.
+
+Everything that decides **which selection is better** — the diversity metric, its tie-breakers, the
+constraint penalty — is set once, on the portfolio. Comparing what workers found requires a single
+answer to that question, so those settings cannot vary between them. Distance storage is fixed for
+a different reason: the workers read one shared buffer.
+
+### Seeds and reproducibility
+
+The portfolio takes one seed and derives a seed per worker from it. So a portfolio is reproducible
+as a whole from a single number, while its workers still search differently. Each worker's derived
+seed is reported back, next to the configuration it ran, which is enough to replay that worker on
+its own with `MaxDivSolverBuilder`.
+
+The reproducibility limits above apply unchanged: exact repetition holds within one machine, build
+and backend.
+
+### Reading the result
+
+The returned solution is an ordinary `MaxDivSolution` — the winner's — with a summary of every
+worker attached. The number worth looking at is `n_workers_with_best_score`:
+
+- **Well below the worker count**: seeds mattered on this problem, and the portfolio earned its
+  cost.
+- **Equal to the worker count**: every worker tied, so the portfolio found nothing a single one
+  would not have. Lower the worker count or solve once.
+
+### On the word "portfolio"
+
+Running several configurations of one solver concurrently and keeping the best is known as an
+**algorithm portfolio**, an idea introduced by Huberman, Lukose and Hogg (1997) and developed by
+Gomes and Selman (2001). The term is also used for per-instance algorithm *selection*, where
+features of the instance pick a single algorithm to run; max-div's sense is the concurrent one.
+
+Portfolio workers may run independently or exchange information as they go — clause-sharing SAT
+solvers such as ManySAT (Hamadi, Jabbour and Sais, 2009) do the latter. max-div's workers are
+independent, which is why the strategy is named for independence rather than for being a portfolio.
+
+**References**
+
+- Huberman, B. A., Lukose, R. M., & Hogg, T. (1997). An economics approach to hard computational
+  problems. *Science*, 275(5296), 51–54.
+- Gomes, C. P., & Selman, B. (2001). Algorithm portfolios. *Artificial Intelligence*, 126(1–2),
+  43–62.
+- Hamadi, Y., Jabbour, S., & Sais, L. (2009). ManySAT: a parallel SAT solver. *Journal on
+  Satisfiability, Boolean Modeling and Computation*, 6(4), 245–262.

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -130,7 +130,7 @@ portfolio** — and keeps the best result any of them reached. The workers share
 distances, so N workers cost N processes but only one copy.
 
 ```python
-from max_div.solver import ParallelMaxDivSolverBuilder, SolverPreset, WorkerConfig, seconds
+from max_div.solver import ParallelMaxDivSolverBuilder, WorkerConfig, seconds
 
 solution = (
     ParallelMaxDivSolverBuilder(problem)
@@ -144,15 +144,17 @@ solution = (
 ### Why Run Several
 
 **The purpose is variance reduction, not speed.** A run's quality depends on its seed, and running
-several seeds at once and keeping the best is insurance against drawing a bad one. It does not make
-any single search faster, and it does not substitute for a larger budget.
+several seeds at once and keeping the best is insurance against drawing a bad one. Running several
+does not make any single search faster, and it does not substitute for a larger budget.
 
-How much it buys depends on the budget. The published preset quantiles show the seed spread
-narrowing sharply as budgets grow — roughly tenfold over the first stretch — and then flattening
-rather than vanishing. Even at that floor the bands of neighboring budgets overlap, so an unlucky
-seed with more budget can still finish below a lucky one with less.
+How much it buys depends on the budget. The [published preset quantiles](../benchmarks/solver/bm_problem_u1_presets.md)
+show the seed spread narrowing sharply as budgets grow — roughly tenfold over the first stretch —
+and then flattening rather than vanishing.
 
-### What Varies Per Worker
+Even at that floor the bands of neighboring budgets overlap, so an unlucky seed with more budget can
+still finish below a lucky one with less.
+
+### What Varies per Worker
 
 Each worker is configured by a `WorkerConfig`: the preset it runs, and optionally the
 initialization strategy it starts from. `init_strategy` lets two workers run the same preset from
@@ -165,16 +167,16 @@ question.
 
 Distance storage is fixed for a different reason: the workers read one shared buffer.
 
-### Seeds And Reproducibility
+### Seeds and Reproducibility
 
-The portfolio takes one seed and derives a seed per worker from it, so a portfolio is reproducible
+The portfolio takes one seed and derives a seed per worker from that seed, so a portfolio is reproducible
 as a whole from a single number while its workers still search differently.
 
 Each worker's `WorkerSummary` carries its derived seed next to the configuration it ran, which is
-enough to replay that worker on its own with `MaxDivSolverBuilder`. The limits described in the
-Reproducibility section apply unchanged.
+enough to replay that worker on its own with `MaxDivSolverBuilder`. The limits in the
+[Reproducibility](#reproducibility) section apply unchanged.
 
-### Reading The Result
+### Reading the Result
 
 `solve()` returns a `ParallelMaxDivSolution`: the winning worker's solution, with a `WorkerSummary`
 per worker attached. The number worth looking at is `n_workers_with_best_score`:
@@ -187,12 +189,14 @@ per worker attached. The number worth looking at is `n_workers_with_best_score`:
 A `ParallelSolvingWarning` is raised for configurations that cannot help — a single worker, or more
 workers than the machine has cores.
 
-### On The Word "Portfolio"
+### On the Word "Portfolio"
 
 Running several configurations of one solver concurrently and keeping the best is known as an
 algorithm portfolio, an idea introduced by Huberman, Lukose and Hogg (1997) and developed by Gomes
-and Selman (2001). The term is also used for per-instance algorithm *selection*, where features of
-the instance pick a single algorithm to run; max-div's sense is the concurrent one.
+and Selman (2001).
+
+The term is also used for per-instance algorithm *selection*, where features of the instance pick a
+single algorithm to run; max-div's sense is the concurrent one.
 
 Portfolio workers may run independently or share what they learn as they go — ManySAT (Hamadi,
 Jabbour and Sais, 2009) shares. max-div's workers are independent: they never exchange information.

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -127,7 +127,8 @@ iterations — the machine-dependence any time budget carries.)
 
 `ParallelMaxDivSolverBuilder` runs several workers on one problem at once — an **algorithm
 portfolio** — and keeps the best result any of them reached. The workers share one copy of the
-distances, so N workers cost N processes but only one copy.
+distances, which are usually the most memory-intensive structure in a solve, so N workers cost N
+processes but not N copies of that data.
 
 ```python
 from max_div.solver import ParallelMaxDivSolverBuilder, WorkerConfig, seconds

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,7 +237,8 @@ include = ["src/max_div"]
 
 [tool.codespell]
 # "intoto": the in-toto attestation format (provenance.intoto.jsonl).
-ignore-words-list = "intoto"
+# "sais": surname of a cited author (Lakhdar Sais).
+ignore-words-list = "intoto,sais"
 
 [tool.coverage.run]
 source_pkgs = ["max_div"]


### PR DESCRIPTION
**Problem**: The parallel API shipped with nothing explaining it — what varies per worker and what cannot, how seeding works, or which number in the result tells you whether running several workers helped.

**Solution**: A "Solving in Parallel" section on the solver concepts page, covering the per-worker/shared split and why the score-defining settings cannot vary, one-seed reproducibility with per-worker derivation, and how to read `n_workers_with_best_score`. It also places the word *portfolio*, which has two current meanings and only one of them is what max-div does.

- **Attention:** the planned capability row is **not** in this PR, and needs your call. The grid requires exactly one cell per tool per axis and fails structurally on a missing one, so adding a parallel-solving axis means a verified mark for all ten third-party tools. I would be guessing at most of them, and the records carry `verified:` dates precisely so that guesses do not enter. That is a research task rather than a data edit.
- **Attention:** `codespell` gained one allowance, `sais` — the surname of a cited author, which it reads as a misspelling of "says".
- **TEST:** full suite and the docs lint pass; the section is prose only, with no generated surface touched.

**Changelog** (none): documentation only, and the feature it documents already carries its own entry.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
