### PR TITLE
chore: end the finalized changelog section with a blank line

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -223,7 +223,7 @@ def step_10_finalize_changelog(version: str) -> None:
             i += 1
     tail = text[m.end() :]
     # When a release section follows, keep a blank line before its `## ` heading, so the finalized
-    # section's last bullet is not left directly above it.
+    # section's last bullet is not left directly above that heading.
     new_body = "".join(new_body_lines).rstrip() + ("\n\n" if tail else "\n")
     new_header = f"## {version} ({date.today().isoformat()})\n"
     text = text[: m.start()] + new_header + new_body + tail

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -222,8 +222,8 @@ def step_10_finalize_changelog(version: str) -> None:
             new_body_lines.append(line)
             i += 1
     tail = text[m.end() :]
-    # A blank line ends the finalized section when a release section follows, so its last bullet is
-    # not left directly above that `## ` heading.
+    # When a release section follows, keep a blank line before its `## ` heading, so the finalized
+    # section's last bullet is not left directly above it.
     new_body = "".join(new_body_lines).rstrip() + ("\n\n" if tail else "\n")
     new_header = f"## {version} ({date.today().isoformat()})\n"
     text = text[: m.start()] + new_header + new_body + tail

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -221,9 +221,12 @@ def step_10_finalize_changelog(version: str) -> None:
         else:
             new_body_lines.append(line)
             i += 1
-    new_body = "".join(new_body_lines).rstrip() + "\n"
+    tail = text[m.end() :]
+    # A blank line ends the finalized section when a release section follows, so its last bullet is
+    # not left directly above that `## ` heading.
+    new_body = "".join(new_body_lines).rstrip() + ("\n\n" if tail else "\n")
     new_header = f"## {version} ({date.today().isoformat()})\n"
-    text = text[: m.start()] + new_header + new_body + text[m.end() :]
+    text = text[: m.start()] + new_header + new_body + tail
     CHANGELOG.write_text(text)
 
 


### PR DESCRIPTION
**Problem**: `release.py`'s changelog finalizer joined the moved entries with a single trailing newline, so the finalized section's last bullet sat directly above the previous release's `## ` heading — no blank line between them.

**Solution**: End the section with a blank line when a release section follows (`"\n\n" if tail else "\n"`). Renders identically — Markdown needs no blank line before an ATX heading — so this is raw-file tidiness, not a rendered or user-facing change.

- **TEST:** Ran the finalizer against a temp changelog: the blank line now precedes the previous heading, and empty categories are still dropped. `make lint` and the suite (3947) are green.

**Changelog**: None — raw-file cosmetics with no rendered effect; `chore/` branch, so CI requires none.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
