### PR TITLE
refactor: make a progress snapshot the input of every progress reporter

### DIFF
--- a/src/max_div/_core/solver/_progress_reporting.py
+++ b/src/max_div/_core/solver/_progress_reporting.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 # =================================================================================================
 @dataclass(frozen=True, slots=True)
 class ProgressSnapshot:
-    """What a reporter can show about one moment of a solve, detached from the solver's live state.
+    """A snapshot records what a reporter can show about one moment of a solve, detached from its live state.
 
     `ProgressReporter` builds one per reporting call and hands it to the rendering methods, so
     renderers never read `SolverState` — a snapshot is self-contained and stays meaningful outside
@@ -52,7 +52,7 @@ class ProgressSnapshot:
 #  Base class
 # =================================================================================================
 class ProgressReporter(ABC):
-    """Reports solver progress; subclasses are pure renderers of `ProgressSnapshot`s.
+    """A progress reporter shows the progress of a running solve; subclasses render `ProgressSnapshot`s.
 
     The solver and its steps call the `solver_step_*`/`update` methods with live state; this base
     class owns the clocks, builds the snapshot, and delegates to the `show_*` methods. Renderers
@@ -83,10 +83,7 @@ class ProgressReporter(ABC):
         *,
         ignore_infeasible_diversity: bool = False,
     ) -> None:
-        """Report current progress and state to the renderer.
-
-        Renderers can choose to not show certain updates they receive, if they come too frequently.
-        """
+        """Report current progress and state to the renderer."""
         self.show_update(self._build_snapshot(progress, state, ignore_infeasible_diversity), get_debug_info)
 
     def solver_step_finished(
@@ -156,7 +153,7 @@ class ProgressReporter(ABC):
 
     @classmethod
     def from_verbosity(cls, verbosity: int) -> ProgressReporter:
-        """Create the reporter a verbosity level names; the only place the integer scheme is decoded.
+        """Create the reporter a verbosity level names; nothing else decodes the integer levels.
 
         Levels: 0 = silent, 10 = tqdm progress bar, 20-23 = progress table from slowest to fastest
         update cadence, 25 = fastest cadence plus a debug-info column.
@@ -174,7 +171,7 @@ class ProgressReporter(ABC):
                     debug_info=False,
                 )
             case 25:
-                # same as 23, but with debug_info enabled
+                # fastest cadence, plus the debug-info column
                 return cls.tabular(c_slowdown=1.01, debug_info=True)
             case _:
                 raise ValueError(f"Invalid verbosity level: {verbosity}")
@@ -199,7 +196,7 @@ class SilentProgressReporter(ProgressReporter):
 #  TQDM
 # =================================================================================================
 class TqdmProgressReporter(ProgressReporter):
-    """A progress reporter showing one tqdm progress bar per solver step."""
+    """A progress reporter that shows one tqdm progress bar per solver step."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -246,7 +243,7 @@ class TqdmProgressReporter(ProgressReporter):
 #  Tabular
 # =================================================================================================
 class TabularProgressReporter(ProgressReporter):
-    """A progress reporter printing one table row per (throttled) update."""
+    """A progress reporter that prints one table row per (throttled) update."""
 
     # -------------------------------------------------------------------------
     #  Constructor

--- a/src/max_div/_core/solver/_progress_reporting.py
+++ b/src/max_div/_core/solver/_progress_reporting.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 import sys
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from time import perf_counter
 from typing import TYPE_CHECKING
 
@@ -18,39 +19,122 @@ if TYPE_CHECKING:
     from numpy._typing import NDArray
 
     from max_div._core.solver._duration import Progress
+    from max_div._core.solver._score import Score
     from max_div._core.solver._solver_state import SolverState
+
+
+# =================================================================================================
+#  ProgressSnapshot
+# =================================================================================================
+@dataclass(frozen=True, slots=True)
+class ProgressSnapshot:
+    """What a reporter can show about one moment of a solve, detached from the solver's live state.
+
+    `ProgressReporter` builds one per reporting call and hands it to the rendering methods, so
+    renderers never read `SolverState` — a snapshot is self-contained and stays meaningful outside
+    the solve that produced it. The selection is held by reference (never copied), keeping
+    construction cheap on the many updates that are throttled away without being shown.
+    """
+
+    step_name: str  # name of the solver step this snapshot was taken in
+    progress: Progress | None  # step progress; None when the step reports none (solver-state init)
+    t_elapsed_solver: float  # seconds since the first step started
+    t_elapsed_step: float  # seconds since the current step started
+    score: Score
+    n_selected: int | np.integer
+    k: int | np.integer
+    m: int | np.integer  # number of constraints
+    selection: NDArray[np.int32]  # currently selected indices, by reference into the live state
+    ignore_infeasible_diversity: bool  # render diversity as not-yet-meaningful while infeasible
 
 
 # =================================================================================================
 #  Base class
 # =================================================================================================
 class ProgressReporter(ABC):
-    @abstractmethod
-    def solver_step_started(self, step_name: str) -> None:
-        """Notify that a new solver step with the provided name has started."""
+    """Reports solver progress; subclasses are pure renderers of `ProgressSnapshot`s.
 
