### PR TITLE
feat: start SMART and THOROUGH from a randomized farthest-point construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A `Verbosity` enum names the verbosity levels for both solvers (plain integers keep working)
 
 ### Changed
+- SMART and THOROUGH now begin from a lightly randomized farthest-point construction: short-budget results improve and constrained problems reach competitor-level quality sooner; a given seed selects different but equally diverse items than before
 
 ### Deprecated
 

--- a/src/max_div/_core/solver/_presets/preset_smart.py
+++ b/src/max_div/_core/solver/_presets/preset_smart.py
@@ -15,7 +15,8 @@ def get_preset_strategies_smart(
     # The greedy farthest-point construction reaches competitor-level quality far sooner than a
     # random start, but its pure form costs quality on unconstrained problems at long budget; a
     # short random prefix (random_fraction=0.1) removes that penalty while keeping most of the
-    # short-budget edge. random_fraction stays off the public farthest_point() factory.
+    # short-budget edge. random_fraction stays off the public farthest_point() factory, until a
+    # more final implementation has been decided upon.
     init_strategy = InitFarthestPoint(random_fraction=0.1)
 
     # --- optimization steps ------------------------------

--- a/src/max_div/_core/solver/_presets/preset_smart.py
+++ b/src/max_div/_core/solver/_presets/preset_smart.py
@@ -12,10 +12,10 @@ def get_preset_strategies_smart(
     thorough: bool = False,
 ) -> tuple[InitializationStrategy, list[OptimizationStep]]:
     # --- initialization ----------------------------------
-    # A lightly randomized farthest-point construction. The greedy construction reaches
-    # competitor-level quality far sooner than a random start, but at long budget the pure form
-    # costs quality on unconstrained problems; a short random prefix (f=0.1) removes that penalty
-    # while keeping most of the short-budget edge. random_fraction stays off the public factory.
+    # The greedy farthest-point construction reaches competitor-level quality far sooner than a
+    # random start, but its pure form costs quality on unconstrained problems at long budget; a
+    # short random prefix (random_fraction=0.1) removes that penalty while keeping most of the
+    # short-budget edge. random_fraction stays off the public farthest_point() factory.
     init_strategy = InitFarthestPoint(random_fraction=0.1)
 
     # --- optimization steps ------------------------------

--- a/src/max_div/_core/solver/_presets/preset_smart.py
+++ b/src/max_div/_core/solver/_presets/preset_smart.py
@@ -1,6 +1,7 @@
 from max_div._core.solver._duration import TargetDuration
 from max_div._core.solver._solver_step import OptimizationStep
 from max_div._core.solver._strategies import InitializationStrategy, OptimizationStrategy
+from max_div._core.solver._strategies._initialization._init_farthest_point import InitFarthestPoint
 
 
 # =================================================================================================
@@ -11,7 +12,11 @@ def get_preset_strategies_smart(
     thorough: bool = False,
 ) -> tuple[InitializationStrategy, list[OptimizationStep]]:
     # --- initialization ----------------------------------
-    init_strategy = InitializationStrategy.random_one_shot(uniform=True, ignore_constraints=True)
+    # A lightly randomized farthest-point construction. The greedy construction reaches
+    # competitor-level quality far sooner than a random start, but at long budget the pure form
+    # costs quality on unconstrained problems; a short random prefix (f=0.1) removes that penalty
+    # while keeping most of the short-budget edge. random_fraction stays off the public factory.
+    init_strategy = InitFarthestPoint(random_fraction=0.1)
 
     # --- optimization steps ------------------------------
     if thorough:

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
@@ -20,6 +20,12 @@ class InitFarthestPoint(InitializationStrategy):
 
     Constraints are ignored by design; feasibility is left to the optimization steps.
 
+    A `random_fraction` above zero widens the random start into a random *prefix*: the first
+    `round(random_fraction * k)` items (at least one) are drawn uniformly at random in a single
+    batch, and the greedy picks fill the rest. The endpoints meet the existing strategies: 0.0 is
+    the single random start and 1.0 a fully random selection. The prefix trades a little of the
+    pure construction's peak quality for diversity among start points.
+
     Suggested use: when the strongest possible starting point is desired, e.g. at short time
     budgets.
 
@@ -27,9 +33,20 @@ class InitFarthestPoint(InitializationStrategy):
        - ~O(n * k), times d when distances are computed on demand from vectors.
     """
 
+    def __init__(self, random_fraction: float = 0.0) -> None:
+        """Create the strategy; `random_fraction` in [0, 1] sets the random-prefix size.
+
+        :raises ValueError: If `random_fraction` is outside [0, 1].
+        """
+        super().__init__()
+        if not (0.0 <= random_fraction <= 1.0):
+            raise ValueError(f"random_fraction must be in [0, 1], got {random_fraction}")
+        self._random_fraction = random_fraction
+
     def get_next_samples(self, state: SolverState, k_remaining: int | np.int32) -> NDArray[np.int32]:
         if state.n_selected == 0:
-            return randint(n=state.n, k=np.int32(1), replace=False, p=P_UNIFORM, rng_state=self._rng_state)
+            n_random = min(max(round(self._random_fraction * int(state.k)), 1), int(state.k))
+            return randint(n=state.n, k=np.int32(n_random), replace=False, p=P_UNIFORM, rng_state=self._rng_state)
         # both arrays below are ascending-index, so positions align
         contributions = state.not_selected_contribution_array
         return np.array([state.not_selected_index_array[np.argmax(contributions)]], dtype=np.int32)

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
@@ -22,9 +22,9 @@ class InitFarthestPoint(InitializationStrategy):
 
     A `random_fraction` above zero widens the random start into a random *prefix*: the first
     `round(random_fraction * k)` items (at least one) are drawn uniformly at random in a single
-    batch, and the greedy picks fill the rest. The endpoints meet the existing strategies: 0.0 is
-    the single random start and 1.0 a fully random selection. The prefix trades a little of the
-    pure construction's peak quality for diversity among start points.
+    batch, and the greedy picks fill the rest. At the endpoints, 0.0 is the pure farthest-point
+    construction from a single random seed, and 1.0 is a fully random selection. The prefix trades
+    a little of the pure construction's peak quality for diversity among start points.
 
     Suggested use: when the strongest possible starting point is desired, e.g. at short time
     budgets.

--- a/tests/_core/solver/_presets/test_main.py
+++ b/tests/_core/solver/_presets/test_main.py
@@ -5,7 +5,18 @@ import pytest
 from max_div._core.solver import SolverPreset
 from max_div._core.solver._duration import TargetDuration, iterations, seconds
 from max_div._core.solver._presets import get_preset_strategies
+from max_div._core.solver._strategies._initialization import InitializationStrategy
+from max_div._core.solver._strategies._initialization._init_farthest_point import InitFarthestPoint
 from max_div._core.solver._strategies._initialization._init_random_one_shot import InitRandomOneShot
+
+# expected initialization strategy per resolved preset: SMART/THOROUGH start from the farthest-point
+# construction, RANDOM/GUIDED from a random one-shot draw
+_EXPECTED_INIT: dict[SolverPreset, type[InitializationStrategy]] = {
+    SolverPreset.RANDOM: InitRandomOneShot,
+    SolverPreset.GUIDED: InitRandomOneShot,
+    SolverPreset.SMART: InitFarthestPoint,
+    SolverPreset.THOROUGH: InitFarthestPoint,
+}
 
 
 @pytest.mark.parametrize(
@@ -19,13 +30,13 @@ from max_div._core.solver._strategies._initialization._init_random_one_shot impo
 )
 @pytest.mark.parametrize("preset", list(SolverPreset))
 def test_get_preset_strategies(preset: SolverPreset, target_duration: TargetDuration):
-    """Perform some rudimentary checks for expected outcome."""
+    """Each preset yields its expected init strategy, at least one optim step, and the requested duration."""
 
     # --- act ---------------------------------------------
-    init_strat, optim_steps = get_preset_strategies(SolverPreset.DEFAULT, target_duration)
+    init_strat, optim_steps = get_preset_strategies(preset, target_duration)
 
     # --- assert ------------------------------------------
-    assert isinstance(init_strat, InitRandomOneShot)  # by default we choose fast initialization
+    assert isinstance(init_strat, _EXPECTED_INIT[preset.resolve_alias()])
     assert len(optim_steps) > 0  # at least 1 optimization step
     assert optim_steps[0]._duration == target_duration  # should be as requested
 

--- a/tests/_core/solver/_presets/test_main.py
+++ b/tests/_core/solver/_presets/test_main.py
@@ -9,7 +9,7 @@ from max_div._core.solver._strategies._initialization import InitializationStrat
 from max_div._core.solver._strategies._initialization._init_farthest_point import InitFarthestPoint
 from max_div._core.solver._strategies._initialization._init_random_one_shot import InitRandomOneShot
 
-# expected init strategy per resolved preset (DEFAULT resolves to its alias's entry)
+# Look up each preset by its resolved alias, so DEFAULT falls back to SMART's entry.
 _EXPECTED_INIT: dict[SolverPreset, type[InitializationStrategy]] = {
     SolverPreset.RANDOM: InitRandomOneShot,
     SolverPreset.GUIDED: InitRandomOneShot,

--- a/tests/_core/solver/_presets/test_main.py
+++ b/tests/_core/solver/_presets/test_main.py
@@ -9,8 +9,7 @@ from max_div._core.solver._strategies._initialization import InitializationStrat
 from max_div._core.solver._strategies._initialization._init_farthest_point import InitFarthestPoint
 from max_div._core.solver._strategies._initialization._init_random_one_shot import InitRandomOneShot
 
-# expected initialization strategy per resolved preset: SMART/THOROUGH start from the farthest-point
-# construction, RANDOM/GUIDED from a random one-shot draw
+# expected init strategy per resolved preset (DEFAULT resolves to its alias's entry)
 _EXPECTED_INIT: dict[SolverPreset, type[InitializationStrategy]] = {
     SolverPreset.RANDOM: InitRandomOneShot,
     SolverPreset.GUIDED: InitRandomOneShot,

--- a/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
+++ b/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
@@ -101,7 +101,7 @@ def test_init_farthest_point_random_prefix_size(random_fraction: float, expected
 
     # --- assert ------------------------------------------
     assert len(first_batch) == expected_prefix
-    assert len({int(i) for i in first_batch}) == expected_prefix  # all distinct
+    assert len({int(i) for i in first_batch}) == expected_prefix  # the drawn items are all distinct
 
 
 def test_init_farthest_point_full_random_prefix_skips_greedy():
@@ -115,7 +115,7 @@ def test_init_farthest_point_full_random_prefix_skips_greedy():
     InitializationStep(InitFarthestPoint(random_fraction=0.0)).run(state_greedy)
 
     # --- assert ------------------------------------------
-    assert state_full.score.size == 1.0  # reached full size k in the single random batch
+    assert state_full.score.size == 1.0  # the single random batch reached full size k
     full_selection = {int(i) for i in state_full.selected_index_array}
     greedy_selection = {int(i) for i in state_greedy.selected_index_array}
-    assert full_selection != greedy_selection  # random fill, not the greedy construction
+    assert full_selection != greedy_selection  # a random fill differs from the greedy construction

--- a/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
+++ b/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
@@ -3,6 +3,7 @@ import pytest
 
 from max_div._core.solver._solver_step import InitializationStep
 from max_div._core.solver._strategies import InitializationStrategy
+from max_div._core.solver._strategies._initialization._init_farthest_point import InitFarthestPoint
 
 from ._helpers import new_solver_state
 
@@ -75,3 +76,46 @@ def test_init_farthest_point_name():
 
     # --- assert ------------------------------------------
     assert strategy.name == "InitFarthestPoint"
+
+
+@pytest.mark.parametrize("random_fraction", [-0.1, 1.1, 2.0])
+def test_init_farthest_point_rejects_out_of_range_random_fraction(random_fraction: float):
+    """random_fraction must lie in [0, 1]."""
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError, match="random_fraction"):
+        InitFarthestPoint(random_fraction=random_fraction)
+
+
+@pytest.mark.parametrize(
+    "random_fraction, expected_prefix",
+    [(0.0, 1), (0.1, 5), (0.5, 25), (1.0, 50)],  # the shared state has k=50
+)
+def test_init_farthest_point_random_prefix_size(random_fraction: float, expected_prefix: int):
+    """The first batch draws round(random_fraction * k) distinct random items, at least one."""
+    # --- arrange -----------------------------------------
+    solver_state = new_solver_state(has_constraints=False)
+    strategy = InitFarthestPoint(random_fraction=random_fraction)
+
+    # --- act ---------------------------------------------
+    first_batch = strategy.get_next_samples(solver_state, solver_state.k)
+
+    # --- assert ------------------------------------------
+    assert len(first_batch) == expected_prefix
+    assert len({int(i) for i in first_batch}) == expected_prefix  # all distinct
+
+
+def test_init_farthest_point_full_random_prefix_skips_greedy():
+    """random_fraction=1.0 fills the whole selection in one random batch, never running a greedy pick."""
+    # --- arrange -----------------------------------------
+    state_full = new_solver_state(has_constraints=False)
+    state_greedy = new_solver_state(has_constraints=False)
+
+    # --- act ---------------------------------------------
+    InitializationStep(InitFarthestPoint(random_fraction=1.0)).run(state_full)
+    InitializationStep(InitFarthestPoint(random_fraction=0.0)).run(state_greedy)
+
+    # --- assert ------------------------------------------
+    assert state_full.score.size == 1.0  # reached full size k in the single random batch
+    full_selection = {int(i) for i in state_full.selected_index_array}
+    greedy_selection = {int(i) for i in state_greedy.selected_index_array}
+    assert full_selection != greedy_selection  # random fill, not the greedy construction

--- a/tests/_core/solver/golden_master_data_jit.json
+++ b/tests/_core/solver/golden_master_data_jit.json
@@ -971,254 +971,13 @@
   "U1|SMART|42": {
    "i_selected": [
     0,
-    18,
-    31,
-    42,
-    51,
-    60,
-    71,
+    19,
+    36,
+    47,
+    56,
+    66,
+    70,
     82,
-    90,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.03098338283598423,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.038619108498096466,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.059142742305994034,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.06367482990026474,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0776430070400238,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0776430070400238,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0776430070400238,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978850603104,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978850603104,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978850603104,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09439842402935028,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09439842402935028,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09439842402935028,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U1|SMART|123": {
-   "i_selected": [
-    1,
-    21,
-    30,
-    42,
-    48,
-    57,
-    68,
-    81,
     89,
     99
    ],
@@ -1233,10 +992,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.039089713245630264,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1245,7 +1004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.039203159511089325,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1254,7 +1013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0795603021979332,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1263,7 +1022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0795603021979332,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1272,7 +1031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0846029669046402,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1281,7 +1040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0846029669046402,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1290,7 +1049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08745618164539337,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1299,7 +1058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09243730455636978,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1308,7 +1067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1317,7 +1076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1326,7 +1085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1335,7 +1094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1344,7 +1103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1353,7 +1112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1362,7 +1121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1371,7 +1130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10346855968236923,
      "div_tie_breakers": [
       1.0
      ]
@@ -1380,7 +1139,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09907945245504379,
+     "diversity": 0.10346855968236923,
      "div_tie_breakers": [
       1.0
      ]
@@ -1389,7 +1148,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1006428673863411,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1398,7 +1157,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1006428673863411,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1407,7 +1166,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1006428673863411,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1416,7 +1175,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1006428673863411,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1425,7 +1184,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1006428673863411,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1434,7 +1193,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1006428673863411,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1443,7 +1202,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1006428673863411,
+     "diversity": 0.10383649915456772,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U1|SMART|123": {
+   "i_selected": [
+    3,
+    13,
+    25,
+    32,
+    45,
+    53,
+    67,
+    76,
+    88,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
      "div_tie_breakers": [
       1.0
      ]
@@ -1453,254 +1453,13 @@
   "U1|THOROUGH|42": {
    "i_selected": [
     0,
-    18,
-    31,
-    45,
-    51,
+    19,
+    36,
+    47,
+    56,
     66,
-    71,
+    70,
     82,
-    89,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.03098338283598423,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.038619108498096466,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.059142742305994034,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.06367482990026474,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0776430070400238,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0776430070400238,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0776430070400238,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978850603104,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978850603104,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978850603104,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534832239151,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09055756777524948,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09055756777524948,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09055756777524948,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0958327129483223,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0958327129483223,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0958327129483223,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0958327129483223,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09878473728895187,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U1|THOROUGH|123": {
-   "i_selected": [
-    1,
-    21,
-    30,
-    43,
-    48,
-    54,
-    68,
-    81,
     89,
     99
    ],
@@ -1715,10 +1474,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.039089713245630264,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1727,7 +1486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.039203159511089325,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1736,7 +1495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0795603021979332,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1745,7 +1504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0795603021979332,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1754,7 +1513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0846029669046402,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1763,7 +1522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0846029669046402,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1772,7 +1531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08745618164539337,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1781,7 +1540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09243730455636978,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1790,7 +1549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1799,7 +1558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1808,7 +1567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1817,7 +1576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1826,7 +1585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706136584281921,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1835,7 +1594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1844,7 +1603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10229168832302094,
      "div_tie_breakers": [
       1.0
      ]
@@ -1853,7 +1612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10346855968236923,
      "div_tie_breakers": [
       1.0
      ]
@@ -1862,7 +1621,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10346855968236923,
      "div_tie_breakers": [
       1.0
      ]
@@ -1871,7 +1630,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1880,7 +1639,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1889,7 +1648,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1898,7 +1657,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1907,7 +1666,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1916,7 +1675,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10383649915456772,
      "div_tie_breakers": [
       1.0
      ]
@@ -1925,7 +1684,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611070871353,
+     "diversity": 0.10383649915456772,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U1|THOROUGH|123": {
+   "i_selected": [
+    3,
+    13,
+    25,
+    32,
+    45,
+    53,
+    67,
+    76,
+    88,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891639709473,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768631309270859,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120121389627457,
      "div_tie_breakers": [
       1.0
      ]
@@ -2898,15 +2898,15 @@
   },
   "U2|SMART|42": {
    "i_selected": [
-    0,
-    26,
-    35,
-    64,
-    67,
-    82,
-    85,
+    11,
+    29,
+    56,
+    66,
+    75,
+    81,
+    86,
+    93,
     95,
-    98,
     99
    ],
    "score_checkpoints": [
@@ -2920,10 +2920,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.12326381355524063,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -2932,7 +2932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17312733829021454,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -2941,7 +2941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.24174833297729492,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -2950,7 +2950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.26252907514572144,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -2959,7 +2959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3198699951171875,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -2968,7 +2968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -2977,7 +2977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -2986,7 +2986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -2995,7 +2995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3004,7 +3004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3013,7 +3013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3022,7 +3022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3031,7 +3031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3040,7 +3040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3049,7 +3049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3058,7 +3058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3067,7 +3067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3076,7 +3076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3085,7 +3085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819776535034,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3094,7 +3094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819776535034,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3103,7 +3103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819776535034,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3112,7 +3112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819776535034,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3121,7 +3121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45580530166625977,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3130,7 +3130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45580530166625977,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3139,252 +3139,11 @@
   },
   "U2|SMART|123": {
    "i_selected": [
-    0,
-    43,
+    3,
     46,
-    67,
-    75,
-    81,
-    89,
-    95,
-    98,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0835219994187355,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08613166213035583,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.2673461139202118,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.2952224910259247,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.39458006620407104,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4440087378025055,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4543173015117645,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4543173015117645,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4543173015117645,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4543173015117645,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4543173015117645,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4543173015117645,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4543173015117645,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45446592569351196,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45477157831192017,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45477157831192017,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45477157831192017,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U2|THOROUGH|42": {
-   "i_selected": [
-    4,
-    33,
-    45,
-    65,
-    67,
+    51,
+    70,
+    73,
     82,
     85,
     95,
@@ -3402,10 +3161,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.12326381355524063,
+     "diversity": 0.43518683314323425,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518683314323425,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518683314323425,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518683314323425,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518683314323425,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518683314323425,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518683314323425,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4478932023048401,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4478932023048401,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4478932023048401,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4557018280029297,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4557018280029297,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4557018280029297,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201707839966,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201707839966,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201707839966,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201707839966,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201707839966,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201707839966,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201707839966,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46346214413642883,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46346214413642883,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46346214413642883,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46346214413642883,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U2|THOROUGH|42": {
+   "i_selected": [
+    11,
+    29,
+    56,
+    66,
+    75,
+    81,
+    86,
+    93,
+    95,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3414,7 +3414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17312733829021454,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3423,7 +3423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.24174833297729492,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3432,7 +3432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.26252907514572144,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3441,7 +3441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3198699951171875,
+     "diversity": 0.41756176948547363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3450,7 +3450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3459,7 +3459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3468,7 +3468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3477,7 +3477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3486,7 +3486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3495,7 +3495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3504,7 +3504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3513,7 +3513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3522,7 +3522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3531,7 +3531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3540,7 +3540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43594518303871155,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3549,7 +3549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819776535034,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3558,7 +3558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45327797532081604,
+     "diversity": 0.4308570325374603,
      "div_tie_breakers": [
       1.0
      ]
@@ -3567,7 +3567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885256290436,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3576,7 +3576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885256290436,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3585,7 +3585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885256290436,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3594,7 +3594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885256290436,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3603,7 +3603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.47805726528167725,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3612,7 +3612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.47805726528167725,
+     "diversity": 0.4582439661026001,
      "div_tie_breakers": [
       1.0
      ]
@@ -3621,13 +3621,13 @@
   },
   "U2|THOROUGH|123": {
    "i_selected": [
-    1,
-    43,
+    3,
+    41,
     46,
     67,
-    75,
-    81,
-    86,
+    69,
+    82,
+    83,
     95,
     96,
     99
@@ -3643,10 +3643,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0835219994187355,
+     "diversity": 0.43518683314323425,
      "div_tie_breakers": [
       1.0
      ]
@@ -3655,7 +3655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08613166213035583,
+     "diversity": 0.43518683314323425,
      "div_tie_breakers": [
       1.0
      ]
@@ -3664,7 +3664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2673461139202118,
+     "diversity": 0.43518683314323425,
      "div_tie_breakers": [
       1.0
      ]
@@ -3673,7 +3673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2952224910259247,
+     "diversity": 0.43518683314323425,
      "div_tie_breakers": [
       1.0
      ]
@@ -3682,7 +3682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.39458006620407104,
+     "diversity": 0.43518683314323425,
      "div_tie_breakers": [
       1.0
      ]
@@ -3691,7 +3691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4440087378025055,
+     "diversity": 0.43518683314323425,
      "div_tie_breakers": [
       1.0
      ]
@@ -3700,7 +3700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4543173015117645,
+     "diversity": 0.43518683314323425,
      "div_tie_breakers": [
       1.0
      ]
@@ -3709,7 +3709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4543173015117645,
+     "diversity": 0.4478932023048401,
      "div_tie_breakers": [
       1.0
      ]
@@ -3718,7 +3718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4543173015117645,
+     "diversity": 0.4478932023048401,
      "div_tie_breakers": [
       1.0
      ]
@@ -3727,7 +3727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4543173015117645,
+     "diversity": 0.4478932023048401,
      "div_tie_breakers": [
       1.0
      ]
@@ -3736,7 +3736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4543173015117645,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3745,7 +3745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4543173015117645,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3754,7 +3754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3763,7 +3763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3772,7 +3772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3781,7 +3781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3790,7 +3790,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3799,7 +3799,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3808,7 +3808,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3817,7 +3817,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.4691455662250519,
      "div_tie_breakers": [
       1.0
      ]
@@ -3826,7 +3826,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.47511792182922363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3835,7 +3835,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.47511792182922363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3844,7 +3844,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.47511792182922363,
      "div_tie_breakers": [
       1.0
      ]
@@ -3853,7 +3853,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433916687965393,
+     "diversity": 0.47511792182922363,
      "div_tie_breakers": [
       1.0
      ]
@@ -4826,15 +4826,15 @@
   },
   "U3|SMART|42": {
    "i_selected": [
-    18,
-    53,
-    67,
-    70,
-    76,
-    84,
+    0,
+    66,
+    72,
+    80,
+    85,
     88,
     91,
     93,
+    96,
     99
    ],
    "score_checkpoints": [
@@ -4848,10 +4848,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1871611624956131,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4860,7 +4860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.34849292039871216,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4869,7 +4869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.576622486114502,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4878,7 +4878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.576622486114502,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4887,7 +4887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7366434335708618,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4896,7 +4896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504183769226,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4905,7 +4905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504183769226,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4914,7 +4914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504183769226,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4923,7 +4923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317726135254,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4932,7 +4932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317726135254,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4941,7 +4941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317726135254,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4950,7 +4950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7720941305160522,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4959,7 +4959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4968,7 +4968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4977,7 +4977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4986,7 +4986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -4995,7 +4995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5004,7 +5004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5013,7 +5013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847795128822327,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5022,7 +5022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847795128822327,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5031,7 +5031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847795128822327,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5040,7 +5040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847795128822327,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5049,7 +5049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9351944327354431,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5058,7 +5058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9351944327354431,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5067,15 +5067,15 @@
   },
   "U3|SMART|123": {
    "i_selected": [
-    1,
-    56,
-    68,
-    75,
-    83,
-    88,
-    91,
-    93,
-    96,
+    3,
+    57,
+    69,
+    77,
+    86,
+    89,
+    92,
+    94,
+    97,
     99
    ],
    "score_checkpoints": [
@@ -5089,10 +5089,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2262745499610901,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5101,7 +5101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.28073492646217346,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5110,7 +5110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4658738672733307,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5119,7 +5119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4861883223056793,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5128,7 +5128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5813131928443909,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5137,7 +5137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6414871215820312,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5146,7 +5146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7771451473236084,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5155,7 +5155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9227909445762634,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5164,7 +5164,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5173,7 +5173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5182,7 +5182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5191,7 +5191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5200,7 +5200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5209,7 +5209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5218,7 +5218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5227,7 +5227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5236,7 +5236,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5245,7 +5245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5254,7 +5254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5263,7 +5263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5272,7 +5272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -5281,7 +5281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -5290,7 +5290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -5299,7 +5299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -5308,11 +5308,11 @@
   },
   "U3|THOROUGH|42": {
    "i_selected": [
-    1,
-    53,
-    67,
-    76,
-    86,
+    0,
+    66,
+    72,
+    80,
+    85,
     88,
     91,
     93,
@@ -5330,10 +5330,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1871611624956131,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5342,7 +5342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.34849292039871216,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5351,7 +5351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.576622486114502,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5360,7 +5360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.576622486114502,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5369,7 +5369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7366434335708618,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5378,7 +5378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504183769226,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5387,7 +5387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504183769226,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5396,7 +5396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504183769226,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5405,7 +5405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317726135254,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5414,7 +5414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317726135254,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5423,7 +5423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317726135254,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5432,7 +5432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7720941305160522,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5441,7 +5441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5450,7 +5450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5459,7 +5459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5468,7 +5468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5477,7 +5477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096672058105,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5486,7 +5486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680708408355713,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5495,7 +5495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680708408355713,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5504,7 +5504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680708408355713,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5513,7 +5513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680708408355713,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5522,7 +5522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680708408355713,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5531,7 +5531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9066054224967957,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5540,7 +5540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9066054224967957,
+     "diversity": 0.9586768746376038,
      "div_tie_breakers": [
       1.0
      ]
@@ -5549,15 +5549,15 @@
   },
   "U3|THOROUGH|123": {
    "i_selected": [
-    1,
-    56,
-    68,
-    75,
-    83,
-    88,
-    91,
-    93,
-    96,
+    3,
+    57,
+    69,
+    77,
+    86,
+    89,
+    92,
+    94,
+    97,
     99
    ],
    "score_checkpoints": [
@@ -5571,10 +5571,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2262745499610901,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5583,7 +5583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.28073492646217346,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5592,7 +5592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4658738672733307,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5601,7 +5601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4861883223056793,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5610,7 +5610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5813131928443909,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5619,7 +5619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6414871215820312,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5628,7 +5628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7771451473236084,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5637,7 +5637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9227909445762634,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5646,7 +5646,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5655,7 +5655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5664,7 +5664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5673,7 +5673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5682,7 +5682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5691,7 +5691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5700,7 +5700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5709,7 +5709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5718,7 +5718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5727,7 +5727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5736,7 +5736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5745,7 +5745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9592085480690002,
      "div_tie_breakers": [
       1.0
      ]
@@ -5754,7 +5754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -5763,7 +5763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -5772,7 +5772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -5781,7 +5781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9632148146629333,
+     "diversity": 0.9616219401359558,
      "div_tie_breakers": [
       1.0
      ]
@@ -6754,14 +6754,14 @@
   },
   "U4|SMART|42": {
    "i_selected": [
-    3,
-    18,
-    31,
-    43,
-    52,
-    60,
-    70,
-    82,
+    0,
+    20,
+    41,
+    49,
+    59,
+    66,
+    76,
+    86,
     91,
     99
    ],
@@ -6776,10 +6776,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.049069520086050034,
+     "diversity": 0.10113362222909927,
      "div_tie_breakers": [
       1.0
      ]
@@ -6788,7 +6788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.060288842767477036,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6797,7 +6797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07948840409517288,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6806,7 +6806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07948840409517288,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6815,7 +6815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08600838482379913,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6824,7 +6824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08600838482379913,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6833,7 +6833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08600838482379913,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6842,7 +6842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08808093518018723,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6851,7 +6851,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08808093518018723,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6860,7 +6860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08808093518018723,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6869,7 +6869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6878,7 +6878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6887,7 +6887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6896,7 +6896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6905,7 +6905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -6914,7 +6914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10395938158035278,
      "div_tie_breakers": [
       1.0
      ]
@@ -6923,7 +6923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10395938158035278,
      "div_tie_breakers": [
       1.0
      ]
@@ -6932,7 +6932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502201318741,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -6941,7 +6941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0969708114862442,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -6950,7 +6950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0969708114862442,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -6959,7 +6959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0969708114862442,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -6968,7 +6968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0969708114862442,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -6977,7 +6977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10160002112388611,
+     "diversity": 0.10678783059120178,
      "div_tie_breakers": [
       1.0
      ]
@@ -6986,7 +6986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1046142503619194,
+     "diversity": 0.10678783059120178,
      "div_tie_breakers": [
       1.0
      ]
@@ -6995,495 +6995,13 @@
   },
   "U4|SMART|123": {
    "i_selected": [
-    1,
-    21,
-    32,
-    50,
-    61,
-    72,
+    0,
+    19,
+    30,
+    48,
+    57,
+    68,
     80,
-    90,
-    92,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0363093800842762,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0363093800842762,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.053276170045137405,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.053276170045137405,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.06719834357500076,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08718644082546234,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09057459235191345,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10203799605369568,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10203799605369568,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10389792919158936,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10389792919158936,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10389792919158936,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10606702417135239,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U4|THOROUGH|42": {
-   "i_selected": [
-    3,
-    18,
-    31,
-    43,
-    52,
-    60,
-    70,
-    82,
-    91,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.049069520086050034,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.060288842767477036,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07948840409517288,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07948840409517288,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08600838482379913,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08600838482379913,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08600838482379913,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08808093518018723,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08808093518018723,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08808093518018723,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502201318741,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0969708114862442,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0969708114862442,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0969708114862442,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0969708114862442,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10160002112388611,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1046142503619194,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U4|THOROUGH|123": {
-   "i_selected": [
-    1,
-    21,
-    32,
-    50,
-    61,
-    72,
-    78,
     87,
     93,
     99
@@ -7499,10 +7017,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0363093800842762,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208819389343,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208819389343,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208819389343,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10961883515119553,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10961883515119553,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10961883515119553,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10961883515119553,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10961883515119553,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10961883515119553,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10961883515119553,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U4|THOROUGH|42": {
+   "i_selected": [
+    0,
+    20,
+    41,
+    49,
+    59,
+    66,
+    76,
+    86,
+    91,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10113362222909927,
      "div_tie_breakers": [
       1.0
      ]
@@ -7511,7 +7270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0363093800842762,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7520,7 +7279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.053276170045137405,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7529,7 +7288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.053276170045137405,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7538,7 +7297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.06719834357500076,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7547,7 +7306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08718644082546234,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7556,7 +7315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09057459235191345,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7565,7 +7324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10203799605369568,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7574,7 +7333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10203799605369568,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7583,7 +7342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10389792919158936,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7592,7 +7351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10389792919158936,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7601,7 +7360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10389792919158936,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7610,7 +7369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7619,7 +7378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7628,7 +7387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10308264195919037,
      "div_tie_breakers": [
       1.0
      ]
@@ -7637,7 +7396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10395938158035278,
      "div_tie_breakers": [
       1.0
      ]
@@ -7646,7 +7405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10395938158035278,
      "div_tie_breakers": [
       1.0
      ]
@@ -7655,7 +7414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -7664,7 +7423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -7673,7 +7432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -7682,7 +7441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -7691,7 +7450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10625467449426651,
      "div_tie_breakers": [
       1.0
      ]
@@ -7700,7 +7459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10678783059120178,
      "div_tie_breakers": [
       1.0
      ]
@@ -7709,7 +7468,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10606702417135239,
+     "diversity": 0.10678783059120178,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U4|THOROUGH|123": {
+   "i_selected": [
+    1,
+    19,
+    30,
+    48,
+    57,
+    66,
+    80,
+    89,
+    93,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1047920435667038,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208819389343,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208819389343,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208819389343,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10804302245378494,
      "div_tie_breakers": [
       1.0
      ]
@@ -8682,16 +8682,16 @@
   },
   "C1|SMART|42": {
    "i_selected": [
-    24,
-    32,
-    65,
-    81,
+    5,
+    29,
+    41,
+    69,
+    76,
     82,
     86,
-    91,
     95,
-    97,
-    98
+    96,
+    99
    ],
    "score_checkpoints": [
     {
@@ -8704,10 +8704,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.5020173192024231,
+     "constraints": 1.0,
+     "diversity": 0.7363571524620056,
      "div_tie_breakers": [
       1.0
      ]
@@ -8716,7 +8716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.694080650806427,
+     "diversity": 0.7363571524620056,
      "div_tie_breakers": [
       1.0
      ]
@@ -8725,7 +8725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7676450610160828,
+     "diversity": 0.7363571524620056,
      "div_tie_breakers": [
       1.0
      ]
@@ -8734,7 +8734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.752679169178009,
      "div_tie_breakers": [
       1.0
      ]
@@ -8743,7 +8743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.752679169178009,
      "div_tie_breakers": [
       1.0
      ]
@@ -8752,7 +8752,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8761,7 +8761,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8770,7 +8770,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8779,7 +8779,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8788,7 +8788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8797,7 +8797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8806,7 +8806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8815,7 +8815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8824,7 +8824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8833,7 +8833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8842,7 +8842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -8851,7 +8851,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7887588143348694,
      "div_tie_breakers": [
       1.0
      ]
@@ -8860,7 +8860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -8869,7 +8869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -8878,7 +8878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -8887,7 +8887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -8896,7 +8896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -8905,7 +8905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8007652163505554,
+     "diversity": 0.8223950266838074,
      "div_tie_breakers": [
       1.0
      ]
@@ -8914,7 +8914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8007652163505554,
+     "diversity": 0.8223950266838074,
      "div_tie_breakers": [
       1.0
      ]
@@ -8923,14 +8923,14 @@
   },
   "C1|SMART|123": {
    "i_selected": [
-    0,
+    3,
+    41,
     50,
-    51,
-    54,
-    68,
-    79,
-    91,
-    93,
+    66,
+    69,
+    76,
+    83,
+    95,
     97,
     99
    ],
@@ -8945,10 +8945,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.26414167881011963,
+     "constraints": 1.0,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -8957,7 +8957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2633856534957886,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -8966,7 +8966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32067981362342834,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -8975,7 +8975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4989123046398163,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -8984,7 +8984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4989123046398163,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -8993,7 +8993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433660507202,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9002,7 +9002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433660507202,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9011,7 +9011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791264533997,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9020,7 +9020,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791264533997,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9029,7 +9029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5914677381515503,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9038,7 +9038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473773121833801,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9047,7 +9047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473773121833801,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9056,7 +9056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473773121833801,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9065,7 +9065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473773121833801,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9074,7 +9074,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473773121833801,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9083,7 +9083,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473773121833801,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9092,7 +9092,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807508468628,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9101,7 +9101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807508468628,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9110,7 +9110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807508468628,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9119,7 +9119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807508468628,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9128,7 +9128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7254599928855896,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9137,7 +9137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7254599928855896,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9146,7 +9146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.765504777431488,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9155,7 +9155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.765504777431488,
+     "diversity": 0.7453342080116272,
      "div_tie_breakers": [
       1.0
      ]
@@ -9164,15 +9164,15 @@
   },
   "C1|THOROUGH|42": {
    "i_selected": [
-    24,
-    32,
-    65,
-    81,
+    5,
+    29,
+    41,
+    69,
+    76,
     82,
     86,
-    91,
     95,
-    97,
+    96,
     99
    ],
    "score_checkpoints": [
@@ -9186,10 +9186,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.5020173192024231,
+     "constraints": 1.0,
+     "diversity": 0.7363571524620056,
      "div_tie_breakers": [
       1.0
      ]
@@ -9198,7 +9198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.694080650806427,
+     "diversity": 0.7363571524620056,
      "div_tie_breakers": [
       1.0
      ]
@@ -9207,7 +9207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7676450610160828,
+     "diversity": 0.7363571524620056,
      "div_tie_breakers": [
       1.0
      ]
@@ -9216,7 +9216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.752679169178009,
      "div_tie_breakers": [
       1.0
      ]
@@ -9225,7 +9225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.752679169178009,
      "div_tie_breakers": [
       1.0
      ]
@@ -9234,7 +9234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9243,7 +9243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9252,7 +9252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9261,7 +9261,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9270,7 +9270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9279,7 +9279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9288,7 +9288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9297,7 +9297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9306,7 +9306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9315,7 +9315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9324,7 +9324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7664602994918823,
      "div_tie_breakers": [
       1.0
      ]
@@ -9333,7 +9333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7887588143348694,
      "div_tie_breakers": [
       1.0
      ]
@@ -9342,7 +9342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -9351,7 +9351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -9360,7 +9360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -9369,7 +9369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -9378,7 +9378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056266784668,
+     "diversity": 0.7916809320449829,
      "div_tie_breakers": [
       1.0
      ]
@@ -9387,7 +9387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8274317383766174,
+     "diversity": 0.8223950266838074,
      "div_tie_breakers": [
       1.0
      ]
@@ -9396,7 +9396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8274317383766174,
+     "diversity": 0.8223950266838074,
      "div_tie_breakers": [
       1.0
      ]
@@ -9405,12 +9405,12 @@
   },
   "C1|THOROUGH|123": {
    "i_selected": [
-    14,
-    28,
-    50,
+    5,
     51,
-    81,
-    82,
+    66,
+    71,
+    76,
+    85,
     91,
     95,
     97,
@@ -9427,10 +9427,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.26414167881011963,
+     "constraints": 1.0,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -9439,7 +9439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2633856534957886,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -9448,7 +9448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32067981362342834,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -9457,7 +9457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4989123046398163,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -9466,7 +9466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4989123046398163,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -9475,7 +9475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433660507202,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9484,7 +9484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433660507202,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9493,7 +9493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791264533997,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9502,7 +9502,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791264533997,
+     "diversity": 0.7304893732070923,
      "div_tie_breakers": [
       1.0
      ]
@@ -9511,7 +9511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791264533997,
+     "diversity": 0.7570629715919495,
      "div_tie_breakers": [
       1.0
      ]
@@ -9520,7 +9520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5685062408447266,
+     "diversity": 0.7570629715919495,
      "div_tie_breakers": [
       1.0
      ]
@@ -9529,7 +9529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5685062408447266,
+     "diversity": 0.7570629715919495,
      "div_tie_breakers": [
       1.0
      ]
@@ -9538,7 +9538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325744628906,
+     "diversity": 0.7782083749771118,
      "div_tie_breakers": [
       1.0
      ]
@@ -9547,7 +9547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325744628906,
+     "diversity": 0.784830629825592,
      "div_tie_breakers": [
       1.0
      ]
@@ -9556,7 +9556,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325744628906,
+     "diversity": 0.784830629825592,
      "div_tie_breakers": [
       1.0
      ]
@@ -9565,7 +9565,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325744628906,
+     "diversity": 0.784830629825592,
      "div_tie_breakers": [
       1.0
      ]
@@ -9574,7 +9574,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6658862233161926,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -9583,7 +9583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6863036155700684,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -9592,7 +9592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7115437984466553,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -9601,7 +9601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7115437984466553,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -9610,7 +9610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486228942871,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -9619,7 +9619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486228942871,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -9628,7 +9628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486228942871,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -9637,7 +9637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486228942871,
+     "diversity": 0.8146164417266846,
      "div_tie_breakers": [
       1.0
      ]
@@ -10611,254 +10611,13 @@
   "C2|SMART|42": {
    "i_selected": [
     24,
-    25,
-    65,
-    81,
-    82,
+    32,
+    66,
+    79,
+    85,
     86,
     91,
     95,
-    97,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.09090909090909083,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.5020173192024231,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.694080650806427,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7839762568473816,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C2|SMART|123": {
-   "i_selected": [
-    0,
-    43,
-    54,
-    58,
-    76,
-    80,
-    86,
-    94,
     97,
     99
    ],
@@ -10873,10 +10632,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.26414167881011963,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7363571524620056,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7113420367240906,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.757997453212738,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8031050562858582,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8065439462661743,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C2|SMART|123": {
+   "i_selected": [
+    20,
+    25,
+    65,
+    81,
+    85,
+    86,
+    91,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.09090909090909083,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -10885,7 +10885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.8181818181818181,
-     "diversity": 0.25265225768089294,
+     "diversity": 0.6353946328163147,
      "div_tie_breakers": [
       1.0
      ]
@@ -10894,7 +10894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.29785433411598206,
+     "diversity": 0.618280291557312,
      "div_tie_breakers": [
       1.0
      ]
@@ -10903,7 +10903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40262269973754883,
+     "diversity": 0.618280291557312,
      "div_tie_breakers": [
       1.0
      ]
@@ -10912,7 +10912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43921494483947754,
+     "diversity": 0.6201636791229248,
      "div_tie_breakers": [
       1.0
      ]
@@ -10921,7 +10921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6649495959281921,
+     "diversity": 0.6201636791229248,
      "div_tie_breakers": [
       1.0
      ]
@@ -10930,7 +10930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637256622314,
+     "diversity": 0.669047474861145,
      "div_tie_breakers": [
       1.0
      ]
@@ -10939,7 +10939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637256622314,
+     "diversity": 0.672282874584198,
      "div_tie_breakers": [
       1.0
      ]
@@ -10948,7 +10948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7110719084739685,
      "div_tie_breakers": [
       1.0
      ]
@@ -10957,7 +10957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7570779323577881,
      "div_tie_breakers": [
       1.0
      ]
@@ -10966,7 +10966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7570779323577881,
      "div_tie_breakers": [
       1.0
      ]
@@ -10975,7 +10975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7570779323577881,
      "div_tie_breakers": [
       1.0
      ]
@@ -10984,7 +10984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -10993,7 +10993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11002,7 +11002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11011,7 +11011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11020,7 +11020,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11029,7 +11029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11038,7 +11038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11047,7 +11047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11056,7 +11056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11065,7 +11065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11074,7 +11074,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11083,7 +11083,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.7988981604576111,
      "div_tie_breakers": [
       1.0
      ]
@@ -11093,254 +11093,13 @@
   "C2|THOROUGH|42": {
    "i_selected": [
     24,
-    25,
-    65,
-    81,
-    82,
+    32,
+    66,
+    79,
+    85,
     86,
     91,
     95,
-    97,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.09090909090909083,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.5020173192024231,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.694080650806427,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450610160828,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7839762568473816,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C2|THOROUGH|123": {
-   "i_selected": [
-    0,
-    43,
-    54,
-    58,
-    76,
-    80,
-    86,
-    94,
     97,
     99
    ],
@@ -11355,10 +11114,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.26414167881011963,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7363571524620056,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7113420367240906,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288918495178223,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197931289673,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.757997453212738,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.785374641418457,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8031050562858582,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8065439462661743,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C2|THOROUGH|123": {
+   "i_selected": [
+    25,
+    29,
+    65,
+    69,
+    81,
+    82,
+    86,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.09090909090909083,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7298109531402588,
      "div_tie_breakers": [
       1.0
      ]
@@ -11367,7 +11367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.8181818181818181,
-     "diversity": 0.25265225768089294,
+     "diversity": 0.6353946328163147,
      "div_tie_breakers": [
       1.0
      ]
@@ -11376,7 +11376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.29785433411598206,
+     "diversity": 0.618280291557312,
      "div_tie_breakers": [
       1.0
      ]
@@ -11385,7 +11385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40262269973754883,
+     "diversity": 0.618280291557312,
      "div_tie_breakers": [
       1.0
      ]
@@ -11394,7 +11394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43921494483947754,
+     "diversity": 0.6201636791229248,
      "div_tie_breakers": [
       1.0
      ]
@@ -11403,7 +11403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6649495959281921,
+     "diversity": 0.6201636791229248,
      "div_tie_breakers": [
       1.0
      ]
@@ -11412,7 +11412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637256622314,
+     "diversity": 0.669047474861145,
      "div_tie_breakers": [
       1.0
      ]
@@ -11421,7 +11421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637256622314,
+     "diversity": 0.6807375550270081,
      "div_tie_breakers": [
       1.0
      ]
@@ -11430,7 +11430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7190234661102295,
      "div_tie_breakers": [
       1.0
      ]
@@ -11439,7 +11439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7353701591491699,
      "div_tie_breakers": [
       1.0
      ]
@@ -11448,7 +11448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7353701591491699,
      "div_tie_breakers": [
       1.0
      ]
@@ -11457,7 +11457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462896108627319,
+     "diversity": 0.7353701591491699,
      "div_tie_breakers": [
       1.0
      ]
@@ -11466,7 +11466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7353701591491699,
      "div_tie_breakers": [
       1.0
      ]
@@ -11475,7 +11475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7916664481163025,
      "div_tie_breakers": [
       1.0
      ]
@@ -11484,7 +11484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7916664481163025,
      "div_tie_breakers": [
       1.0
      ]
@@ -11493,7 +11493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926370620728,
+     "diversity": 0.7916664481163025,
      "div_tie_breakers": [
       1.0
      ]
@@ -11502,7 +11502,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.7916664481163025,
      "div_tie_breakers": [
       1.0
      ]
@@ -11511,7 +11511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.806788980960846,
      "div_tie_breakers": [
       1.0
      ]
@@ -11520,7 +11520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.806788980960846,
      "div_tie_breakers": [
       1.0
      ]
@@ -11529,7 +11529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.806788980960846,
      "div_tie_breakers": [
       1.0
      ]
@@ -11538,7 +11538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.806788980960846,
      "div_tie_breakers": [
       1.0
      ]
@@ -11547,7 +11547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.806788980960846,
      "div_tie_breakers": [
       1.0
      ]
@@ -11556,7 +11556,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.806788980960846,
      "div_tie_breakers": [
       1.0
      ]
@@ -11565,7 +11565,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683876991272,
+     "diversity": 0.806788980960846,
      "div_tie_breakers": [
       1.0
      ]
@@ -12538,16 +12538,16 @@
   },
   "C3|SMART|42": {
    "i_selected": [
-    17,
-    28,
-    54,
-    68,
-    107,
-    110,
-    133,
-    141,
+    16,
+    44,
+    86,
+    98,
+    124,
+    127,
+    137,
     145,
-    148
+    147,
+    149
    ],
    "score_checkpoints": [
     {
@@ -12560,28 +12560,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6666666666666667,
-     "diversity": 4.88346829641273e-09,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 1.0454369814283382e-08,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2984633445739746,
+     "diversity": 0.51189786195755,
      "div_tie_breakers": [
       1.0
      ]
@@ -12590,7 +12572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.51189786195755,
      "div_tie_breakers": [
       1.0
      ]
@@ -12599,7 +12581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5135583877563477,
      "div_tie_breakers": [
       1.0
      ]
@@ -12608,7 +12590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12617,7 +12599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12626,7 +12608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12635,7 +12617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12644,7 +12626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12653,7 +12635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12662,7 +12644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4862046539783478,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12671,7 +12653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126585960388,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12680,7 +12662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126585960388,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12689,7 +12671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126585960388,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12698,7 +12680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126585960388,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12707,7 +12689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377370595932,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12716,7 +12698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377370595932,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -12725,7 +12707,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377370595932,
+     "diversity": 0.5210878849029541,
      "div_tie_breakers": [
       1.0
      ]
@@ -12734,7 +12716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377370595932,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -12743,7 +12725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377370595932,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -12752,7 +12734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377370595932,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -12761,7 +12743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49525198340415955,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -12770,7 +12752,25 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49525198340415955,
+     "diversity": 0.5257596969604492,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.530687153339386,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.530687153339386,
      "div_tie_breakers": [
       1.0
      ]
@@ -12779,15 +12779,15 @@
   },
   "C3|SMART|123": {
    "i_selected": [
-    10,
-    45,
-    51,
-    95,
-    96,
-    128,
-    130,
-    143,
+    26,
+    42,
+    102,
+    103,
+    127,
+    131,
+    139,
     145,
+    147,
     149
    ],
    "score_checkpoints": [
@@ -12801,10 +12801,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.19673216342926025,
+     "constraints": 1.0,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12813,7 +12813,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12822,7 +12822,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12831,7 +12831,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12840,7 +12840,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12849,7 +12849,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12858,7 +12858,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12867,7 +12867,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49814918637275696,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12876,7 +12876,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49883195757865906,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12885,7 +12885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49883195757865906,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12894,7 +12894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49883195757865906,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12903,7 +12903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49883195757865906,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12912,7 +12912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5141459703445435,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12921,7 +12921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5141459703445435,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12930,7 +12930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5141459703445435,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -12939,7 +12939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5141459703445435,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -12948,7 +12948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372923851013,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -12957,7 +12957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372923851013,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -12966,7 +12966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372923851013,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -12975,7 +12975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372923851013,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -12984,7 +12984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.527382493019104,
+     "diversity": 0.5112220048904419,
      "div_tie_breakers": [
       1.0
      ]
@@ -12993,7 +12993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.527382493019104,
+     "diversity": 0.5112220048904419,
      "div_tie_breakers": [
       1.0
      ]
@@ -13002,7 +13002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.527382493019104,
+     "diversity": 0.5112220048904419,
      "div_tie_breakers": [
       1.0
      ]
@@ -13011,7 +13011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5305420756340027,
+     "diversity": 0.5112220048904419,
      "div_tie_breakers": [
       1.0
      ]
@@ -13020,15 +13020,15 @@
   },
   "C3|THOROUGH|42": {
    "i_selected": [
-    17,
-    48,
-    63,
-    106,
-    107,
+    16,
+    44,
+    86,
+    102,
+    124,
     130,
-    132,
-    141,
+    137,
     145,
+    147,
     149
    ],
    "score_checkpoints": [
@@ -13042,28 +13042,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6666666666666667,
-     "diversity": 4.88346829641273e-09,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 1.0454369814283382e-08,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2984633445739746,
+     "diversity": 0.51189786195755,
      "div_tie_breakers": [
       1.0
      ]
@@ -13072,7 +13054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.51189786195755,
      "div_tie_breakers": [
       1.0
      ]
@@ -13081,7 +13063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5135583877563477,
      "div_tie_breakers": [
       1.0
      ]
@@ -13090,7 +13072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13099,7 +13081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13108,7 +13090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13117,7 +13099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13126,7 +13108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906779885292053,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13135,7 +13117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44007477164268494,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13144,7 +13126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44007477164268494,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13153,7 +13135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44007477164268494,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13162,7 +13144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44007477164268494,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13171,7 +13153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4588708281517029,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13180,7 +13162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4588708281517029,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13189,7 +13171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5152265429496765,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13198,7 +13180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5152265429496765,
+     "diversity": 0.5206162929534912,
      "div_tie_breakers": [
       1.0
      ]
@@ -13207,7 +13189,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245596885681,
+     "diversity": 0.5210878849029541,
      "div_tie_breakers": [
       1.0
      ]
@@ -13216,7 +13198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245596885681,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -13225,7 +13207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245596885681,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -13234,7 +13216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245596885681,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -13243,7 +13225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245596885681,
+     "diversity": 0.5257596969604492,
      "div_tie_breakers": [
       1.0
      ]
@@ -13252,7 +13234,25 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245596885681,
+     "diversity": 0.5257596969604492,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.52920001745224,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.52920001745224,
      "div_tie_breakers": [
       1.0
      ]
@@ -13261,15 +13261,15 @@
   },
   "C3|THOROUGH|123": {
    "i_selected": [
-    13,
-    46,
-    56,
-    96,
+    26,
+    54,
     102,
-    125,
-    128,
-    144,
+    103,
+    127,
+    131,
+    139,
     145,
+    147,
     149
    ],
    "score_checkpoints": [
@@ -13283,10 +13283,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.19673216342926025,
+     "constraints": 1.0,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13295,7 +13295,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13304,7 +13304,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13313,7 +13313,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13322,7 +13322,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13331,7 +13331,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13340,7 +13340,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895130634308,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13349,7 +13349,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49814918637275696,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13358,7 +13358,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5038048028945923,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13367,7 +13367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5038048028945923,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13376,7 +13376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.506422758102417,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13385,7 +13385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.506422758102417,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13394,7 +13394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5243911743164062,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13403,7 +13403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13412,7 +13412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.4976486265659332,
      "div_tie_breakers": [
       1.0
      ]
@@ -13421,7 +13421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13430,7 +13430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13439,7 +13439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13448,7 +13448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13457,7 +13457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13466,7 +13466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13475,7 +13475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13484,7 +13484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -13493,7 +13493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280835032463074,
+     "diversity": 0.5011175274848938,
      "div_tie_breakers": [
       1.0
      ]
@@ -14466,14 +14466,14 @@
   },
   "C4|SMART|42": {
    "i_selected": [
-    14,
-    31,
-    39,
+    4,
+    27,
+    28,
     54,
-    67,
-    70,
-    101,
-    107,
+    58,
+    100,
+    103,
+    132,
     145,
     149
    ],
@@ -14488,28 +14488,55 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.625,
-     "diversity": 4.88346829641273e-09,
+     "constraints": 0.8125,
+     "diversity": 0.51189786195755,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 6.171485100736618e-09,
+     "diversity": 0.4092804491519928,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.4927343428134918,
+     "div_tie_breakers": [
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.1723412573337555,
+     "diversity": 0.45410990715026855,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.28410547971725464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.28027448058128357,
      "div_tie_breakers": [
       1.0
      ]
@@ -14518,7 +14545,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1611602008342743,
+     "diversity": 0.21290870010852814,
      "div_tie_breakers": [
       1.0
      ]
@@ -14527,7 +14554,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17001815140247345,
+     "diversity": 0.21290870010852814,
      "div_tie_breakers": [
       1.0
      ]
@@ -14536,7 +14563,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.21771110594272614,
      "div_tie_breakers": [
       1.0
      ]
@@ -14545,7 +14572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.21771110594272614,
      "div_tie_breakers": [
       1.0
      ]
@@ -14554,7 +14581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -14563,7 +14590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -14572,7 +14599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776297688484192,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -14581,7 +14608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776297688484192,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -14590,7 +14617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776297688484192,
+     "diversity": 0.3234667479991913,
      "div_tie_breakers": [
       1.0
      ]
@@ -14599,7 +14626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.3234667479991913,
      "div_tie_breakers": [
       1.0
      ]
@@ -14608,7 +14635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.3402751684188843,
      "div_tie_breakers": [
       1.0
      ]
@@ -14617,7 +14644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.3619333803653717,
      "div_tie_breakers": [
       1.0
      ]
@@ -14626,7 +14653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.36519527435302734,
      "div_tie_breakers": [
       1.0
      ]
@@ -14635,7 +14662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.40812453627586365,
      "div_tie_breakers": [
       1.0
      ]
@@ -14644,7 +14671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.28421103954315186,
+     "diversity": 0.40812453627586365,
      "div_tie_breakers": [
       1.0
      ]
@@ -14653,7 +14680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31391388177871704,
+     "diversity": 0.40812453627586365,
      "div_tie_breakers": [
       1.0
      ]
@@ -14662,7 +14689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31391388177871704,
+     "diversity": 0.4196354150772095,
      "div_tie_breakers": [
       1.0
      ]
@@ -14671,34 +14698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31391388177871704,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3472690284252167,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3472690284252167,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3472690284252167,
+     "diversity": 0.4196354150772095,
      "div_tie_breakers": [
       1.0
      ]
@@ -14707,16 +14707,16 @@
   },
   "C4|SMART|123": {
    "i_selected": [
-    20,
-    22,
-    46,
-    56,
-    68,
-    87,
+    17,
+    19,
+    48,
+    53,
+    77,
+    102,
     103,
-    139,
+    133,
     145,
-    149
+    147
    ],
    "score_checkpoints": [
     {
@@ -14729,10 +14729,28 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.4976486265659332,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.5008677840232849,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.19673216342926025,
+     "diversity": 0.4048536717891693,
      "div_tie_breakers": [
       1.0
      ]
@@ -14741,7 +14759,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.35185307264328003,
      "div_tie_breakers": [
       1.0
      ]
@@ -14750,7 +14768,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.3708398938179016,
      "div_tie_breakers": [
       1.0
      ]
@@ -14759,7 +14777,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.3804384171962738,
      "div_tie_breakers": [
       1.0
      ]
@@ -14768,7 +14786,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.3804384171962738,
      "div_tie_breakers": [
       1.0
      ]
@@ -14777,7 +14795,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.3804384171962738,
      "div_tie_breakers": [
       1.0
      ]
@@ -14786,7 +14804,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -14795,7 +14813,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3333321213722229,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -14804,7 +14822,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581639528274536,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -14813,7 +14831,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581639528274536,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -14822,7 +14840,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581639528274536,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -14831,7 +14849,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581639528274536,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14840,7 +14858,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3938915729522705,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14849,7 +14867,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.39502307772636414,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14858,7 +14876,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.39502307772636414,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14867,7 +14885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.39502307772636414,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14876,7 +14894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40344518423080444,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14885,7 +14903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40344518423080444,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14894,7 +14912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40344518423080444,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14903,7 +14921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40344518423080444,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14912,7 +14930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40344518423080444,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14921,25 +14939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40344518423080444,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.40344518423080444,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4164593815803528,
+     "diversity": 0.41690677404403687,
      "div_tie_breakers": [
       1.0
      ]
@@ -14948,14 +14948,14 @@
   },
   "C4|THOROUGH|42": {
    "i_selected": [
-    14,
-    31,
-    39,
-    54,
-    67,
-    70,
-    101,
-    107,
+    4,
+    19,
+    27,
+    50,
+    56,
+    100,
+    103,
+    132,
     145,
     149
    ],
@@ -14970,28 +14970,55 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.625,
-     "diversity": 4.88346829641273e-09,
+     "constraints": 0.8125,
+     "diversity": 0.51189786195755,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 6.171485100736618e-09,
+     "diversity": 0.4092804491519928,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.4927343428134918,
+     "div_tie_breakers": [
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.1723412573337555,
+     "diversity": 0.45410990715026855,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.28410547971725464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.28027448058128357,
      "div_tie_breakers": [
       1.0
      ]
@@ -15000,7 +15027,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1611602008342743,
+     "diversity": 0.21290870010852814,
      "div_tie_breakers": [
       1.0
      ]
@@ -15009,7 +15036,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17001815140247345,
+     "diversity": 0.21290870010852814,
      "div_tie_breakers": [
       1.0
      ]
@@ -15018,7 +15045,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.21771110594272614,
      "div_tie_breakers": [
       1.0
      ]
@@ -15027,7 +15054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.21771110594272614,
      "div_tie_breakers": [
       1.0
      ]
@@ -15036,7 +15063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -15045,7 +15072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1724127233028412,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -15054,7 +15081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776297688484192,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -15063,7 +15090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776297688484192,
+     "diversity": 0.3204943537712097,
      "div_tie_breakers": [
       1.0
      ]
@@ -15072,7 +15099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776297688484192,
+     "diversity": 0.3234667479991913,
      "div_tie_breakers": [
       1.0
      ]
@@ -15081,7 +15108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.3234667479991913,
      "div_tie_breakers": [
       1.0
      ]
@@ -15090,7 +15117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.3402751684188843,
      "div_tie_breakers": [
       1.0
      ]
@@ -15099,7 +15126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.3619333803653717,
      "div_tie_breakers": [
       1.0
      ]
@@ -15108,7 +15135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.40907859802246094,
      "div_tie_breakers": [
       1.0
      ]
@@ -15117,7 +15144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273574471473694,
+     "diversity": 0.40907859802246094,
      "div_tie_breakers": [
       1.0
      ]
@@ -15126,7 +15153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.28421103954315186,
+     "diversity": 0.40907859802246094,
      "div_tie_breakers": [
       1.0
      ]
@@ -15135,7 +15162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31391388177871704,
+     "diversity": 0.40907859802246094,
      "div_tie_breakers": [
       1.0
      ]
@@ -15144,7 +15171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31391388177871704,
+     "diversity": 0.4127112627029419,
      "div_tie_breakers": [
       1.0
      ]
@@ -15153,34 +15180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31391388177871704,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3472690284252167,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3472690284252167,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3472690284252167,
+     "diversity": 0.4127112627029419,
      "div_tie_breakers": [
       1.0
      ]
@@ -15189,16 +15189,16 @@
   },
   "C4|THOROUGH|123": {
    "i_selected": [
-    22,
-    25,
-    44,
-    57,
-    73,
-    100,
-    101,
-    137,
+    17,
+    26,
+    48,
+    53,
+    77,
+    102,
+    103,
+    133,
     145,
-    149
+    147
    ],
    "score_checkpoints": [
     {
@@ -15211,10 +15211,28 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.4976486265659332,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.5008677840232849,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.19673216342926025,
+     "diversity": 0.4048536717891693,
      "div_tie_breakers": [
       1.0
      ]
@@ -15223,7 +15241,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.35185307264328003,
      "div_tie_breakers": [
       1.0
      ]
@@ -15232,7 +15250,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.25156325101852417,
+     "diversity": 0.3708398938179016,
      "div_tie_breakers": [
       1.0
      ]
@@ -15241,7 +15259,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.3804384171962738,
      "div_tie_breakers": [
       1.0
      ]
@@ -15250,7 +15268,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.3804384171962738,
      "div_tie_breakers": [
       1.0
      ]
@@ -15259,7 +15277,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.3804384171962738,
      "div_tie_breakers": [
       1.0
      ]
@@ -15268,7 +15286,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734112739563,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15277,7 +15295,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3333321213722229,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15286,7 +15304,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3704644441604614,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15295,7 +15313,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3704644441604614,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15304,7 +15322,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3704644441604614,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15313,7 +15331,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3704644441604614,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15322,7 +15340,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.37825441360473633,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15331,7 +15349,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3869827091693878,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15340,7 +15358,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3869827091693878,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15349,7 +15367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3869827091693878,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15358,7 +15376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38941365480422974,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15367,7 +15385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38941365480422974,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15376,7 +15394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3910003900527954,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15385,7 +15403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40122002363204956,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15394,7 +15412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4251360595226288,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]
@@ -15403,25 +15421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4251360595226288,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4251360595226288,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4251360595226288,
+     "diversity": 0.41467854380607605,
      "div_tie_breakers": [
       1.0
      ]

--- a/tests/_core/solver/golden_master_data_nojit.json
+++ b/tests/_core/solver/golden_master_data_nojit.json
@@ -971,254 +971,13 @@
   "U1|SMART|42": {
    "i_selected": [
     0,
-    18,
-    31,
-    42,
-    51,
-    60,
-    71,
+    19,
+    36,
+    47,
+    56,
+    66,
+    70,
     82,
-    90,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.030983379632396488,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.03861910430894172,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.059142739162203695,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.06367482314229743,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07764300691825043,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07764300691825043,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07764300691825043,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978167972452,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978167972452,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978167972452,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09439842130753354,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09439842130753354,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09439842130753354,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U1|SMART|123": {
-   "i_selected": [
-    1,
-    21,
-    30,
-    42,
-    48,
-    57,
-    68,
-    81,
     89,
     99
    ],
@@ -1233,10 +992,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.03908971123869304,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1245,7 +1004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.03920315830731465,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1254,7 +1013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07956029957394134,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1263,7 +1022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07956029957394134,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1272,7 +1031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08460296738760266,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1281,7 +1040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08460296738760266,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1290,7 +1049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08745618297210918,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1299,7 +1058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09243730284941436,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1308,7 +1067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1317,7 +1076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1326,7 +1085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1335,7 +1094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1344,7 +1103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1353,7 +1112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1362,7 +1121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1371,7 +1130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10346855821829945,
      "div_tie_breakers": [
       1.0
      ]
@@ -1380,7 +1139,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09907944680976563,
+     "diversity": 0.10346855821829945,
      "div_tie_breakers": [
       1.0
      ]
@@ -1389,7 +1148,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10064286197439647,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1398,7 +1157,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10064286197439647,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1407,7 +1166,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10064286197439647,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1416,7 +1175,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10064286197439647,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1425,7 +1184,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10064286197439647,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1434,7 +1193,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10064286197439647,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1443,7 +1202,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10064286197439647,
+     "diversity": 0.10383649864953591,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U1|SMART|123": {
+   "i_selected": [
+    3,
+    13,
+    25,
+    32,
+    45,
+    53,
+    67,
+    76,
+    88,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
      "div_tie_breakers": [
       1.0
      ]
@@ -1453,254 +1453,13 @@
   "U1|THOROUGH|42": {
    "i_selected": [
     0,
-    18,
-    31,
-    45,
-    51,
+    19,
+    36,
+    47,
+    56,
     66,
-    71,
+    70,
     82,
-    89,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.030983379632396488,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.03861910430894172,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.059142739162203695,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.06367482314229743,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07764300691825043,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07764300691825043,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07764300691825043,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978167972452,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978167972452,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08107978167972452,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08919534517921204,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09055756279066512,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09055756279066512,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09055756279066512,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09583270521758161,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09583270521758161,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09583270521758161,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09583270521758161,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09878473448055355,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U1|THOROUGH|123": {
-   "i_selected": [
-    1,
-    21,
-    30,
-    43,
-    48,
-    54,
-    68,
-    81,
     89,
     99
    ],
@@ -1715,10 +1474,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.03908971123869304,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1727,7 +1486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.03920315830731465,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1736,7 +1495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07956029957394134,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1745,7 +1504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07956029957394134,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1754,7 +1513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08460296738760266,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1763,7 +1522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08460296738760266,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1772,7 +1531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08745618297210918,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1781,7 +1540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09243730284941436,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1790,7 +1549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1799,7 +1558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1808,7 +1567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1817,7 +1576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1826,7 +1585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09706135833864064,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1835,7 +1594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1844,7 +1603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10229167996888999,
      "div_tie_breakers": [
       1.0
      ]
@@ -1853,7 +1612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10346855821829945,
      "div_tie_breakers": [
       1.0
      ]
@@ -1862,7 +1621,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10346855821829945,
      "div_tie_breakers": [
       1.0
      ]
@@ -1871,7 +1630,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1880,7 +1639,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1889,7 +1648,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1898,7 +1657,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1907,7 +1666,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1916,7 +1675,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10383649864953591,
      "div_tie_breakers": [
       1.0
      ]
@@ -1925,7 +1684,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09752611153163143,
+     "diversity": 0.10383649864953591,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U1|THOROUGH|123": {
+   "i_selected": [
+    3,
+    13,
+    25,
+    32,
+    45,
+    53,
+    67,
+    76,
+    88,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09698891137525609,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.09768630992542932,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10120120636665464,
      "div_tie_breakers": [
       1.0
      ]
@@ -2898,15 +2898,15 @@
   },
   "U2|SMART|42": {
    "i_selected": [
-    0,
-    26,
-    35,
-    64,
-    67,
-    82,
-    85,
+    11,
+    29,
+    56,
+    66,
+    75,
+    81,
+    86,
+    93,
     95,
-    98,
     99
    ],
    "score_checkpoints": [
@@ -2920,10 +2920,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1232638138661302,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -2932,7 +2932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17312734004671576,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -2941,7 +2941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.24174832912311855,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -2950,7 +2950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2625290739750654,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -2959,7 +2959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31986996536672935,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -2968,7 +2968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -2977,7 +2977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -2986,7 +2986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -2995,7 +2995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3004,7 +3004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3013,7 +3013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3022,7 +3022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3031,7 +3031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3040,7 +3040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3049,7 +3049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3058,7 +3058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3067,7 +3067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3076,7 +3076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3085,7 +3085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819519137783,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3094,7 +3094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819519137783,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3103,7 +3103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819519137783,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3112,7 +3112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819519137783,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3121,7 +3121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4558052709025793,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3130,7 +3130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4558052709025793,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3139,252 +3139,11 @@
   },
   "U2|SMART|123": {
    "i_selected": [
-    0,
-    43,
+    3,
     46,
-    67,
-    75,
-    81,
-    89,
-    95,
-    98,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0835219941042286,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0861316576644959,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.2673461148794585,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.29522247892653236,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.39458005361450676,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.44400874398150736,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45431730456128083,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45431730456128083,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45431730456128083,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45431730456128083,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45431730456128083,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45431730456128083,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45431730456128083,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4544659270599716,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45477155345851217,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45477155345851217,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.45477155345851217,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U2|THOROUGH|42": {
-   "i_selected": [
-    4,
-    33,
-    45,
-    65,
-    67,
+    51,
+    70,
+    73,
     82,
     85,
     95,
@@ -3402,10 +3161,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1232638138661302,
+     "diversity": 0.43518682078110227,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518682078110227,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518682078110227,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518682078110227,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518682078110227,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518682078110227,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.43518682078110227,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.44789320385101994,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.44789320385101994,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.44789320385101994,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.45570183587067703,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.45570183587067703,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.45570183587067703,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201855639255,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201855639255,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201855639255,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201855639255,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201855639255,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201855639255,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.46194201855639255,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.463462157559891,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.463462157559891,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.463462157559891,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.463462157559891,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U2|THOROUGH|42": {
+   "i_selected": [
+    11,
+    29,
+    56,
+    66,
+    75,
+    81,
+    86,
+    93,
+    95,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3414,7 +3414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17312734004671576,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3423,7 +3423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.24174832912311855,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3432,7 +3432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2625290739750654,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3441,7 +3441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.31986996536672935,
+     "diversity": 0.4175617748828994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3450,7 +3450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3459,7 +3459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3468,7 +3468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3477,7 +3477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3486,7 +3486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3495,7 +3495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3504,7 +3504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3513,7 +3513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3522,7 +3522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3531,7 +3531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3540,7 +3540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4359451606392015,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3549,7 +3549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4502819519137783,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3558,7 +3558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.453277969793576,
+     "diversity": 0.43085704024781896,
      "div_tie_breakers": [
       1.0
      ]
@@ -3567,7 +3567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885260877779,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3576,7 +3576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885260877779,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3585,7 +3585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885260877779,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3594,7 +3594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4629885260877779,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3603,7 +3603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4780572470344383,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3612,7 +3612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4780572470344383,
+     "diversity": 0.4582439495539895,
      "div_tie_breakers": [
       1.0
      ]
@@ -3621,13 +3621,13 @@
   },
   "U2|THOROUGH|123": {
    "i_selected": [
-    1,
-    43,
+    3,
+    41,
     46,
     67,
-    75,
-    81,
-    86,
+    69,
+    82,
+    83,
     95,
     96,
     99
@@ -3643,10 +3643,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0835219941042286,
+     "diversity": 0.43518682078110227,
      "div_tie_breakers": [
       1.0
      ]
@@ -3655,7 +3655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0861316576644959,
+     "diversity": 0.43518682078110227,
      "div_tie_breakers": [
       1.0
      ]
@@ -3664,7 +3664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2673461148794585,
+     "diversity": 0.43518682078110227,
      "div_tie_breakers": [
       1.0
      ]
@@ -3673,7 +3673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.29522247892653236,
+     "diversity": 0.43518682078110227,
      "div_tie_breakers": [
       1.0
      ]
@@ -3682,7 +3682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.39458005361450676,
+     "diversity": 0.43518682078110227,
      "div_tie_breakers": [
       1.0
      ]
@@ -3691,7 +3691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44400874398150736,
+     "diversity": 0.43518682078110227,
      "div_tie_breakers": [
       1.0
      ]
@@ -3700,7 +3700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45431730456128083,
+     "diversity": 0.43518682078110227,
      "div_tie_breakers": [
       1.0
      ]
@@ -3709,7 +3709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45431730456128083,
+     "diversity": 0.44789320385101994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3718,7 +3718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45431730456128083,
+     "diversity": 0.44789320385101994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3727,7 +3727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45431730456128083,
+     "diversity": 0.44789320385101994,
      "div_tie_breakers": [
       1.0
      ]
@@ -3736,7 +3736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45431730456128083,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3745,7 +3745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45431730456128083,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3754,7 +3754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3763,7 +3763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3772,7 +3772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3781,7 +3781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3790,7 +3790,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3799,7 +3799,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3808,7 +3808,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3817,7 +3817,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.46914555500451416,
      "div_tie_breakers": [
       1.0
      ]
@@ -3826,7 +3826,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.4751178979914219,
      "div_tie_breakers": [
       1.0
      ]
@@ -3835,7 +3835,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.4751178979914219,
      "div_tie_breakers": [
       1.0
      ]
@@ -3844,7 +3844,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.4751178979914219,
      "div_tie_breakers": [
       1.0
      ]
@@ -3853,7 +3853,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46433917099877503,
+     "diversity": 0.4751178979914219,
      "div_tie_breakers": [
       1.0
      ]
@@ -4826,15 +4826,15 @@
   },
   "U3|SMART|42": {
    "i_selected": [
-    18,
-    53,
-    67,
-    70,
-    76,
-    84,
+    0,
+    66,
+    72,
+    80,
+    85,
     88,
     91,
     93,
+    96,
     99
    ],
    "score_checkpoints": [
@@ -4848,10 +4848,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.18716114750420748,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4860,7 +4860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3484929169932517,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4869,7 +4869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5766225049086812,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4878,7 +4878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5766225049086812,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4887,7 +4887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7366434195670313,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4896,7 +4896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504246564518,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4905,7 +4905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504246564518,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4914,7 +4914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504246564518,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4923,7 +4923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317569907803,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4932,7 +4932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317569907803,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4941,7 +4941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317569907803,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4950,7 +4950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7720941273503257,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4959,7 +4959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4968,7 +4968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4977,7 +4977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4986,7 +4986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -4995,7 +4995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5004,7 +5004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5013,7 +5013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847794535080764,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5022,7 +5022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847794535080764,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5031,7 +5031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847794535080764,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5040,7 +5040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8847794535080764,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5049,7 +5049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9351943994874989,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5058,7 +5058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9351943994874989,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5067,15 +5067,15 @@
   },
   "U3|SMART|123": {
    "i_selected": [
-    1,
-    56,
-    68,
-    75,
-    83,
-    88,
-    91,
-    93,
-    96,
+    3,
+    57,
+    69,
+    77,
+    86,
+    89,
+    92,
+    94,
+    97,
     99
    ],
    "score_checkpoints": [
@@ -5089,10 +5089,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.22627454155657595,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5101,7 +5101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2807349239555785,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5110,7 +5110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4658738664155376,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5119,7 +5119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.48618833564900776,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5128,7 +5128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5813131776292584,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5137,7 +5137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6414870432265618,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5146,7 +5146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7771451084216436,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5155,7 +5155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9227908660901385,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5164,7 +5164,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5173,7 +5173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5182,7 +5182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5191,7 +5191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5200,7 +5200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5209,7 +5209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5218,7 +5218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5227,7 +5227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5236,7 +5236,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5245,7 +5245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5254,7 +5254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5263,7 +5263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5272,7 +5272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -5281,7 +5281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -5290,7 +5290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -5299,7 +5299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -5308,11 +5308,11 @@
   },
   "U3|THOROUGH|42": {
    "i_selected": [
-    1,
-    53,
-    67,
-    76,
-    86,
+    0,
+    66,
+    72,
+    80,
+    85,
     88,
     91,
     93,
@@ -5330,10 +5330,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.18716114750420748,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5342,7 +5342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3484929169932517,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5351,7 +5351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5766225049086812,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5360,7 +5360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5766225049086812,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5369,7 +5369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7366434195670313,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5378,7 +5378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504246564518,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5387,7 +5387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504246564518,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5396,7 +5396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7575504246564518,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5405,7 +5405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317569907803,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5414,7 +5414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317569907803,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5423,7 +5423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7590317569907803,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5432,7 +5432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7720941273503257,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5441,7 +5441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5450,7 +5450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5459,7 +5459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5468,7 +5468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5477,7 +5477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8607096285734237,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5486,7 +5486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680707899560711,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5495,7 +5495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680707899560711,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5504,7 +5504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680707899560711,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5513,7 +5513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680707899560711,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5522,7 +5522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8680707899560711,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5531,7 +5531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9066053732810361,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5540,7 +5540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9066053732810361,
+     "diversity": 0.9586768721869489,
      "div_tie_breakers": [
       1.0
      ]
@@ -5549,15 +5549,15 @@
   },
   "U3|THOROUGH|123": {
    "i_selected": [
-    1,
-    56,
-    68,
-    75,
-    83,
-    88,
-    91,
-    93,
-    96,
+    3,
+    57,
+    69,
+    77,
+    86,
+    89,
+    92,
+    94,
+    97,
     99
    ],
    "score_checkpoints": [
@@ -5571,10 +5571,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.22627454155657595,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5583,7 +5583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2807349239555785,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5592,7 +5592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4658738664155376,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5601,7 +5601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.48618833564900776,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5610,7 +5610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5813131776292584,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5619,7 +5619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6414870432265618,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5628,7 +5628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7771451084216436,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5637,7 +5637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9227908660901385,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5646,7 +5646,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5655,7 +5655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5664,7 +5664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5673,7 +5673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5682,7 +5682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5691,7 +5691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5700,7 +5700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5709,7 +5709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5718,7 +5718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5727,7 +5727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5736,7 +5736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5745,7 +5745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9592085315386292,
      "div_tie_breakers": [
       1.0
      ]
@@ -5754,7 +5754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -5763,7 +5763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -5772,7 +5772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -5781,7 +5781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.963214740476306,
+     "diversity": 0.9616219704075679,
      "div_tie_breakers": [
       1.0
      ]
@@ -6754,14 +6754,14 @@
   },
   "U4|SMART|42": {
    "i_selected": [
-    3,
-    18,
-    31,
-    43,
-    52,
-    60,
-    70,
-    82,
+    0,
+    20,
+    41,
+    49,
+    59,
+    66,
+    76,
+    86,
     91,
     99
    ],
@@ -6776,10 +6776,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0490695159237502,
+     "diversity": 0.1011336180134603,
      "div_tie_breakers": [
       1.0
      ]
@@ -6788,7 +6788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.060288841184982275,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6797,7 +6797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07948839964160322,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6806,7 +6806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.07948839964160322,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6815,7 +6815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08600837949776403,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6824,7 +6824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08600837949776403,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6833,7 +6833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08600837949776403,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6842,7 +6842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0880809305091256,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6851,7 +6851,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0880809305091256,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6860,7 +6860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0880809305091256,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6869,7 +6869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6878,7 +6878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6887,7 +6887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6896,7 +6896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6905,7 +6905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -6914,7 +6914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.1039593845716412,
      "div_tie_breakers": [
       1.0
      ]
@@ -6923,7 +6923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.1039593845716412,
      "div_tie_breakers": [
       1.0
      ]
@@ -6932,7 +6932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09685502010320947,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -6941,7 +6941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09697080562107538,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -6950,7 +6950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09697080562107538,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -6959,7 +6959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09697080562107538,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -6968,7 +6968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09697080562107538,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -6977,7 +6977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10160001959576917,
+     "diversity": 0.10678782570174046,
      "div_tie_breakers": [
       1.0
      ]
@@ -6986,7 +6986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10461424700653804,
+     "diversity": 0.10678782570174046,
      "div_tie_breakers": [
       1.0
      ]
@@ -6995,495 +6995,13 @@
   },
   "U4|SMART|123": {
    "i_selected": [
-    1,
-    21,
-    32,
-    50,
-    61,
-    72,
+    0,
+    19,
+    30,
+    48,
+    57,
+    68,
     80,
-    90,
-    92,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0363093749681661,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0363093749681661,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.05327616602280359,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.05327616602280359,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.06719833849152887,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08718643600986391,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09057458562142376,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10203798504904821,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10203798504904821,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10389791872704038,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10389791872704038,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10389791872704038,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.1060670138862934,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U4|THOROUGH|42": {
-   "i_selected": [
-    3,
-    18,
-    31,
-    43,
-    52,
-    60,
-    70,
-    82,
-    91,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 1.0,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0490695159237502,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.060288841184982275,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07948839964160322,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.07948839964160322,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08600837949776403,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08600837949776403,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.08600837949776403,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0880809305091256,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0880809305091256,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.0880809305091256,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09685502010320947,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09697080562107538,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09697080562107538,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09697080562107538,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.09697080562107538,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10160001959576917,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.10461424700653804,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "U4|THOROUGH|123": {
-   "i_selected": [
-    1,
-    21,
-    32,
-    50,
-    61,
-    72,
-    78,
     87,
     93,
     99
@@ -7499,10 +7017,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0363093749681661,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208466565651,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208466565651,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208466565651,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1096188295259058,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1096188295259058,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1096188295259058,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1096188295259058,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1096188295259058,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1096188295259058,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1096188295259058,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U4|THOROUGH|42": {
+   "i_selected": [
+    0,
+    20,
+    41,
+    49,
+    59,
+    66,
+    76,
+    86,
+    91,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1011336180134603,
      "div_tie_breakers": [
       1.0
      ]
@@ -7511,7 +7270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.0363093749681661,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7520,7 +7279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.05327616602280359,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7529,7 +7288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.05327616602280359,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7538,7 +7297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.06719833849152887,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7547,7 +7306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.08718643600986391,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7556,7 +7315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09057458562142376,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7565,7 +7324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10203798504904821,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7574,7 +7333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10203798504904821,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7583,7 +7342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10389791872704038,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7592,7 +7351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10389791872704038,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7601,7 +7360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10389791872704038,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7610,7 +7369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7619,7 +7378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7628,7 +7387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10308263925612694,
      "div_tie_breakers": [
       1.0
      ]
@@ -7637,7 +7396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.1039593845716412,
      "div_tie_breakers": [
       1.0
      ]
@@ -7646,7 +7405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.1039593845716412,
      "div_tie_breakers": [
       1.0
      ]
@@ -7655,7 +7414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -7664,7 +7423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -7673,7 +7432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -7682,7 +7441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -7691,7 +7450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10625467383299031,
      "div_tie_breakers": [
       1.0
      ]
@@ -7700,7 +7459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10678782570174046,
      "div_tie_breakers": [
       1.0
      ]
@@ -7709,7 +7468,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1060670138862934,
+     "diversity": 0.10678782570174046,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "U4|THOROUGH|123": {
+   "i_selected": [
+    1,
+    19,
+    30,
+    48,
+    57,
+    66,
+    80,
+    89,
+    93,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 1.0,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10479203642621018,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208466565651,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208466565651,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.10637208466565651,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.1080430212661147,
      "div_tie_breakers": [
       1.0
      ]
@@ -8682,16 +8682,16 @@
   },
   "C1|SMART|42": {
    "i_selected": [
-    24,
-    32,
-    65,
-    81,
+    5,
+    29,
+    41,
+    69,
+    76,
     82,
     86,
-    91,
     95,
-    97,
-    98
+    96,
+    99
    ],
    "score_checkpoints": [
     {
@@ -8704,10 +8704,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.5020173343670897,
+     "constraints": 1.0,
+     "diversity": 0.7363570701411459,
      "div_tie_breakers": [
       1.0
      ]
@@ -8716,7 +8716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6940806445749332,
+     "diversity": 0.7363570701411459,
      "div_tie_breakers": [
       1.0
      ]
@@ -8725,7 +8725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7676450438083533,
+     "diversity": 0.7363570701411459,
      "div_tie_breakers": [
       1.0
      ]
@@ -8734,7 +8734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7526790953239642,
      "div_tie_breakers": [
       1.0
      ]
@@ -8743,7 +8743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7526790953239642,
      "div_tie_breakers": [
       1.0
      ]
@@ -8752,7 +8752,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8761,7 +8761,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8770,7 +8770,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8779,7 +8779,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8788,7 +8788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8797,7 +8797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8806,7 +8806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8815,7 +8815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8824,7 +8824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8833,7 +8833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8842,7 +8842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -8851,7 +8851,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7887588041487258,
      "div_tie_breakers": [
       1.0
      ]
@@ -8860,7 +8860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -8869,7 +8869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -8878,7 +8878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -8887,7 +8887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -8896,7 +8896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -8905,7 +8905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8007652139434877,
+     "diversity": 0.8223950067624344,
      "div_tie_breakers": [
       1.0
      ]
@@ -8914,7 +8914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8007652139434877,
+     "diversity": 0.8223950067624344,
      "div_tie_breakers": [
       1.0
      ]
@@ -8923,14 +8923,14 @@
   },
   "C1|SMART|123": {
    "i_selected": [
-    0,
+    3,
+    41,
     50,
-    51,
-    54,
-    68,
-    79,
-    91,
-    93,
+    66,
+    69,
+    76,
+    83,
+    95,
     97,
     99
    ],
@@ -8945,10 +8945,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.26414167212072953,
+     "constraints": 1.0,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -8957,7 +8957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2633856566224413,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -8966,7 +8966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32067980398886065,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -8975,7 +8975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49891230857206026,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -8984,7 +8984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49891230857206026,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -8993,7 +8993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433478229146,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9002,7 +9002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433478229146,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9011,7 +9011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791273546084,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9020,7 +9020,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791273546084,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9029,7 +9029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5914677479474441,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9038,7 +9038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473772639388315,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9047,7 +9047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473772639388315,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9056,7 +9056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473772639388315,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9065,7 +9065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473772639388315,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9074,7 +9074,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473772639388315,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9083,7 +9083,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6473772639388315,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9092,7 +9092,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807088292454,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9101,7 +9101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807088292454,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9110,7 +9110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807088292454,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9119,7 +9119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6691807088292454,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9128,7 +9128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7254599750415415,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9137,7 +9137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7254599750415415,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9146,7 +9146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7655047562197534,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9155,7 +9155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7655047562197534,
+     "diversity": 0.7453341320533203,
      "div_tie_breakers": [
       1.0
      ]
@@ -9164,15 +9164,15 @@
   },
   "C1|THOROUGH|42": {
    "i_selected": [
-    24,
-    32,
-    65,
-    81,
+    5,
+    29,
+    41,
+    69,
+    76,
     82,
     86,
-    91,
     95,
-    97,
+    96,
     99
    ],
    "score_checkpoints": [
@@ -9186,10 +9186,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.5020173343670897,
+     "constraints": 1.0,
+     "diversity": 0.7363570701411459,
      "div_tie_breakers": [
       1.0
      ]
@@ -9198,7 +9198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6940806445749332,
+     "diversity": 0.7363570701411459,
      "div_tie_breakers": [
       1.0
      ]
@@ -9207,7 +9207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7676450438083533,
+     "diversity": 0.7363570701411459,
      "div_tie_breakers": [
       1.0
      ]
@@ -9216,7 +9216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7526790953239642,
      "div_tie_breakers": [
       1.0
      ]
@@ -9225,7 +9225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7526790953239642,
      "div_tie_breakers": [
       1.0
      ]
@@ -9234,7 +9234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9243,7 +9243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9252,7 +9252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9261,7 +9261,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9270,7 +9270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9279,7 +9279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9288,7 +9288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9297,7 +9297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9306,7 +9306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9315,7 +9315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9324,7 +9324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.766460283393954,
      "div_tie_breakers": [
       1.0
      ]
@@ -9333,7 +9333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7887588041487258,
      "div_tie_breakers": [
       1.0
      ]
@@ -9342,7 +9342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -9351,7 +9351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -9360,7 +9360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -9369,7 +9369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -9378,7 +9378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7875056138334757,
+     "diversity": 0.7916809456546168,
      "div_tie_breakers": [
       1.0
      ]
@@ -9387,7 +9387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8274316926069212,
+     "diversity": 0.8223950067624344,
      "div_tie_breakers": [
       1.0
      ]
@@ -9396,7 +9396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8274316926069212,
+     "diversity": 0.8223950067624344,
      "div_tie_breakers": [
       1.0
      ]
@@ -9405,12 +9405,12 @@
   },
   "C1|THOROUGH|123": {
    "i_selected": [
-    14,
-    28,
-    50,
+    5,
     51,
-    81,
-    82,
+    66,
+    71,
+    76,
+    85,
     91,
     95,
     97,
@@ -9427,10 +9427,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.26414167212072953,
+     "constraints": 1.0,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -9439,7 +9439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2633856566224413,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -9448,7 +9448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32067980398886065,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -9457,7 +9457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49891230857206026,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -9466,7 +9466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.49891230857206026,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -9475,7 +9475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433478229146,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9484,7 +9484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5099433478229146,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9493,7 +9493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791273546084,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9502,7 +9502,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791273546084,
+     "diversity": 0.7304892759565564,
      "div_tie_breakers": [
       1.0
      ]
@@ -9511,7 +9511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5124791273546084,
+     "diversity": 0.7570629351052995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9520,7 +9520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5685062617191319,
+     "diversity": 0.7570629351052995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9529,7 +9529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5685062617191319,
+     "diversity": 0.7570629351052995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9538,7 +9538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325797074344,
+     "diversity": 0.7782083491457524,
      "div_tie_breakers": [
       1.0
      ]
@@ -9547,7 +9547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325797074344,
+     "diversity": 0.7848306111894476,
      "div_tie_breakers": [
       1.0
      ]
@@ -9556,7 +9556,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325797074344,
+     "diversity": 0.7848306111894476,
      "div_tie_breakers": [
       1.0
      ]
@@ -9565,7 +9565,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5907325797074344,
+     "diversity": 0.7848306111894476,
      "div_tie_breakers": [
       1.0
      ]
@@ -9574,7 +9574,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.665886245666726,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -9583,7 +9583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6863036070964917,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -9592,7 +9592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7115437861886267,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -9601,7 +9601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7115437861886267,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -9610,7 +9610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486110538348,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -9619,7 +9619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486110538348,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -9628,7 +9628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486110538348,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -9637,7 +9637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7377486110538348,
+     "diversity": 0.8146164172609338,
      "div_tie_breakers": [
       1.0
      ]
@@ -10611,254 +10611,13 @@
   "C2|SMART|42": {
    "i_selected": [
     24,
-    25,
-    65,
-    81,
-    82,
+    32,
+    66,
+    79,
+    85,
     86,
     91,
     95,
-    97,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.09090909090909083,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.5020173343670897,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.6940806445749332,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7839762566482321,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C2|SMART|123": {
-   "i_selected": [
-    0,
-    43,
-    54,
-    58,
-    76,
-    80,
-    86,
-    94,
     97,
     99
    ],
@@ -10873,10 +10632,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.26414167212072953,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7363570701411459,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7113419770153667,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7579973865561586,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8031050183938109,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8065439307276416,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C2|SMART|123": {
+   "i_selected": [
+    20,
+    25,
+    65,
+    81,
+    85,
+    86,
+    91,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.09090909090909083,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -10885,7 +10885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.8181818181818181,
-     "diversity": 0.2526522564094418,
+     "diversity": 0.6353946074275736,
      "div_tie_breakers": [
       1.0
      ]
@@ -10894,7 +10894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.29785431858474387,
+     "diversity": 0.6182802810467076,
      "div_tie_breakers": [
       1.0
      ]
@@ -10903,7 +10903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40262268418195346,
+     "diversity": 0.6182802810467076,
      "div_tie_breakers": [
       1.0
      ]
@@ -10912,7 +10912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4392149368963282,
+     "diversity": 0.6201637072046646,
      "div_tie_breakers": [
       1.0
      ]
@@ -10921,7 +10921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6649495793712148,
+     "diversity": 0.6201637072046646,
      "div_tie_breakers": [
       1.0
      ]
@@ -10930,7 +10930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637478182269,
+     "diversity": 0.6690474376130345,
      "div_tie_breakers": [
       1.0
      ]
@@ -10939,7 +10939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637478182269,
+     "diversity": 0.6722828315466947,
      "div_tie_breakers": [
       1.0
      ]
@@ -10948,7 +10948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7110718691995466,
      "div_tie_breakers": [
       1.0
      ]
@@ -10957,7 +10957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7570778740751692,
      "div_tie_breakers": [
       1.0
      ]
@@ -10966,7 +10966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7570778740751692,
      "div_tie_breakers": [
       1.0
      ]
@@ -10975,7 +10975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7570778740751692,
      "div_tie_breakers": [
       1.0
      ]
@@ -10984,7 +10984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -10993,7 +10993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11002,7 +11002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11011,7 +11011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11020,7 +11020,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11029,7 +11029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11038,7 +11038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11047,7 +11047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11056,7 +11056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11065,7 +11065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11074,7 +11074,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11083,7 +11083,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.7988980972484516,
      "div_tie_breakers": [
       1.0
      ]
@@ -11093,254 +11093,13 @@
   "C2|THOROUGH|42": {
    "i_selected": [
     24,
-    25,
-    65,
-    81,
-    82,
+    32,
+    66,
+    79,
+    85,
     86,
     91,
     95,
-    97,
-    98
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.09090909090909083,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.5020173343670897,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.6940806445749332,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7676450438083533,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7839762566482321,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C2|THOROUGH|123": {
-   "i_selected": [
-    0,
-    43,
-    54,
-    58,
-    76,
-    80,
-    86,
-    94,
     97,
     99
    ],
@@ -11355,10 +11114,251 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.6363636363636364,
-     "diversity": 0.26414167212072953,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7363570701411459,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7113419770153667,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7288917783016953,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7529197547830142,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7579973865561586,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7853745910269831,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8031050183938109,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8065439307276416,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C2|THOROUGH|123": {
+   "i_selected": [
+    25,
+    29,
+    65,
+    69,
+    81,
+    82,
+    86,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.09090909090909083,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8181818181818181,
+     "diversity": 0.7298108973213604,
      "div_tie_breakers": [
       1.0
      ]
@@ -11367,7 +11367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.8181818181818181,
-     "diversity": 0.2526522564094418,
+     "diversity": 0.6353946074275736,
      "div_tie_breakers": [
       1.0
      ]
@@ -11376,7 +11376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.29785431858474387,
+     "diversity": 0.6182802810467076,
      "div_tie_breakers": [
       1.0
      ]
@@ -11385,7 +11385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40262268418195346,
+     "diversity": 0.6182802810467076,
      "div_tie_breakers": [
       1.0
      ]
@@ -11394,7 +11394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4392149368963282,
+     "diversity": 0.6201637072046646,
      "div_tie_breakers": [
       1.0
      ]
@@ -11403,7 +11403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6649495793712148,
+     "diversity": 0.6201637072046646,
      "div_tie_breakers": [
       1.0
      ]
@@ -11412,7 +11412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637478182269,
+     "diversity": 0.6690474376130345,
      "div_tie_breakers": [
       1.0
      ]
@@ -11421,7 +11421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7188637478182269,
+     "diversity": 0.6807375078057238,
      "div_tie_breakers": [
       1.0
      ]
@@ -11430,7 +11430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7190234513421842,
      "div_tie_breakers": [
       1.0
      ]
@@ -11439,7 +11439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7353701742891664,
      "div_tie_breakers": [
       1.0
      ]
@@ -11448,7 +11448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7353701742891664,
      "div_tie_breakers": [
       1.0
      ]
@@ -11457,7 +11457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7462895982114203,
+     "diversity": 0.7353701742891664,
      "div_tie_breakers": [
       1.0
      ]
@@ -11466,7 +11466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7353701742891664,
      "div_tie_breakers": [
       1.0
      ]
@@ -11475,7 +11475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7916664237255899,
      "div_tie_breakers": [
       1.0
      ]
@@ -11484,7 +11484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7916664237255899,
      "div_tie_breakers": [
       1.0
      ]
@@ -11493,7 +11493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7630926504904593,
+     "diversity": 0.7916664237255899,
      "div_tie_breakers": [
       1.0
      ]
@@ -11502,7 +11502,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.7916664237255899,
      "div_tie_breakers": [
       1.0
      ]
@@ -11511,7 +11511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.8067889544519562,
      "div_tie_breakers": [
       1.0
      ]
@@ -11520,7 +11520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.8067889544519562,
      "div_tie_breakers": [
       1.0
      ]
@@ -11529,7 +11529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.8067889544519562,
      "div_tie_breakers": [
       1.0
      ]
@@ -11538,7 +11538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.8067889544519562,
      "div_tie_breakers": [
       1.0
      ]
@@ -11547,7 +11547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.8067889544519562,
      "div_tie_breakers": [
       1.0
      ]
@@ -11556,7 +11556,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.8067889544519562,
      "div_tie_breakers": [
       1.0
      ]
@@ -11565,7 +11565,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7803683949411743,
+     "diversity": 0.8067889544519562,
      "div_tie_breakers": [
       1.0
      ]
@@ -12538,16 +12538,16 @@
   },
   "C3|SMART|42": {
    "i_selected": [
-    17,
-    28,
-    54,
-    68,
-    107,
-    110,
-    133,
-    141,
+    16,
+    44,
+    86,
+    98,
+    124,
+    127,
+    137,
     145,
-    148
+    147,
+    149
    ],
    "score_checkpoints": [
     {
@@ -12560,28 +12560,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6666666666666667,
-     "diversity": 4.883468226535209e-09,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 1.0454369350057621e-08,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2984633439726746,
+     "diversity": 0.5118978375515136,
      "div_tie_breakers": [
       1.0
      ]
@@ -12590,7 +12572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5118978375515136,
      "div_tie_breakers": [
       1.0
      ]
@@ -12599,7 +12581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5135583519982547,
      "div_tie_breakers": [
       1.0
      ]
@@ -12608,7 +12590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12617,7 +12599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12626,7 +12608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12635,7 +12617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12644,7 +12626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12653,7 +12635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12662,7 +12644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.48620464549227305,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12671,7 +12653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126363091789,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12680,7 +12662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126363091789,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12689,7 +12671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126363091789,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12698,7 +12680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4890126363091789,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12707,7 +12689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377350417635,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12716,7 +12698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377350417635,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -12725,7 +12707,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377350417635,
+     "diversity": 0.5210878923670036,
      "div_tie_breakers": [
       1.0
      ]
@@ -12734,7 +12716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377350417635,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -12743,7 +12725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377350417635,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -12752,7 +12734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.492377350417635,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -12761,7 +12743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4952519636083276,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -12770,7 +12752,25 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4952519636083276,
+     "diversity": 0.5257596951377624,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.5306871551193143,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.5306871551193143,
      "div_tie_breakers": [
       1.0
      ]
@@ -12779,15 +12779,15 @@
   },
   "C3|SMART|123": {
    "i_selected": [
-    10,
-    45,
-    51,
-    95,
-    96,
-    128,
-    130,
-    143,
+    26,
+    42,
+    102,
+    103,
+    127,
+    131,
+    139,
     145,
+    147,
     149
    ],
    "score_checkpoints": [
@@ -12801,10 +12801,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.19673215377780473,
+     "constraints": 1.0,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12813,7 +12813,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12822,7 +12822,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12831,7 +12831,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12840,7 +12840,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12849,7 +12849,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12858,7 +12858,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12867,7 +12867,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4981491811374882,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12876,7 +12876,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4988319464151022,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12885,7 +12885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4988319464151022,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12894,7 +12894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4988319464151022,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12903,7 +12903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4988319464151022,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12912,7 +12912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.514145988035843,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12921,7 +12921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.514145988035843,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12930,7 +12930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.514145988035843,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -12939,7 +12939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.514145988035843,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -12948,7 +12948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372992339481,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -12957,7 +12957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372992339481,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -12966,7 +12966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372992339481,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -12975,7 +12975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5261372992339481,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -12984,7 +12984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5273825198883494,
+     "diversity": 0.5112220033479723,
      "div_tie_breakers": [
       1.0
      ]
@@ -12993,7 +12993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5273825198883494,
+     "diversity": 0.5112220033479723,
      "div_tie_breakers": [
       1.0
      ]
@@ -13002,7 +13002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5273825198883494,
+     "diversity": 0.5112220033479723,
      "div_tie_breakers": [
       1.0
      ]
@@ -13011,7 +13011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.530542076865497,
+     "diversity": 0.5112220033479723,
      "div_tie_breakers": [
       1.0
      ]
@@ -13020,15 +13020,15 @@
   },
   "C3|THOROUGH|42": {
    "i_selected": [
-    17,
-    48,
-    63,
-    106,
-    107,
+    16,
+    44,
+    86,
+    102,
+    124,
     130,
-    132,
-    141,
+    137,
     145,
+    147,
     149
    ],
    "score_checkpoints": [
@@ -13042,28 +13042,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
-     "size": 1.0,
-     "constraints": 0.6666666666666667,
-     "diversity": 4.883468226535209e-09,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 1.0454369350057621e-08,
-     "div_tie_breakers": [
-      0.800000011920929
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2984633439726746,
+     "diversity": 0.5118978375515136,
      "div_tie_breakers": [
       1.0
      ]
@@ -13072,7 +13054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5118978375515136,
      "div_tie_breakers": [
       1.0
      ]
@@ -13081,7 +13063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5135583519982547,
      "div_tie_breakers": [
       1.0
      ]
@@ -13090,7 +13072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13099,7 +13081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13108,7 +13090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13117,7 +13099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13126,7 +13108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38906778177542956,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13135,7 +13117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4400747711000532,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13144,7 +13126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4400747711000532,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13153,7 +13135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4400747711000532,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13162,7 +13144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4400747711000532,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13171,7 +13153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4588708212117334,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13180,7 +13162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4588708212117334,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13189,7 +13171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5152265446636094,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13198,7 +13180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5152265446636094,
+     "diversity": 0.5206163109481774,
      "div_tie_breakers": [
       1.0
      ]
@@ -13207,7 +13189,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245661725415,
+     "diversity": 0.5210878923670036,
      "div_tie_breakers": [
       1.0
      ]
@@ -13216,7 +13198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245661725415,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -13225,7 +13207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245661725415,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -13234,7 +13216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245661725415,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -13243,7 +13225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245661725415,
+     "diversity": 0.5257596951377624,
      "div_tie_breakers": [
       1.0
      ]
@@ -13252,7 +13234,25 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5248245661725415,
+     "diversity": 0.5257596951377624,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.5291999710853551,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.5291999710853551,
      "div_tie_breakers": [
       1.0
      ]
@@ -13261,15 +13261,15 @@
   },
   "C3|THOROUGH|123": {
    "i_selected": [
-    13,
-    46,
-    56,
-    96,
+    26,
+    54,
     102,
-    125,
-    128,
-    144,
+    103,
+    127,
+    131,
+    139,
     145,
+    147,
     149
    ],
    "score_checkpoints": [
@@ -13283,10 +13283,10 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8888888888888888,
-     "diversity": 0.19673215377780473,
+     "constraints": 1.0,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13295,7 +13295,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13304,7 +13304,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13313,7 +13313,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13322,7 +13322,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13331,7 +13331,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13340,7 +13340,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4200895164089819,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13349,7 +13349,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4981491811374882,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13358,7 +13358,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5038048143650865,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13367,7 +13367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5038048143650865,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13376,7 +13376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5064227569682214,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13385,7 +13385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5064227569682214,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13394,7 +13394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5243911924392763,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13403,7 +13403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13412,7 +13412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.4976486259207695,
      "div_tie_breakers": [
       1.0
      ]
@@ -13421,7 +13421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13430,7 +13430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13439,7 +13439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13448,7 +13448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13457,7 +13457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13466,7 +13466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13475,7 +13475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13484,7 +13484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -13493,7 +13493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5280834851421419,
+     "diversity": 0.5011175254394495,
      "div_tie_breakers": [
       1.0
      ]
@@ -14466,14 +14466,14 @@
   },
   "C4|SMART|42": {
    "i_selected": [
-    14,
-    31,
-    39,
+    4,
+    27,
+    28,
     54,
-    67,
-    70,
-    101,
-    107,
+    58,
+    100,
+    103,
+    132,
     145,
     149
    ],
@@ -14488,28 +14488,55 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.625,
-     "diversity": 4.883468226535209e-09,
+     "constraints": 0.8125,
+     "diversity": 0.5118978375515136,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 6.171484655522557e-09,
+     "diversity": 0.40928043264679714,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.4927343328916696,
+     "div_tie_breakers": [
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.17234124956495295,
+     "diversity": 0.45410989741623686,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.2841054804174128,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.2802744610422146,
      "div_tie_breakers": [
       1.0
      ]
@@ -14518,7 +14545,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1611601820304535,
+     "diversity": 0.21290868199692597,
      "div_tie_breakers": [
       1.0
      ]
@@ -14527,7 +14554,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17001813888896067,
+     "diversity": 0.21290868199692597,
      "div_tie_breakers": [
       1.0
      ]
@@ -14536,7 +14563,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.21771109619351642,
      "div_tie_breakers": [
       1.0
      ]
@@ -14545,7 +14572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.21771109619351642,
      "div_tie_breakers": [
       1.0
      ]
@@ -14554,7 +14581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -14563,7 +14590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -14572,7 +14599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776298162133884,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -14581,7 +14608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776298162133884,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -14590,7 +14617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776298162133884,
+     "diversity": 0.32346674276923104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14599,7 +14626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.32346674276923104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14608,7 +14635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.3402751809222351,
      "div_tie_breakers": [
       1.0
      ]
@@ -14617,7 +14644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.36193338536533726,
      "div_tie_breakers": [
       1.0
      ]
@@ -14626,7 +14653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.3651952928769271,
      "div_tie_breakers": [
       1.0
      ]
@@ -14635,7 +14662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.4081245487162072,
      "div_tie_breakers": [
       1.0
      ]
@@ -14644,7 +14671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2842110333373809,
+     "diversity": 0.4081245487162072,
      "div_tie_breakers": [
       1.0
      ]
@@ -14653,7 +14680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3139138752956736,
+     "diversity": 0.4081245487162072,
      "div_tie_breakers": [
       1.0
      ]
@@ -14662,7 +14689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3139138752956736,
+     "diversity": 0.41963541223003775,
      "div_tie_breakers": [
       1.0
      ]
@@ -14671,34 +14698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3139138752956736,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.34726899660806565,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.34726899660806565,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.34726899660806565,
+     "diversity": 0.41963541223003775,
      "div_tie_breakers": [
       1.0
      ]
@@ -14707,16 +14707,16 @@
   },
   "C4|SMART|123": {
    "i_selected": [
-    20,
-    22,
-    46,
-    56,
-    68,
-    87,
+    17,
+    19,
+    48,
+    53,
+    77,
+    102,
     103,
-    139,
+    133,
     145,
-    149
+    147
    ],
    "score_checkpoints": [
     {
@@ -14729,10 +14729,28 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.4976486259207695,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.5008678091824328,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.19673215377780473,
+     "diversity": 0.4048536737792797,
      "div_tie_breakers": [
       1.0
      ]
@@ -14741,7 +14759,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.35185307727968695,
      "div_tie_breakers": [
       1.0
      ]
@@ -14750,7 +14768,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.3708398958431677,
      "div_tie_breakers": [
       1.0
      ]
@@ -14759,7 +14777,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.38043841449326604,
      "div_tie_breakers": [
       1.0
      ]
@@ -14768,7 +14786,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.38043841449326604,
      "div_tie_breakers": [
       1.0
      ]
@@ -14777,7 +14795,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.38043841449326604,
      "div_tie_breakers": [
       1.0
      ]
@@ -14786,7 +14804,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -14795,7 +14813,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.33333210071833885,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -14804,7 +14822,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581638373053173,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -14813,7 +14831,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581638373053173,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -14822,7 +14840,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581638373053173,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -14831,7 +14849,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38581638373053173,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14840,7 +14858,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3938915649375604,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14849,7 +14867,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3950230560849073,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14858,7 +14876,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3950230560849073,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14867,7 +14885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3950230560849073,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14876,7 +14894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4034451799051928,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14885,7 +14903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4034451799051928,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14894,7 +14912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4034451799051928,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14903,7 +14921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4034451799051928,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14912,7 +14930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4034451799051928,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14921,25 +14939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4034451799051928,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4034451799051928,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41645936025857144,
+     "diversity": 0.41690677256540576,
      "div_tie_breakers": [
       1.0
      ]
@@ -14948,14 +14948,14 @@
   },
   "C4|THOROUGH|42": {
    "i_selected": [
-    14,
-    31,
-    39,
-    54,
-    67,
-    70,
-    101,
-    107,
+    4,
+    19,
+    27,
+    50,
+    56,
+    100,
+    103,
+    132,
     145,
     149
    ],
@@ -14970,28 +14970,55 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.625,
-     "diversity": 4.883468226535209e-09,
+     "constraints": 0.8125,
+     "diversity": 0.5118978375515136,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 6.171484655522557e-09,
+     "diversity": 0.40928043264679714,
      "div_tie_breakers": [
-      0.800000011920929
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.4927343328916696,
+     "div_tie_breakers": [
+      1.0
      ]
     },
     {
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.17234124956495295,
+     "diversity": 0.45410989741623686,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.2841054804174128,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.2802744610422146,
      "div_tie_breakers": [
       1.0
      ]
@@ -15000,7 +15027,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1611601820304535,
+     "diversity": 0.21290868199692597,
      "div_tie_breakers": [
       1.0
      ]
@@ -15009,7 +15036,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17001813888896067,
+     "diversity": 0.21290868199692597,
      "div_tie_breakers": [
       1.0
      ]
@@ -15018,7 +15045,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.21771109619351642,
      "div_tie_breakers": [
       1.0
      ]
@@ -15027,7 +15054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.21771109619351642,
      "div_tie_breakers": [
       1.0
      ]
@@ -15036,7 +15063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -15045,7 +15072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.17241271210403322,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -15054,7 +15081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776298162133884,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -15063,7 +15090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776298162133884,
+     "diversity": 0.3204943503882744,
      "div_tie_breakers": [
       1.0
      ]
@@ -15072,7 +15099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21776298162133884,
+     "diversity": 0.32346674276923104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15081,7 +15108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.32346674276923104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15090,7 +15117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.3402751809222351,
      "div_tie_breakers": [
       1.0
      ]
@@ -15099,7 +15126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.36193338536533726,
      "div_tie_breakers": [
       1.0
      ]
@@ -15108,7 +15135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.40907861427455905,
      "div_tie_breakers": [
       1.0
      ]
@@ -15117,7 +15144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.27273573114618627,
+     "diversity": 0.40907861427455905,
      "div_tie_breakers": [
       1.0
      ]
@@ -15126,7 +15153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2842110333373809,
+     "diversity": 0.40907861427455905,
      "div_tie_breakers": [
       1.0
      ]
@@ -15135,7 +15162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3139138752956736,
+     "diversity": 0.40907861427455905,
      "div_tie_breakers": [
       1.0
      ]
@@ -15144,7 +15171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3139138752956736,
+     "diversity": 0.41271125595816494,
      "div_tie_breakers": [
       1.0
      ]
@@ -15153,34 +15180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3139138752956736,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.34726899660806565,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.34726899660806565,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.34726899660806565,
+     "diversity": 0.41271125595816494,
      "div_tie_breakers": [
       1.0
      ]
@@ -15189,16 +15189,16 @@
   },
   "C4|THOROUGH|123": {
    "i_selected": [
-    22,
-    25,
-    44,
-    57,
-    73,
-    100,
-    101,
-    137,
+    17,
+    26,
+    48,
+    53,
+    77,
+    102,
+    103,
+    133,
     145,
-    149
+    147
    ],
    "score_checkpoints": [
     {
@@ -15211,10 +15211,28 @@
      ]
     },
     {
-     "step": "step 1/2 - InitRandomOneShot(u,uncon)",
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.4976486259207695,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.8125,
+     "diversity": 0.5008678091824328,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.19673215377780473,
+     "diversity": 0.4048536737792797,
      "div_tie_breakers": [
       1.0
      ]
@@ -15223,7 +15241,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.35185307727968695,
      "div_tie_breakers": [
       1.0
      ]
@@ -15232,7 +15250,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.2515632469504838,
+     "diversity": 0.3708398958431677,
      "div_tie_breakers": [
       1.0
      ]
@@ -15241,7 +15259,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.38043841449326604,
      "div_tie_breakers": [
       1.0
      ]
@@ -15250,7 +15268,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.38043841449326604,
      "div_tie_breakers": [
       1.0
      ]
@@ -15259,7 +15277,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.38043841449326604,
      "div_tie_breakers": [
       1.0
      ]
@@ -15268,7 +15286,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3077734073348627,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15277,7 +15295,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.33333210071833885,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15286,7 +15304,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.37046441098589744,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15295,7 +15313,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.37046441098589744,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15304,7 +15322,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.37046441098589744,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15313,7 +15331,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.37046441098589744,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15322,7 +15340,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3782543882144122,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15331,7 +15349,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3869827023367914,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15340,7 +15358,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3869827023367914,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15349,7 +15367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3869827023367914,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15358,7 +15376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38941365135566497,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15367,7 +15385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38941365135566497,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15376,7 +15394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.39100037123134196,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15385,7 +15403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4012200318389691,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15394,7 +15412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.42513605658073284,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]
@@ -15403,25 +15421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.42513605658073284,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.42513605658073284,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.42513605658073284,
+     "diversity": 0.4146785513512527,
      "div_tie_breakers": [
       1.0
      ]


### PR DESCRIPTION
**TL;DR**: SMART and THOROUGH now initialize with a lightly randomized farthest-point construction (10% random prefix) instead of a uniform random draw: better short-budget results and constrained quality reached sooner.

## Description

### Problem addressed

SMART and THOROUGH started from a uniform random selection. Published comparisons show max-div trailing the best single-shot picker at short budgets on large problems, and the gap traces to initialization: a farthest-point construction reaches or beats that field almost immediately. A pure farthest-point start, however, costs solution quality on unconstrained problems at long budget, so it cannot simply replace the random draw unconditionally.

### Implementation

Both presets now build from `InitFarthestPoint` with a short random prefix: the first ⌈0.1·k⌉ picks are uniformly random, the rest are the greedy farthest-point construction. The prefix restores the start-point diversity a pure construction gives up — enough to remove the unconstrained long-budget penalty while keeping most of the short-budget edge.

`random_fraction` is added to `InitFarthestPoint` but kept off the public `farthest_point()` factory, which stays no-argument; the presets construct the class directly, matching the existing internal pattern for parameterized init strategies. The setting is universal — no constraint-conditional branch — because a small prefix collapses the constrained-vs-unconstrained tradeoff to within measurement noise.

## Attention points

- **Selections change for every SMART/THOROUGH seed** (constrained and unconstrained), by design. The golden-master rows solving these two presets are regenerated once; **RANDOM and GUIDED come through bit-identical** — verified that only the 32 SMART/THOROUGH cases changed across both the jit and nojit fixtures.
- **`random_fraction=0.0` is byte-identical to the previous farthest-point behavior**, so the existing opt-in `farthest_point()` strategy is unaffected.
- **f=0.1 is a short-budget lean**: a larger prefix is marginally better on the long-budget asymptote, and 0.1 was chosen for the early-budget end.

## Tests / Spikes

- **SPIKE:** A random-prefix parameter sweep established that a 0.1 prefix removes the unconstrained penalty while retaining the constrained benefit — what makes one universal setting viable instead of a constraint fork.
- **TEST:** Full suite green (3934 passed) under numba JIT; targeted init and preset tests green under `NUMBA_DISABLE_JIT`. Golden regeneration confirmed to touch only the SMART/THOROUGH cases.
- Added 3 unit tests for `random_fraction` (range validation, prefix size across the endpoints, full-random behavior); reworked the preset-init test to check every preset's init type, which it previously left unchecked.

## Changelog entry

Category **Changed**:

```
SMART and THOROUGH now begin from a lightly randomized farthest-point construction: short-budget results improve and constrained problems reach competitor-level quality sooner; a given seed selects different but equally diverse items than before
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
