### PR TITLE
feat: default the portfolio worker count to half the logical cores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Parallel solving: configure several workers with `ParallelMaxDivSolverBuilder` and they solve one problem at once, sharing a single copy of the distances; the best result comes back with a summary of what every worker found
+- Parallel solving: configure several workers with `ParallelMaxDivSolverBuilder` (defaulting to half the logical cores) and they solve one problem at once, sharing a single copy of the distances; the best result comes back with a summary of what every worker found
 
 ### Changed
 

--- a/src/max_div/_core/solver/_builders/_parallel.py
+++ b/src/max_div/_core/solver/_builders/_parallel.py
@@ -6,7 +6,12 @@ from typing import Self
 from max_div._core._utils import deterministic_hash_int64
 from max_div._core.problem import MaxDivProblem
 from max_div._core.solver._duration import TargetDuration
-from max_div._core.solver._parallel import ParallelMaxDivSolver, WorkerConfig, warn_about_worker_count
+from max_div._core.solver._parallel import (
+    ParallelMaxDivSolver,
+    WorkerConfig,
+    default_worker_count,
+    warn_about_worker_count,
+)
 from max_div._core.solver._presets import get_preset_strategies
 from max_div._core.solver._solver_config import SolverConfig
 from max_div._core.solver._solver_step import InitializationStep
@@ -36,7 +41,9 @@ class ParallelMaxDivSolverBuilder(SolverBuilderBase):
     # -------------------------------------------------------------------------
     #  Builder API
     # -------------------------------------------------------------------------
-    def with_workers(self, target_duration: TargetDuration, workers: int | Sequence[WorkerConfig]) -> Self:
+    def with_workers(
+        self, target_duration: TargetDuration, workers: int | Sequence[WorkerConfig] | None = None
+    ) -> Self:
         """Set what the portfolio runs, and for how long each worker runs it.
 
         The workers run side by side, so the portfolio takes as long as one of them rather than the
@@ -44,9 +51,11 @@ class ParallelMaxDivSolverBuilder(SolverBuilderBase):
         budget keeps them to the same real time where an iteration count would not.
 
         :param workers: an integer runs the default configuration that many times; a sequence gives
-                        one configuration per worker.
+                        one configuration per worker; omitting it uses `default_worker_count()`.
         """
         self._target_duration = target_duration
+        if workers is None:
+            workers = default_worker_count()
         self._worker_configs = [WorkerConfig() for _ in range(workers)] if isinstance(workers, int) else list(workers)
         return self
 

--- a/src/max_div/_core/solver/_parallel/__init__.py
+++ b/src/max_div/_core/solver/_parallel/__init__.py
@@ -9,7 +9,7 @@ from ._coordinator import IndependentCoordinator, WorkerCoordinator
 from ._executor import run_portfolio, solve_in_worker
 from ._result import WorkerResult, best_result
 from ._solution import ParallelMaxDivSolution, WorkerSummary
-from ._solver import ParallelMaxDivSolver, warn_about_worker_count
+from ._solver import ParallelMaxDivSolver, default_worker_count, warn_about_worker_count
 from ._worker_config import WorkerConfig
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     "WorkerResult",
     "WorkerSummary",
     "best_result",
+    "default_worker_count",
     "run_portfolio",
     "solve_in_worker",
     "warn_about_worker_count",

--- a/src/max_div/_core/solver/_parallel/_solver.py
+++ b/src/max_div/_core/solver/_parallel/_solver.py
@@ -92,3 +92,13 @@ def warn_about_worker_count(n_workers: int) -> None:
             ParallelSolvingWarning,
             stacklevel=3,
         )
+
+
+def default_worker_count() -> int:
+    """Return the default portfolio size when the caller names none: half the logical cores, at least 2.
+
+    Half the logical count is the physical-core count on 2-way-SMT machines — the cores a compute- and
+    bandwidth-bound solve can actually use — and a conservative half on machines without SMT, so it
+    never oversubscribes real cores. An explicit count on `with_workers` overrides it.
+    """
+    return max(2, (os.cpu_count() or 2) // 2)

--- a/tests/_core/solver/_builders/test_parallel.py
+++ b/tests/_core/solver/_builders/test_parallel.py
@@ -5,7 +5,7 @@ from max_div._core._warnings import ParallelSolvingWarning
 from max_div._core.problem import MaxDivProblem
 from max_div._core.solver._builders import MaxDivSolverBuilder, ParallelMaxDivSolverBuilder
 from max_div._core.solver._duration import iterations
-from max_div._core.solver._parallel import ParallelMaxDivSolution, WorkerConfig
+from max_div._core.solver._parallel import ParallelMaxDivSolution, WorkerConfig, default_worker_count
 from max_div._core.solver._presets import SolverPreset
 from max_div._core.solver._strategies import InitializationStrategy
 
@@ -140,3 +140,31 @@ def test_building_without_workers_is_rejected():
     # --- arrange / act / assert --------------------------
     with pytest.raises(ValueError, match="needs workers"):
         ParallelMaxDivSolverBuilder(_problem()).build()
+
+
+# =================================================================================================
+#  Default worker count
+# =================================================================================================
+def test_omitting_the_count_uses_the_default(monkeypatch: pytest.MonkeyPatch):
+    """With no worker count given, the portfolio runs half the logical cores (here 8/2 = 4)."""
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr("max_div._core.solver._parallel._solver.os.cpu_count", lambda: 8)
+
+    # --- act ---------------------------------------------
+    solution = ParallelMaxDivSolverBuilder(_problem()).with_seed(5).with_workers(_BUDGET).build().solve()
+
+    # --- assert ------------------------------------------
+    assert len(solution.workers) == 4
+
+
+@pytest.mark.parametrize(
+    "logical,expected",
+    [(16, 8), (12, 6), (8, 4), (4, 2), (2, 2), (1, 2), (None, 2)],
+)
+def test_default_worker_count_is_half_the_cores_at_least_two(monkeypatch: pytest.MonkeyPatch, logical, expected):
+    """The count is half the logical cores, floored at two; an unknown core count also falls back to two."""
+    # --- arrange -----------------------------------------
+    monkeypatch.setattr("max_div._core.solver._parallel._solver.os.cpu_count", lambda: logical)
+
+    # --- act / assert ------------------------------------
+    assert default_worker_count() == expected


### PR DESCRIPTION
**Problem**: `ParallelMaxDivSolverBuilder.with_workers` required an explicit worker count, so every portfolio caller had to pick one even where a sensible default exists.

**Solution**: `workers` is now optional; omitting it runs `max(2, logical // 2)` workers of the default configuration. Half the logical count is the physical-core count under 2-way SMT and never oversubscribes real cores; an explicit count or worker list still overrides it.

- **Attention:** `logical // 2` (via `os.cpu_count()`, read once at configuration) was chosen over a physical-core basis to stay stdlib-only — the cost is under-using non-SMT machines, where a caller can raise the count.
- **SPIKE:** the half-the-cores default comes from an overnight contention + best-of-N measurement — the throughput knee on the large full-matrix problem sits near half the cores, and past it each added worker becomes a weaker best-of-N sample.
- **TEST:** two unit tests added — the builder default via a monkeypatched core count, and `default_worker_count` parametrized over seven core counts (including an unknown one); the parallel-builder suite is green.

**Changelog** (Added): folded into the existing "Parallel solving" Unreleased entry, which now notes the builder "(defaulting to half the logical cores)" rather than adding a separate line.


Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
