### PR TITLE
chore: gate docs and the Python test matrix in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -130,6 +130,23 @@ jobs:
           # ignore-vulns: |
           #   GHSA-xxxx-xxxx-xxxx  # why accepted
 
+  # Docs must build cleanly at PR time. A broken nav entry, dead cross-link, or stale mkdocstrings
+  # reference is only a warning, so without the strict build `make docs` now runs it would publish
+  # silently — Read the Docs serves the last good build and never signals GitHub.
+  docs:
+    needs: [preflight]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          version: ${{ vars.UV_VERSION }}
+      - name: Build docs (strict)
+        run: make docs
+
   ci-gate:
     name: CI gate
     # The single stable required check on main: branch protection requires only
@@ -137,7 +154,7 @@ jobs:
     # `always()` is load-bearing — without it the gate is skipped when an
     # upstream job fails, and GitHub treats a skipped required check as passing.
     if: always()
-    needs: [preflight, pre-commit, test, test-benchmarks-harness, package, pip-audit]
+    needs: [preflight, pre-commit, test, test-benchmarks-harness, package, pip-audit, docs]
     runs-on: ubuntu-latest
     steps:
       - name: Fail if any required job did not succeed

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -131,8 +131,9 @@ jobs:
           #   GHSA-xxxx-xxxx-xxxx  # why accepted
 
   # Docs must build cleanly at PR time. A broken nav entry, dead cross-link, or stale mkdocstrings
-  # reference is only a warning, so without the strict build `make docs` now runs it would publish
-  # silently — Read the Docs serves the last good build and never signals GitHub.
+  # reference is only a warning, which a non-strict build publishes silently — Read the Docs then
+  # serves the last good build and never signals GitHub. The strict `make docs` fails this check on
+  # any such warning.
   docs:
     needs: [preflight]
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,14 @@ repos:
         # too, so editing one leaves them stale exactly as it leaves the feature tables stale.
         files: ^(data/(capability_axes|solver_registry)\.yaml|docs/solvers/.*\.md)$
         pass_filenames: false
+      - id: python-matrix-coverage
+        name: python matrix covers .python-versions
+        entry: uv run --no-default-groups --group tooling python scripts/check_python_matrix.py
+        language: system
+        # A version added to .python-versions but not to the CI matrix would ship untested; this
+        # fails when a declared version has no matrix leg.
+        files: ^(\.python-versions|\.github/workflows/_unit_tests\.yml)$
+        pass_filenames: false
       - id: uv-lock
         name: uv lock --check
         entry: uv lock --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,8 +56,7 @@ repos:
         name: python matrix covers .python-versions
         entry: uv run --no-default-groups --group tooling python scripts/check_python_matrix.py
         language: system
-        # A version added to .python-versions but not to the CI matrix would ship untested; this
-        # fails when a declared version has no matrix leg.
+        # A version added to .python-versions but not to the CI matrix would ship untested.
         files: ^(\.python-versions|\.github/workflows/_unit_tests\.yml)$
         pass_filenames: false
       - id: uv-lock

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ splash:
 
 docs:
 	# output dir comes from mkdocs.yml (site_dir: ./reports/docs)
-	uv run --exact --no-default-groups --extra docs mkdocs build;
+	uv run --exact --no-default-groups --extra docs mkdocs build --strict;
 
 show-coverage:
 	# trigger browser to open coverage report

