### PR TITLE
chore: keep the docs toolchain out of published metadata

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,13 +5,16 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.13"
+  jobs:
+    install:
+      # uv reads the PEP 735 `docs` dependency-group (pip cannot), which keeps the docs toolchain out
+      # of the package's published PyPI metadata. The export deliberately uses `--no-default-groups
+      # --group docs`, not `--only-group docs`: mkdocstrings and mkdocs-autoapi import max_div to read
+      # its docstrings, so the project and its runtime deps must be installed too. `--no-hashes` lets
+      # the (hashless) local project sit in the same requirements file as the hashed dependencies.
+      - pip install uv
+      - uv export --no-default-groups --group docs --no-editable --no-hashes > docs-requirements.txt
+      - pip install -r docs-requirements.txt
 
 mkdocs:
   configuration: mkdocs.yml
-
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ splash:
 
 docs:
 	# output dir comes from mkdocs.yml (site_dir: ./reports/docs)
-	uv run --exact --no-default-groups --extra docs mkdocs build --strict;
+	uv run --exact --no-default-groups --group docs mkdocs build --strict;
 
 show-coverage:
 	# trigger browser to open coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,9 +107,8 @@ dev = [
     { include-group = "package" },
     { include-group = "tooling" },
 ]
-# Docs toolchain — a dependency-group, not a published extra, so it stays out of the package's PyPI
-# metadata; Read the Docs installs it with uv (see .readthedocs.yaml). Kept out of dev for the same
-# reason as notebooks below: building the docs is a separate activity from the test/lint cycle CI runs.
+# Docs toolchain, in its own dependency-group so it stays out of the package's PyPI metadata; out of
+# dev like notebooks below. Read the Docs installs it with uv (see .readthedocs.yaml).
 docs = [
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,16 +47,6 @@ classifiers = [
     "Typing :: Typed",
 ]
 
-[project.optional-dependencies]
-docs = [
-    "mkdocs>=1.6.1",
-    "mkdocs-material>=9.0.0",
-    "mkdocstrings[python]>=0.24.0",
-    "mkdocs-autoapi[python]>=0.4.1",
-    "mkdocs-include-markdown-plugin>=7.2.0",
-    "ruff>=0.14.0",
-]
-
 [dependency-groups]
 # Comparison-benchmark harness (see benchmarks/README.md); never part of the published package.
 benchmarks = [
@@ -116,6 +106,17 @@ dev = [
     { include-group = "lint" },
     { include-group = "package" },
     { include-group = "tooling" },
+]
+# Docs toolchain — a dependency-group, not a published extra, so it stays out of the package's PyPI
+# metadata; Read the Docs installs it with uv (see .readthedocs.yaml). Kept out of dev for the same
+# reason as notebooks below: building the docs is a separate activity from the test/lint cycle CI runs.
+docs = [
+    "mkdocs>=1.6.1",
+    "mkdocs-material>=9.0.0",
+    "mkdocstrings[python]>=0.24.0",
+    "mkdocs-autoapi[python]>=0.4.1",
+    "mkdocs-include-markdown-plugin>=7.2.0",
+    "ruff>=0.14.0",
 ]
 # notebook/analysis tooling — not needed to run the test suite, so kept out of the
 # dev group that CI installs (and out of the lowest-direct resolution surface)

--- a/uv.lock
+++ b/uv.lock
@@ -1800,16 +1800,6 @@ dependencies = [
     { name = "tqdm" },
 ]
 
-[package.optional-dependencies]
-docs = [
-    { name = "mkdocs" },
-    { name = "mkdocs-autoapi", extra = ["python"] },
-    { name = "mkdocs-include-markdown-plugin" },
-    { name = "mkdocs-material" },
-    { name = "mkdocstrings", extra = ["python"] },
-    { name = "ruff" },
-]
-
 [package.dev-dependencies]
 benchmarks = [
     { name = "apricot-select" },
@@ -1837,6 +1827,14 @@ dev = [
     { name = "ruff" },
     { name = "scipy-stubs" },
     { name = "ty" },
+]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-autoapi", extra = ["python"] },
+    { name = "mkdocs-include-markdown-plugin" },
+    { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
+    { name = "ruff" },
 ]
 lint = [
     { name = "pre-commit" },
@@ -1869,11 +1867,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.2.0" },
     { name = "icc-rt", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "intel-cmplr-lib-rt", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.6.1" },
-    { name = "mkdocs-autoapi", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.4.1" },
-    { name = "mkdocs-include-markdown-plugin", marker = "extra == 'docs'", specifier = ">=7.2.0" },
-    { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.0.0" },
-    { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24.0" },
     { name = "numba", marker = "python_full_version < '3.12'", specifier = ">=0.57" },
     { name = "numba", marker = "python_full_version == '3.12.*'", specifier = ">=0.59" },
     { name = "numba", marker = "python_full_version == '3.13.*'", specifier = ">=0.61" },
@@ -1881,13 +1874,11 @@ requires-dist = [
     { name = "numpy", marker = "python_full_version < '3.13'", specifier = ">=2.0.0" },
     { name = "numpy", marker = "python_full_version == '3.13.*'", specifier = ">=2.1.0" },
     { name = "numpy", marker = "python_full_version >= '3.14'", specifier = ">=2.3.2" },
-    { name = "ruff", marker = "extra == 'docs'", specifier = ">=0.14.0" },
     { name = "scipy", marker = "python_full_version < '3.13'", specifier = ">=1.10.0" },
     { name = "scipy", marker = "python_full_version == '3.13.*'", specifier = ">=1.14.1" },
     { name = "scipy", marker = "python_full_version >= '3.14'", specifier = ">=1.16.1" },
     { name = "tqdm", specifier = ">=4.66.0" },
 ]
-provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
 benchmarks = [
@@ -1917,6 +1908,14 @@ dev = [
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "scipy-stubs", specifier = ">=1.10.0" },
     { name = "ty", specifier = ">=0.0.58" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-autoapi", extras = ["python"], specifier = ">=0.4.1" },
+    { name = "mkdocs-include-markdown-plugin", specifier = ">=7.2.0" },
+    { name = "mkdocs-material", specifier = ">=9.0.0" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0" },
+    { name = "ruff", specifier = ">=0.14.0" },
 ]
 lint = [
     { name = "pre-commit", specifier = ">=4.0" },


### PR DESCRIPTION
**TL;DR**: Move the docs toolchain from a published PyPI extra to a private dependency-group, so max-div stops advertising mkdocs + ruff in its package metadata; Read the Docs switches to a uv-based install.

## Description

### Problem addressed

max-div's docs-building toolchain — mkdocs, the theme, mkdocstrings… and `ruff` — was a `[project.optional-dependencies]` extra, so it shipped in the package's PyPI metadata (`Provides-Extra: docs` plus six requirements). A numerics library advertised a docs/lint toolchain to every consumer, and `pip install max-div[docs]` resolved it. It was opt-in, so no plain install pulled it — metadata pollution, not a forced dependency. The extra existed only because Read the Docs installed it via `python.install: method: pip`, which reads PyPI extras but not PEP 735 dependency-groups.

### Implementation

- **Move the six docs deps** from `[project.optional-dependencies] docs` to `[dependency-groups] docs`. Dependency-groups are not published, so the rebuilt wheel's metadata no longer carries the extra. This also aligns docs with the repo's split-by-activity groups (test, lint, package…) — it was the lone exception.
- **Rework `.readthedocs.yaml`** from the pip method to a `build.jobs` uv install. The export uses `--no-default-groups --group docs` (not `--only-group docs`) so it keeps the project and its runtime deps — mkdocstrings and mkdocs-autoapi import `max_div` to read docstrings — with `--no-hashes` so the hashless local project can share the requirements file with the hashed dependencies.
- `make docs` switches `--extra docs` to `--group docs`; the docs CI job exercises this on every PR.

## Attention points

- **Read the Docs is the real gate.** The `build.jobs` install path only fully validates on an actual RTD build, and RTD's status is not reported to GitHub. I simulated it locally (fresh venv → `pip install -r` the export → `import max_div` → `mkdocs build --strict`, all green), but the live RTD build should be watched after merge.
- **The `docs` extra is removed**, so `pip install max-div[docs]` no longer resolves. No changelog entry: the extra was never a consumer-facing option — it was only ever max-div's own docs-build toolchain.

## Tests / Spikes

- **TEST:** Rebuilt the wheel and confirmed `Provides-Extra: docs` and the six `extra == 'docs'` requirements are gone from the metadata.
- **TEST:** Simulated the RTD build in a clean venv — the exported requirements install, `import max_div` / mkdocstrings work, and `mkdocs build --strict` succeeds.
- **TEST:** Full suite green (3947); `make lint` clean (including `uv lock --check` after the re-lock); `make docs` builds via the group.

## Changelog entry

None — packaging-metadata hygiene; the removed `docs` extra was max-div's own docs-build toolchain, never a consumer-facing option, so no user-facing change. `chore/` branch, so CI requires none.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
