### PR TITLE
test: allow for harness overhead in the micro-benchmark timing bound

### DIFF
--- a/tests/_core/_utils/test_micro_benchmark.py
+++ b/tests/_core/_utils/test_micro_benchmark.py
@@ -6,8 +6,8 @@ from max_div._core._utils import BenchmarkResult, benchmark
 
 # The benchmark harness adds a fixed per-call cost (function call, timer reads) on top of the timed
 # work — an absolute error that on slow CI runners approaches the smallest workload here. The median
-# ceiling below allows for it additively; a purely multiplicative bound would demand the overhead
-# shrink with the workload.
+# ceiling below allows for that overhead additively; a purely multiplicative bound would demand the
+# overhead shrink with the workload.
 _T_OVERHEAD_ALLOWANCE_SEC = 30e-6
 
 

--- a/tests/_core/_utils/test_micro_benchmark.py
+++ b/tests/_core/_utils/test_micro_benchmark.py
@@ -4,12 +4,21 @@ import pytest
 
 from max_div._core._utils import BenchmarkResult, benchmark
 
+# The benchmark harness adds a fixed per-call cost (function call, timer reads) on top of the timed
+# work itself. That cost is an ABSOLUTE error, so the median bound below allows for it additively —
+# a purely multiplicative bound would demand the overhead shrink with the workload, which is what
+# made the smallest workload fail on slow CI runners (~10 µs of overhead observed on a 10 µs spin,
+# breaching the 2x ceiling on every same-runner rerun).
+_T_OVERHEAD_ALLOWANCE_SEC = 30e-6
+
 
 @pytest.mark.flaky(reruns=10)
 @pytest.mark.parametrize("t_sleep", [1e-5, 1e-4, 1e-3])
 @pytest.mark.parametrize("silent", [True, False])
 @pytest.mark.parametrize("index_range", [None, 1000])
 def test_micro_benchmark(t_sleep: float, silent: bool, index_range: int | None):
+    """A busy-wait of a known duration measures near that duration, up to harness overhead."""
+
     # --- arrange -----------------------------------------
     def f_test(_idx: int = 0):
         t_start = perf_counter_ns()
@@ -30,7 +39,7 @@ def test_micro_benchmark(t_sleep: float, silent: bool, index_range: int | None):
     # --- assert ------------------------------------------
     assert isinstance(result, BenchmarkResult)
     assert result.t_sec_q_25 <= result.t_sec_q_50 <= result.t_sec_q_75
-    assert 0.5 * t_sleep <= result.t_sec_q_50 <= 2 * t_sleep
+    assert 0.5 * t_sleep <= result.t_sec_q_50 <= 2 * t_sleep + _T_OVERHEAD_ALLOWANCE_SEC
 
 
 @pytest.mark.parametrize(

--- a/tests/_core/_utils/test_micro_benchmark.py
+++ b/tests/_core/_utils/test_micro_benchmark.py
@@ -5,10 +5,9 @@ import pytest
 from max_div._core._utils import BenchmarkResult, benchmark
 
 # The benchmark harness adds a fixed per-call cost (function call, timer reads) on top of the timed
-# work itself. That cost is an ABSOLUTE error, so the median bound below allows for it additively —
-# a purely multiplicative bound would demand the overhead shrink with the workload, which is what
-# made the smallest workload fail on slow CI runners (~10 µs of overhead observed on a 10 µs spin,
-# breaching the 2x ceiling on every same-runner rerun).
+# work — an absolute error that on slow CI runners approaches the smallest workload here. The median
+# ceiling below allows for it additively; a purely multiplicative bound would demand the overhead
+# shrink with the workload.
 _T_OVERHEAD_ALLOWANCE_SEC = 30e-6
 
 


### PR DESCRIPTION
**Problem**: `test_micro_benchmark` bounds the measured median at 2× the busy-wait duration. The harness's fixed per-call overhead (~10 µs observed on a slow CI runner) breaches that on the 10 µs case — and since `pytest-rerunfailures` reruns share the runner, all 10 attempts fail together, costing whole-job reruns.

**Solution**: the median ceiling gains an additive overhead allowance (30 µs, ~3× the observed overhead) — modeling the error as what it is, an absolute cost, instead of demanding it shrink proportionally with the workload. The 0.5× lower bound and the quantile-ordering assertion are untouched.

- **Attention:** at the 1 ms case the allowance adds only 3% of slack, so the bound still catches order-of-magnitude harness regressions everywhere.
- **TEST:** all 17 micro-benchmark tests pass locally; full suite green (3895).

**Changelog** (none): test-only change, no user-facing effect.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