--- a/scripts/check_python_matrix.py
+++ b/scripts/check_python_matrix.py
@@ -1,0 +1,64 @@
+"""Check that the CI test matrix covers every Python in `.python-versions`.
+
+`.python-versions` is the declared set of supported Python minors, and `scripts/release.py` already
+ties it to the trove classifiers. Nothing tied it to what CI actually runs: the matrix in
+`.github/workflows/_unit_tests.yml` is hand-curated (each Python paired with resolution and jit
+axes, plus a free-threaded `3.14t` leg), so a version could be added to `.python-versions` and the
+classifiers, pass the release check, and ship to PyPI without a single test leg running on it.
+
+This closes that gap by failing when a declared version has no matrix leg. The check is
+one-directional: extra matrix legs (notably `3.14t`, deliberately absent from `.python-versions`)
+are fine; only an uncovered declared version is an error.
+
+Usage:
+
+    python scripts/check_python_matrix.py    # exits non-zero if a declared version is untested
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PYTHON_VERSIONS_FILE = REPO_ROOT / ".python-versions"
+UNIT_TESTS_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "_unit_tests.yml"
+
+# Matrix legs quote their Python as `python: "3.11"`. The different key `python_version:` and the
+# `${{ ... }}` references carry no quoted literal, so this matches the matrix versions and nothing
+# else.
+_MATRIX_PYTHON = re.compile(r'\bpython:\s*"([^"]+)"')
+
+
+def read_declared_versions(path: Path = PYTHON_VERSIONS_FILE) -> set[str]:
+    """Return the Python minors declared in `.python-versions` (one per non-empty line)."""
+    return {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+
+
+def read_tested_versions(path: Path = UNIT_TESTS_WORKFLOW) -> set[str]:
+    """Return the Python value of every leg in the workflow's test matrix."""
+    return set(_MATRIX_PYTHON.findall(path.read_text(encoding="utf-8")))
+
+
+def uncovered_versions(declared: set[str], tested: set[str]) -> set[str]:
+    """Return declared versions with no matching matrix leg; extra tested legs are allowed."""
+    return declared - tested
+
+
+def main() -> int:
+    """Report any declared Python version the CI matrix does not test; return 1 if any."""
+    declared = read_declared_versions()
+    tested = read_tested_versions()
+    missing = uncovered_versions(declared, tested)
+    if missing:
+        print(
+            f".python-versions declares {sorted(missing)} with no matching leg in the "
+            f"{UNIT_TESTS_WORKFLOW.relative_to(REPO_ROOT)} test matrix (matrix tests {sorted(tested)}).",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"CI matrix covers all {len(declared)} declared Python versions: {sorted(declared)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_python_matrix.py
+++ b/scripts/check_python_matrix.py
@@ -1,14 +1,14 @@
 """Check that the CI test matrix covers every Python in `.python-versions`.
 
-`.python-versions` is the declared set of supported Python minors, and `scripts/release.py` already
-ties it to the trove classifiers. Nothing tied it to what CI actually runs: the matrix in
-`.github/workflows/_unit_tests.yml` is hand-curated (each Python paired with resolution and jit
-axes, plus a free-threaded `3.14t` leg), so a version could be added to `.python-versions` and the
-classifiers, pass the release check, and ship to PyPI without a single test leg running on it.
+`.python-versions` is the declared set of supported Python minors; `scripts/release.py` ties it to
+the trove classifiers. The CI test matrix in `.github/workflows/_unit_tests.yml` is separate and
+hand-curated (each Python paired with resolution and jit axes, plus a free-threaded `3.14t` leg), so
+a version can sit in `.python-versions` and the classifiers, pass the release check, and reach PyPI
+with no test leg running on it. This check fails when a declared version has no matrix leg, so that
+cannot happen.
 
-This closes that gap by failing when a declared version has no matrix leg. The check is
-one-directional: extra matrix legs (notably `3.14t`, deliberately absent from `.python-versions`)
-are fine; only an uncovered declared version is an error.
+The check is one-directional: extra matrix legs (notably `3.14t`, deliberately absent from
+`.python-versions`) are fine; only an uncovered declared version is an error.
 
 Usage:
 

--- a/scripts/check_python_matrix.py
+++ b/scripts/check_python_matrix.py
@@ -1,14 +1,16 @@
 """Check that the CI test matrix covers every Python in `.python-versions`.
 
-`.python-versions` is the declared set of supported Python minors; `scripts/release.py` ties it to
-the trove classifiers. The CI test matrix in `.github/workflows/_unit_tests.yml` is separate and
-hand-curated (each Python paired with resolution and jit axes, plus a free-threaded `3.14t` leg), so
-a version can sit in `.python-versions` and the classifiers, pass the release check, and reach PyPI
-with no test leg running on it. This check fails when a declared version has no matrix leg, so that
-cannot happen.
+`.python-versions` is the declared set of supported Python minors, and `scripts/release.py` ties it
+to the trove classifiers. Nothing ties it to what CI runs.
 
-The check is one-directional: extra matrix legs (notably `3.14t`, deliberately absent from
-`.python-versions`) are fine; only an uncovered declared version is an error.
+The test matrix in `.github/workflows/_unit_tests.yml` is separate and hand-curated (each Python
+paired with resolution and jit axes, plus a free-threaded `3.14t` leg), so a version can sit in
+`.python-versions` and the classifiers, pass the release check, and reach PyPI with no test leg
+running on it.
+
+This check fails when a declared version has no matrix leg. It is one-directional: extra matrix legs
+(notably `3.14t`, deliberately absent from `.python-versions`) are fine; only an uncovered declared
+version is an error.
 
 Usage:
 

--- a/tests/test_check_python_matrix.py
+++ b/tests/test_check_python_matrix.py
@@ -1,0 +1,57 @@
+"""Guards for the CI-matrix coverage check (scripts/check_python_matrix.py)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_python_matrix.py"
+
+
+def _load_module():
+    """Import the check by path — `scripts/` is maintainer tooling, not an importable package."""
+    spec = importlib.util.spec_from_file_location("check_python_matrix", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_mod = _load_module()
+
+
+def test_reads_only_quoted_matrix_python_values(tmp_path):
+    """The parser picks up quoted `python:` matrix legs and ignores `python_version:` / expressions."""
+    # --- arrange -----------------------------------------
+    workflow = tmp_path / "wf.yml"
+    workflow.write_text(
+        "        include:\n"
+        '          - { python: "3.11", resolution: highest }\n'
+        '          - { python: "3.14t", resolution: highest }\n'
+        "          python_version: ${{ matrix.python }}\n",
+        encoding="utf-8",
+    )
+
+    # --- act ---------------------------------------------
+    tested = _mod.read_tested_versions(workflow)
+
+    # --- assert ------------------------------------------
+    assert tested == {"3.11", "3.14t"}
+
+
+def test_uncovered_versions_flags_declared_gap_only():
+    """A declared version absent from the matrix is uncovered; an extra matrix leg is not."""
+    # --- act ---------------------------------------------
+    missing = _mod.uncovered_versions(declared={"3.11", "3.15"}, tested={"3.11", "3.14t"})
+
+    # --- assert ------------------------------------------
+    assert missing == {"3.15"}
+
+
+def test_repo_matrix_covers_declared_versions():
+    """The live repo satisfies the invariant: every declared version has a matrix leg."""
+    # --- act ---------------------------------------------
+    exit_code = _mod.main()
+
+    # --- assert ------------------------------------------
+    assert exit_code == 0


### PR DESCRIPTION
**TL;DR**: Two CI-hardening fixes, no solver code:
- docs build with `--strict` at PR time (a new gated `docs` job), so silent doc breakage fails the build
- a pre-commit hook fails when a Python in `.python-versions` has no CI test-matrix leg

## Description

### Problem addressed

Two gaps in the CI config, no solver code involved. Nothing built the docs at PR time and Read the Docs is not strict, so a warning-level break — a bad nav entry, dead cross-link, or stale mkdocstrings reference — published silently (RTD then serves the last good build and never signals GitHub). Separately, the CI Python matrix is hand-curated and nothing ties it to `.python-versions`, so a version could be declared and classified, pass `release.py`'s check, yet ship to PyPI with no test leg running on it.

### Implementation

- **Strict docs gate** — `make docs` now runs `mkdocs build --strict`, and a new `docs` job runs it on every PR, wired into the required `ci-gate`. The strict build passes clean today, so this adds a gate with no backlog of warnings to clear first. Read-the-Docs strictness is deliberately left alone: a strict RTD that stops updating is no better than a PR-time gate that catches breakage before it reaches the site.
- **Matrix-coverage check** — a `python-matrix-coverage` pre-commit hook runs `scripts/check_python_matrix.py`, which fails when a version in `.python-versions` has no leg in the `_unit_tests.yml` matrix (one-directional: extra legs like the free-threaded `3.14t` are allowed). It runs in `make lint` and the CI `pre-commit` job, so it catches at PR time, and completes `release.py`'s existing `.python-versions`-to-classifiers check.

## Attention points

- **No user-facing change**, so no changelog (and a `chore/` branch, which CI does not gate on one).
- The matrix check parses the workflow's `python:` legs by regex — robust against the different `python_version:` key and the templated expressions, and covered by a test.

## Tests / Spikes

- **TEST:** Full suite green (3947 passed, +3 from the new check's tests); `make lint` clean (the new hook runs and passes); `make docs` builds strict (exit 0).
- Added 3 unit tests for the matrix check: the leg parser, the one-directional gap detection, and a live-repo smoke test that the invariant holds today.

## Changelog entry

None — CI hardening with no user-facing effect; `chore/` branch, so no `CHANGELOG.md` entry is required.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