-    @abstractmethod
+    The solver and its steps call the `solver_step_*`/`update` methods with live state; this base
+    class owns the clocks, builds the snapshot, and delegates to the `show_*` methods. Renderers
+    therefore work from snapshots alone and can be driven without a solver attached.
+    """
+
+    def __init__(self) -> None:
+        self._t_start_solver = -1.0
+        self._t_start_step = 0.0
+        self._step_name = ""
+
+    # -------------------------------------------------------------------------
+    #  Main API (called by the solver and its steps)
+    # -------------------------------------------------------------------------
+    def solver_step_started(self, step_name: str) -> None:
+        """Record that a new solver step with the provided name has started, and notify the renderer."""
+        self._step_name = step_name
+        self._t_start_step = perf_counter()
+        if self._t_start_solver < 0:
+            self._t_start_solver = self._t_start_step
+        self.show_step_started(step_name)
+
     def update(
         self,
         progress: Progress,
         state: SolverState,
         get_debug_info: Callable[[], str] | None = None,
-        **kwargs: bool,
+        *,
+        ignore_infeasible_diversity: bool = False,
     ) -> None:
-        """Update progress reporter with current progress and state.
+        """Report current progress and state to the renderer.
 
-        Reporters can choose to not report certain updates they receive, if they come too frequently.
+        Renderers can choose to not show certain updates they receive, if they come too frequently.
         """
+        self.show_update(self._build_snapshot(progress, state, ignore_infeasible_diversity), get_debug_info)
 
-    @abstractmethod
     def solver_step_finished(
         self,
         progress: Progress | None,
         state: SolverState,
         get_debug_info: Callable[[], str] | None = None,
-        **kwargs: bool,
+        *,
+        ignore_infeasible_diversity: bool = False,
     ) -> None:
-        """Notify that the current solver step has finished."""
+        """Report that the current solver step has finished."""
+        self.show_step_finished(self._build_snapshot(progress, state, ignore_infeasible_diversity), get_debug_info)
+
+    # -------------------------------------------------------------------------
+    #  Rendering interface (implemented by subclasses, consuming snapshots only)
+    # -------------------------------------------------------------------------
+    @abstractmethod
+    def show_step_started(self, step_name: str) -> None:
+        """Render the start of a new solver step."""
+
+    @abstractmethod
+    def show_update(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
+        """Render a progress update, or skip it (e.g. when updates come too frequently)."""
+
+    @abstractmethod
+    def show_step_finished(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
+        """Render the end of the current solver step."""
+
+    # -------------------------------------------------------------------------
+    #  Internal
+    # -------------------------------------------------------------------------
+    def _build_snapshot(
+        self, progress: Progress | None, state: SolverState, ignore_infeasible_diversity: bool
+    ) -> ProgressSnapshot:
+        """Build a snapshot of the current progress and state, stamping the elapsed times."""
+        t_now = perf_counter()
+        return ProgressSnapshot(
+            step_name=self._step_name,
+            progress=progress,
+            t_elapsed_solver=t_now - self._t_start_solver,
+            t_elapsed_step=t_now - self._t_start_step,
+            score=state.score,
+            n_selected=state.n_selected,
+            k=state.k,
+            m=state.m,
+            selection=state.selected_index_array,
+            ignore_infeasible_diversity=ignore_infeasible_diversity,
+        )
 
     # -------------------------------------------------------------------------
     #  Factory methods
@@ -70,6 +154,31 @@ class ProgressReporter(ABC):
         """Create a tabular progress reporter."""
         return TabularProgressReporter(c_slowdown=c_slowdown, debug_info=debug_info)
 
+    @classmethod
+    def from_verbosity(cls, verbosity: int) -> ProgressReporter:
+        """Create the reporter a verbosity level names; the only place the integer scheme is decoded.
+
+        Levels: 0 = silent, 10 = tqdm progress bar, 20-23 = progress table from slowest to fastest
+        update cadence, 25 = fastest cadence plus a debug-info column.
+
+        :raises ValueError: If `verbosity` is not one of the levels above.
+        """
+        match verbosity:
+            case 0:
+                return cls.silent()
+            case 10:
+                return cls.tqdm()
+            case 20 | 21 | 22 | 23:
+                return cls.tabular(
+                    c_slowdown=[1.10, 1.05, 1.02, 1.01][verbosity - 20],
+                    debug_info=False,
+                )
+            case 25:
+                # same as 23, but with debug_info enabled
+                return cls.tabular(c_slowdown=1.01, debug_info=True)
+            case _:
+                raise ValueError(f"Invalid verbosity level: {verbosity}")
+
 
 # =================================================================================================
 #  Silent
@@ -77,16 +186,12 @@ class ProgressReporter(ABC):
 class SilentProgressReporter(ProgressReporter):
     """A progress reporter that is fully silent and doesn't output anything."""
 
-    def solver_step_started(self, step_name: str) -> None: ...  # no-op
-    def update(
-        self, progress: Progress, state: SolverState, get_debug_info: Callable[[], str] | None = None, **kwargs: bool
+    def show_step_started(self, step_name: str) -> None: ...  # no-op
+    def show_update(
+        self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None
     ) -> None: ...  # no-op
-    def solver_step_finished(
-        self,
-        progress: Progress | None,
-        state: SolverState,
-        get_debug_info: Callable[[], str] | None = None,
-        **kwargs: bool,
+    def show_step_finished(
+        self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None
     ) -> None: ...  # no-op
 
 
@@ -94,38 +199,32 @@ class SilentProgressReporter(ProgressReporter):
 #  TQDM
 # =================================================================================================
 class TqdmProgressReporter(ProgressReporter):
+    """A progress reporter showing one tqdm progress bar per solver step."""
+
     def __init__(self) -> None:
         super().__init__()
         self._current_step_name: str = ""
         self._current_pbar: tqdm | None = None
 
     # -------------------------------------------------------------------------
-    #  main API
+    #  Rendering interface
     # -------------------------------------------------------------------------
-    def solver_step_started(self, step_name: str) -> None:
+    def show_step_started(self, step_name: str) -> None:
         if (step_name != self._current_step_name) or (not self._current_pbar):
             self._close_current_pbar()  # close previous pbar, if present
             self._current_pbar = tqdm(desc=f"{step_name} ", total=1, file=sys.stdout)  # initialize new pbar
             self._current_step_name = step_name
 
-    def update(
-        self, progress: Progress, state: SolverState, get_debug_info: Callable[[], str] | None = None, **kwargs: bool
-    ) -> None:
-        if self._current_pbar is not None:
+    def show_update(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
+        if (self._current_pbar is not None) and (snapshot.progress is not None):
             # ignore updates coming in before starting a new step or after finishing the current step
-            n = progress.tqdm_n_current
+            n = snapshot.progress.tqdm_n_current
             if n > self._current_pbar.n:
                 self._current_pbar.n = n
-                self._current_pbar.total = progress.tqdm_n_total
+                self._current_pbar.total = snapshot.progress.tqdm_n_total
                 self._current_pbar.refresh()
 
-    def solver_step_finished(
-        self,
-        progress: Progress | None,
-        state: SolverState,
-        get_debug_info: Callable[[], str] | None = None,
-        **kwargs: bool,
-    ) -> None:
+    def show_step_finished(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
         self._close_current_pbar()
 
     # -------------------------------------------------------------------------
@@ -147,6 +246,8 @@ class TqdmProgressReporter(ProgressReporter):
 #  Tabular
 # =================================================================================================
 class TabularProgressReporter(ProgressReporter):
+    """A progress reporter printing one table row per (throttled) update."""
+
     # -------------------------------------------------------------------------
     #  Constructor
     # -------------------------------------------------------------------------
@@ -165,55 +266,42 @@ class TabularProgressReporter(ProgressReporter):
 
         :param debug_info: If `True`, includes additional column with solver step debug info.
         """
+        super().__init__()
+
         # settings
         self._c_slowdown = c_slowdown
         self._debug_info = debug_info
 
         self._progress_table: ProgressTable | None = None
-        self._step_name = ""
 
         # don't show next table line before passing both thresholds below:
-        self._next_report_t_elapsed: float = 0.0
+        self._next_report_t: float = 0.0
         self._next_report_iter: int = 0
-
-        # start times
-        self._t_start_solver = -1.0
-        self._t_start_step = 0.0
 
         # other stats
         self._n_progress_reports_this_step = 0
 
     # -------------------------------------------------------------------------
-    #  Main API
+    #  Rendering interface
     # -------------------------------------------------------------------------
-    def solver_step_started(self, step_name: str) -> None:
+    def show_step_started(self, step_name: str) -> None:
         # make sure table is initialized
-        self._step_name = step_name
         if not self._progress_table:
             self._initialize_table(step_name_width=len(step_name))
 
         # reset progress reporting thresholds
         self._n_progress_reports_this_step = 0
-        self._next_report_t: float = 0.0
-        self._next_report_iter: int = 0
+        self._next_report_t = 0.0
+        self._next_report_iter = 0
 
-        # record step start time
-        self._t_start_step = perf_counter()
-        if self._t_start_solver < 0:
-            self._t_start_solver = self._t_start_step
-
-    def update(
-        self, progress: Progress, state: SolverState, get_debug_info: Callable[[], str] | None = None, **kwargs: bool
-    ) -> None:
-        iter_now = progress.iter_count
-        t_now = perf_counter()
-        t_elapsed_step = t_now - self._t_start_step
+    def show_update(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
+        iter_now = snapshot.progress.iter_count if (snapshot.progress is not None) else 0
+        t_elapsed_step = snapshot.t_elapsed_step
 
         if (iter_now >= self._next_report_iter) and (t_elapsed_step >= self._next_report_t):
             # show table row
             debug_info = get_debug_info() if (self._debug_info and (get_debug_info is not None)) else ""
-            ignore_infeasible_diversity = kwargs.get("ignore_infeasible_diversity", False)
-            self._show_table_row(progress, state, debug_info, ignore_infeasible_diversity)
+            self._show_table_row(snapshot, debug_info)
             self._n_progress_reports_this_step += 1
 
             # update next report thresholds
@@ -221,17 +309,10 @@ class TabularProgressReporter(ProgressReporter):
             t_increment = min(1.0, 0.1 * (self._c_slowdown**self._n_progress_reports_this_step))
             self._next_report_t += t_increment * math.ceil((t_elapsed_step - self._next_report_t) / t_increment)
 
-    def solver_step_finished(
-        self,
-        progress: Progress | None,
-        state: SolverState,
-        get_debug_info: Callable[[], str] | None = None,
-        **kwargs: bool,
-    ) -> None:
+    def show_step_finished(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
         # show final metrics + horizontal table line
         debug_info = get_debug_info() if (self._debug_info and (get_debug_info is not None)) else ""
-        ignore_infeasible_diversity = kwargs.get("ignore_infeasible_diversity", False)
-        self._show_table_row(progress, state, debug_info, ignore_infeasible_diversity)
+        self._show_table_row(snapshot, debug_info)
         self._show_table_line()
 
     # -------------------------------------------------------------------------
@@ -255,36 +336,28 @@ class TabularProgressReporter(ProgressReporter):
         )
         self._progress_table.show_header()
 
-    def _show_table_row(
-        self,
-        progress: Progress | None,
-        state: SolverState,
-        debug_info: str = "",
-        ignore_infeasible_diversity: bool = False,
-    ) -> None:
-        t_now = perf_counter()
-        t_elapsed_solver = t_now - self._t_start_solver
-        t_elapsed_step = t_now - self._t_start_step
-        score = state.score
+    def _show_table_row(self, snapshot: ProgressSnapshot, debug_info: str = "") -> None:
+        progress = snapshot.progress
+        score = snapshot.score
 
-        if ignore_infeasible_diversity and (score.constraints < 1.0):
+        if snapshot.ignore_infeasible_diversity and (score.constraints < 1.0):
             diversity_str = f"({score.diversity:.4e})"  # between brackets if we're ignoring it
         else:
             diversity_str = f"{score.diversity:.6e}"
 
-        self._progress_table.show_progress(  # ty: ignore[unresolved-attribute]  # table is initialized in solver_step_started before any row is shown
+        self._progress_table.show_progress(  # ty: ignore[unresolved-attribute]  # table is initialized in show_step_started before any row is shown
             values=[
-                format_long_time_duration(t_elapsed_solver, n_chars=8),
-                self._step_name,
+                format_long_time_duration(snapshot.t_elapsed_solver, n_chars=8),
+                snapshot.step_name,
                 f"{progress.fraction * 100:.2f}%" if progress else "",
                 f"{progress.iter_count:_}".rjust(10) if progress else "",
-                format_long_time_duration(t_elapsed_step, n_chars=8),
-                f"{state.n_selected:>6}/{state.k:>6}",
-                f"{score.constraints:.6f}" if (state.m > 0) else "/",
+                format_long_time_duration(snapshot.t_elapsed_step, n_chars=8),
+                f"{snapshot.n_selected:>6}/{snapshot.k:>6}",
+                f"{score.constraints:.6f}" if (snapshot.m > 0) else "/",
                 diversity_str,
                 self._get_selection_hash(
-                    selection=state.selected_index_array,  # create hash from currently selected indices...
-                    n=math.ceil((32 * state.n_selected) / state.k),  # ...of length proportional to selection size
+                    selection=snapshot.selection,  # create hash from currently selected indices...
+                    n=math.ceil((32 * snapshot.n_selected) / snapshot.k),  # ...of length proportional to selection size
                 ).ljust(32),
             ]
             + ([debug_info] if self._debug_info else [])

--- a/src/max_div/_core/solver/_progress_reporting.py
+++ b/src/max_div/_core/solver/_progress_reporting.py
@@ -153,7 +153,7 @@ class ProgressReporter(ABC):
 
     @classmethod
     def from_verbosity(cls, verbosity: int) -> ProgressReporter:
-        """Create the reporter a verbosity level names; nothing else decodes the integer levels.
+        """Create the reporter for a verbosity level; the integer levels are decoded only here.
 
         Levels: 0 = silent, 10 = tqdm progress bar, 20-23 = progress table from slowest to fastest
         update cadence, 25 = fastest cadence plus a debug-info column.
@@ -171,7 +171,6 @@ class ProgressReporter(ABC):
                     debug_info=False,
                 )
             case 25:
-                # fastest cadence, plus the debug-info column
                 return cls.tabular(c_slowdown=1.01, debug_info=True)
             case _:
                 raise ValueError(f"Invalid verbosity level: {verbosity}")

--- a/src/max_div/_core/solver/_solver.py
+++ b/src/max_div/_core/solver/_solver.py
@@ -91,24 +91,7 @@ class MaxDivSolver:
         # --- Init ----------------------------------------
 
         # --- progress reporting ---
-        match verbosity:
-            case 0:
-                progress_reporter = ProgressReporter.silent()
-            case 10:
-                progress_reporter = ProgressReporter.tqdm()
-            case 20 | 21 | 22 | 23:
-                progress_reporter = ProgressReporter.tabular(
-                    c_slowdown=[1.10, 1.05, 1.02, 1.01][verbosity - 20],
-                    debug_info=False,
-                )
-            case 25:
-                # same as 23, but with debug_info enabled
-                progress_reporter = ProgressReporter.tabular(
-                    c_slowdown=1.01,
-                    debug_info=True,
-                )
-            case _:
-                raise ValueError(f"Invalid verbosity level: {verbosity}")
+        progress_reporter = ProgressReporter.from_verbosity(verbosity)
 
         # --- solver steps ---
         n_steps = len(self._solver_steps)

--- a/tests/_core/solver/test_progress_reporter.py
+++ b/tests/_core/solver/test_progress_reporter.py
@@ -1,14 +1,57 @@
 from collections.abc import Callable
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
+from max_div._core.solver._duration import Progress
 from max_div._core.solver._progress_reporting import (
     ProgressReporter,
+    ProgressSnapshot,
     SilentProgressReporter,
     TabularProgressReporter,
     TqdmProgressReporter,
 )
+from max_div._core.solver._score import Score
+
+
+def _stub_state(n_selected: int = 3, k: int = 5, m: int = 2) -> SimpleNamespace:
+    """A stand-in for SolverState carrying just the fields snapshot building reads."""
+    return SimpleNamespace(
+        score=Score(size=1.0, constraints=0.5, diversity=0.25, div_tie_breakers=()),
+        n_selected=n_selected,
+        k=k,
+        m=m,
+        selected_index_array=np.arange(n_selected, dtype=np.int32),
+    )
+
+
+def _stub_progress(iter_count: int = 7) -> Progress:
+    """A Progress with fixed, easily recognizable values."""
+    return Progress(
+        tqdm_n_total=100,
+        fraction=0.42,
+        iter_count=iter_count,
+        est_n_iters_remaining=10,
+        est_iters_per_second=2.0,
+    )
+
+
+class _RecordingProgressReporter(ProgressReporter):
+    """Renders nothing; records every show_* call so tests can inspect the snapshots built."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[tuple[str, object]] = []
+
+    def show_step_started(self, step_name: str) -> None:
+        self.calls.append(("started", step_name))
+
+    def show_update(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
+        self.calls.append(("update", snapshot))
+
+    def show_step_finished(self, snapshot: ProgressSnapshot, get_debug_info: Callable[[], str] | None = None) -> None:
+        self.calls.append(("finished", snapshot))
 
 
 @pytest.mark.parametrize(
@@ -53,3 +96,119 @@ def test_progress_reporter_selection_hash(selection: np.ndarray, n: int):
 
     assert hash_str_1 != hash_str_2
     assert hash_str_1[:8] != hash_str_2[:8]  # even first part should be different, if just the last input digit changed
+
+
+@pytest.mark.parametrize(
+    "verbosity, expected_class, expected_c_slowdown, expected_debug_info",
+    [
+        (0, SilentProgressReporter, None, None),
+        (10, TqdmProgressReporter, None, None),
+        (20, TabularProgressReporter, 1.10, False),
+        (21, TabularProgressReporter, 1.05, False),
+        (22, TabularProgressReporter, 1.02, False),
+        (23, TabularProgressReporter, 1.01, False),
+        (25, TabularProgressReporter, 1.01, True),
+    ],
+)
+def test_from_verbosity(
+    verbosity: int,
+    expected_class: type[ProgressReporter],
+    expected_c_slowdown: float | None,
+    expected_debug_info: bool | None,
+):
+    # --- act ---------------------------------------------
+    reporter = ProgressReporter.from_verbosity(verbosity)
+
+    # --- assert ------------------------------------------
+    assert type(reporter) is expected_class
+    if expected_c_slowdown is not None:
+        assert reporter._c_slowdown == expected_c_slowdown
+        assert reporter._debug_info == expected_debug_info
+
+
+@pytest.mark.parametrize("verbosity", [-1, 1, 11, 24, 26, 42])
+def test_from_verbosity_invalid_level(verbosity: int):
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError):
+        ProgressReporter.from_verbosity(verbosity)
+
+
+def test_snapshot_building():
+    """The base class builds snapshots carrying the step name, elapsed times, and the state fields."""
+    # --- arrange -----------------------------------------
+    reporter = _RecordingProgressReporter()
+    state = _stub_state(n_selected=3, k=5, m=2)
+    progress = _stub_progress(iter_count=7)
+
+    # --- act ---------------------------------------------
+    reporter.solver_step_started("step A")
+    reporter.update(progress, state, ignore_infeasible_diversity=True)
+    reporter.solver_step_finished(None, state)
+
+    # --- assert ------------------------------------------
+    assert [call[0] for call in reporter.calls] == ["started", "update", "finished"]
+
+    snapshot = reporter.calls[1][1]
+    assert isinstance(snapshot, ProgressSnapshot)
+    assert snapshot.step_name == "step A"
+    assert snapshot.progress is progress
+    assert snapshot.score is state.score
+    assert (snapshot.n_selected, snapshot.k, snapshot.m) == (3, 5, 2)
+    assert snapshot.selection is state.selected_index_array  # by reference, not copied
+    assert snapshot.ignore_infeasible_diversity is True
+    assert snapshot.t_elapsed_solver >= snapshot.t_elapsed_step >= 0.0
+
+    snapshot_finished = reporter.calls[2][1]
+    assert snapshot_finished.progress is None
+    assert snapshot_finished.ignore_infeasible_diversity is False
+
+
+def test_snapshot_solver_clock_spans_steps():
+    """The solver clock starts at the first step and keeps running across step boundaries."""
+    # --- arrange -----------------------------------------
+    reporter = _RecordingProgressReporter()
+    state = _stub_state()
+
+    # --- act ---------------------------------------------
+    reporter.solver_step_started("step A")
+    reporter.solver_step_started("step B")
+    reporter.update(_stub_progress(), state)
+
+    # --- assert ------------------------------------------
+    snapshot = reporter.calls[-1][1]
+    assert snapshot.step_name == "step B"
+    assert snapshot.t_elapsed_solver >= snapshot.t_elapsed_step  # solver clock was not reset by step B
+
+
+def test_tabular_show_update_without_progress(capsys):
+    """A snapshot without progress renders a row with blank progress columns instead of crashing."""
+    # --- arrange -----------------------------------------
+    reporter = TabularProgressReporter()
+    state = _stub_state()
+
+    # --- act ---------------------------------------------
+    reporter.solver_step_started("step A")
+    reporter.update(None, state)  # ty: ignore[invalid-argument-type]  # deliberately exercising the None path
+
+    # --- assert ------------------------------------------
+    output_lines = [line for line in capsys.readouterr().out.splitlines() if line.startswith("|")]
+    row = output_lines[-1]
+    assert "step A" in row
+    assert "%" not in row  # progress columns are blank
+    assert "3/     5" in row
+
+
+def test_tqdm_show_update_without_progress():
+    """A snapshot without progress leaves the tqdm bar untouched instead of crashing."""
+    # --- arrange -----------------------------------------
+    reporter = TqdmProgressReporter()
+    state = _stub_state()
+    reporter.solver_step_started("step A")
+    n_before = reporter._current_pbar.n
+
+    # --- act ---------------------------------------------
+    reporter.update(None, state)  # ty: ignore[invalid-argument-type]  # deliberately exercising the None path
+
+    # --- assert ------------------------------------------
+    assert reporter._current_pbar.n == n_before
+    reporter.solver_step_finished(None, state)

--- a/tests/_core/solver/test_progress_reporter.py
+++ b/tests/_core/solver/test_progress_reporter.py
@@ -16,7 +16,7 @@ from max_div._core.solver._score import Score
 
 
 def _stub_state(n_selected: int = 3, k: int = 5, m: int = 2) -> SimpleNamespace:
-    """A stand-in for SolverState carrying just the fields snapshot building reads."""
+    """Return a stand-in for SolverState carrying just the fields snapshot building reads."""
     return SimpleNamespace(
         score=Score(size=1.0, constraints=0.5, diversity=0.25, div_tie_breakers=()),
         n_selected=n_selected,
@@ -27,7 +27,7 @@ def _stub_state(n_selected: int = 3, k: int = 5, m: int = 2) -> SimpleNamespace:
 
 
 def _stub_progress(iter_count: int = 7) -> Progress:
-    """A Progress with fixed, easily recognizable values."""
+    """Return a Progress with fixed, easily recognizable values."""
     return Progress(
         tqdm_n_total=100,
         fraction=0.42,
@@ -38,7 +38,7 @@ def _stub_progress(iter_count: int = 7) -> Progress:
 
 
 class _RecordingProgressReporter(ProgressReporter):
-    """Renders nothing; records every show_* call so tests can inspect the snapshots built."""
+    """A reporter that renders nothing and records every show_* call, so tests can inspect the snapshots built."""
 
     def __init__(self) -> None:
         super().__init__()
@@ -116,6 +116,7 @@ def test_from_verbosity(
     expected_c_slowdown: float | None,
     expected_debug_info: bool | None,
 ):
+    """Each verbosity level maps to the expected reporter class and settings."""
     # --- act ---------------------------------------------
     reporter = ProgressReporter.from_verbosity(verbosity)
 
@@ -128,6 +129,7 @@ def test_from_verbosity(
 
 @pytest.mark.parametrize("verbosity", [-1, 1, 11, 24, 26, 42])
 def test_from_verbosity_invalid_level(verbosity: int):
+    """An unknown verbosity level raises ValueError."""
     # --- act & assert ------------------------------------
     with pytest.raises(ValueError):
         ProgressReporter.from_verbosity(verbosity)

--- a/tests/_core/solver/test_solver_step.py
+++ b/tests/_core/solver/test_solver_step.py
@@ -43,6 +43,7 @@ class DummySolverState:
     def __init__(self, n: int, k: int):
         self.n = n
         self.k = k
+        self.m = 0
         self.n_selected = 0
         self.score = Mock()
 
@@ -51,6 +52,10 @@ class DummySolverState:
 
     def add_many(self, samples: NDArray[np.int32]):
         self.n_selected += len(samples)
+
+    @property
+    def selected_index_array(self):
+        return np.arange(self.n_selected, dtype=np.int32)
 
     @property
     def not_selected_index_array(self):

--- a/tests/_core/solver/test_solver_step.py
+++ b/tests/_core/solver/test_solver_step.py
@@ -55,10 +55,12 @@ class DummySolverState:
 
     @property
     def selected_index_array(self):
+        """Return the indices currently counted as selected."""
         return np.arange(self.n_selected, dtype=np.int32)
 
     @property
     def not_selected_index_array(self):
+        """Return the indices not currently counted as selected."""
         return np.arange(self.n, dtype=np.int32)[self.n_selected :]
 
 


### PR DESCRIPTION
**TL;DR**: Progress reporters now render from a light `ProgressSnapshot` built by the base class, instead of reading the live `SolverState` — behavior-preserving, output byte-identical.

## Description

### Problem addressed

Every `ProgressReporter` read straight from `SolverState`, an object that holds the distance store and only exists inside the solving process. That ties rendering to an in-process solve: progress can never be rendered anywhere else — in particular not by a parent process showing the progress of solver worker processes, which have to ship something picklable instead. The tabular reporter also owned the elapsed-time clocks, mixing timekeeping into presentation.

### Implementation

- **`ProgressSnapshot`** — a frozen dataclass carrying the handful of fields the reporters actually show: step name, `Progress`, elapsed times, score, selected/k/m, and the selection array **by reference** (nothing is copied on the many updates that are throttled away).
- **The base class is the adapter**: the `solver_step_started` / `update` / `solver_step_finished` methods the solver and steps call keep their signatures, but now stamp the clocks, build the snapshot, and delegate to new abstract `show_*` methods. Subclasses are pure renderers over snapshots and can be driven without a solver attached.
- **`ProgressReporter.from_verbosity()`** absorbs the verbosity `match` from `MaxDivSolver.solve` — the integer scheme is decoded in exactly one place.
- The `**kwargs: bool` escape hatch on the reporting calls is tightened to the one flag it ever carried, `ignore_infeasible_diversity`, now a snapshot field.

## Attention points

- **Elapsed times are stamped at snapshot construction** (the reporting call) rather than at print time — a difference of microseconds, invisible at the table's formatting resolution.
- `get_debug_info` stays a lazily invoked callable parameter, so the debug string is still only formatted for rows that actually print.
- A snapshot without `Progress` (the solver-state-init step reports none) renders blank progress columns; both reporters now handle that explicitly.

## Tests / Spikes

- **TEST:** single-solver output verified **byte-identical** before vs. after, at verbosity 20 and 25, under a frozen fake clock that makes row selection deterministic (358 table rows compared).
- 7 unit tests added: `from_verbosity` mapping and rejection, snapshot field/clock construction, and the no-progress rendering paths.
- Full suite green (3895 tests), coverage 100% on both touched modules.

## Changelog entry

None: behavior-preserving refactor, no user-facing change.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
