### PR TITLE
chore: drop the pinned uv version from CI

### DIFF
--- a/.github/actions/pre_commit/action.yml
+++ b/.github/actions/pre_commit/action.yml
@@ -2,18 +2,12 @@ name: Pre-commit
 author: Bert Pluymers
 description: Set up uv and run the full pre-commit hook suite over all files (mirrors `make lint`).
 
-inputs:
-    uv_version:
-        required: true
-        description: "Version of uv to be used. Empty installs the latest."
-
 runs:
     using: composite
     steps:
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ inputs.uv_version }}
           enable-cache: true
 
       - name: Cache pre-commit hook environments

--- a/.github/actions/unit_test/action.yml
+++ b/.github/actions/unit_test/action.yml
@@ -3,9 +3,6 @@ author: Bert Pluymers
 description: Run unit tests at a specific Python version, dependency resolution, and numba JIT mode.
 
 inputs:
-    uv_version:
-        required: true
-        description: "Version of uv to be used. Empty installs the latest."
     python_version:
         required: false
         description: "Python version. Empty string uses .python-version."
@@ -29,7 +26,6 @@ runs:
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ inputs.uv_version }}
           # Distinct cache key per combo (incl. Python, since wheels are cpXY-specific) so
           # parallel legs don't race to save one shared key or restore the wrong interpreter's wheels.
           cache-suffix: py${{ inputs.python_version }}-${{ inputs.dependency_resolution }}-jit-${{ inputs.jit }}

--- a/.github/workflows/_package_check.yml
+++ b/.github/workflows/_package_check.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ vars.UV_VERSION }}
           enable-cache: false  # this job's output is the published artifact; never restore from a poisonable cache
 
       - name: Build sdist + wheel
@@ -49,8 +48,6 @@ jobs:
           persist-credentials: false
       - name: Install uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
 
       - name: Download distribution artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/_unit_tests.yml
+++ b/.github/workflows/_unit_tests.yml
@@ -44,7 +44,6 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/unit_test
         with:
-          uv_version: ${{ vars.UV_VERSION }}
           python_version: ${{ matrix.python }}
           dependency_resolution: ${{ matrix.resolution }}
           jit: ${{ matrix.jit }}
@@ -70,8 +69,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
       - name: Download coverage data from all matrix combos
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -72,8 +72,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/pre_commit
-        with:
-          uv_version: ${{ vars.UV_VERSION }}
 
   test:
     needs: [preflight]
@@ -93,8 +91,6 @@ jobs:
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
       - name: Run harness tests
         run: make test-benchmarks
 
@@ -118,8 +114,6 @@ jobs:
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
       - name: Export the locked runtime dependencies
         run: uv export --frozen --no-emit-project --no-dev --no-hashes --format requirements-txt -o requirements.txt
       - uses: pypa/gh-action-pip-audit@1220774d901786e6f652ae159f7b6bc8fea6d266 # v1.1.0
@@ -143,8 +137,6 @@ jobs:
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          version: ${{ vars.UV_VERSION }}
       - name: Build docs (strict)
         run: make docs
 

--- a/.github/workflows/push_to_branch.yml
+++ b/.github/workflows/push_to_branch.yml
@@ -40,8 +40,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/pre_commit
-        with:
-          uv_version: ${{ vars.UV_VERSION }}
 
   test:  # latest-only here; the full matrix runs on PR / push-to-main / release
     needs: [check-open-pr]
@@ -52,5 +50,3 @@ jobs:
         with:
           persist-credentials: false
       - uses: ./.github/actions/unit_test
-        with:
-          uv_version: ${{ vars.UV_VERSION }}

--- a/.github/workflows/release_tag.yml
+++ b/.github/workflows/release_tag.yml
@@ -19,7 +19,6 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ vars.UV_VERSION }}
           enable-cache: false  # release path never restores from a poisonable cache
       - name: Compare tag to pyproject version
         env:
@@ -104,7 +103,6 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: ${{ vars.UV_VERSION }}
           enable-cache: false  # release path never restores from a poisonable cache
       - name: Download the provenance bundle from the publish job
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
**Problem**: CI pinned uv to a repo-level Actions variable (`vars.UV_VERSION`), an out-of-band value that had to be kept in sync by hand and is invisible to a clean clone or a fork.

**Solution**: Remove every `version:`/`uv_version:` reference so `astral-sh/setup-uv` installs the latest uv. Safe because uv is only the installer/runner — the dependency set stays pinned by `uv.lock` — so a floating uv version changes nothing about what CI resolves, tests, or builds.

- **Attention:** the `UV_VERSION` repo variable is now unused and can be deleted in GitHub → Settings → Variables (not doable from a PR).
- **TEST:** `actionlint`, `zizmor`, and `check-github-workflows` pass on all seven changed files.

**Changelog** (none): CI-only change, no user-facing effect.


Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
