### PR TITLE
chore: enable Dependabot updates for pre-commit hooks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,3 +100,34 @@ updates:
     # number, since the two are meant to stay equal.
     cooldown:
       default-days: 14  # covers every semver level; no per-level override needed
+
+  - package-ecosystem: "pre-commit"
+    # Bumps the pinned `rev` of each hook in .pre-commit-config.yaml; the hook tooling
+    # (ruff, actionlint, zizmor, codespell, ...) rots without these bumps.
+    directory: "/"
+    # Wednesday: a third distinct day, for the collision reason spelled out on the
+    # github-actions entry — auto-merged bumps that fire in the same minute strand each other
+    # behind an out-of-date main.
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "01:00"
+      timezone: "Europe/Zurich"
+    commit-message:
+      prefix: "chore"
+    # Split by update type, as on the entries above and for the same reason: a batch holding a
+    # single major resolves to major and would park every minor/patch bump behind review.
+    groups:
+      pre-commit:  # minor/patch batch: auto-merges once checks pass
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+      pre-commit-major:  # majors batch separately and wait for review
+        patterns: ["*"]
+        update-types: ["major"]
+    # 14 days, matching the entries above. A hook `rev` resolves to a git ref, so (as on the
+    # github-actions entry) the wait is soak time for a compromised or broken release to surface
+    # upstream before a bump can auto-merge. Not subsumed by the weekly cadence: the schedule
+    # sets how often Dependabot looks, the cooldown how old a release must be to be eligible, so
+    # a release that landed in the days before a run still waits rather than being taken at once.
+    cooldown:
+      default-days: 14  # covers every semver level; no per-level override needed


### PR DESCRIPTION
**Problem**: Dependabot tracked the github-actions and uv ecosystems but not the pinned hook `rev`s in `.pre-commit-config.yaml`, so the lint/format tooling (ruff, actionlint, zizmor, ...) only moved when bumped by hand.

**Solution**: Add a `pre-commit` Dependabot ecosystem, adapted to this repo's existing entries rather than copied verbatim: its own weekly day (Wednesday — keeps the day-separation that stops auto-merged sibling bumps stranding each other behind main), a minor/patch-vs-major group split, and the 14-day cooldown used throughout.

- **Attention:** the 14-day cooldown is not subsumed by the weekly cadence — the schedule sets how often Dependabot looks, the cooldown how old a release must be to be eligible — so a recent release still waits.
- **TEST:** `check-dependabot` (schema validation), `check-yaml`, and `zizmor` pass on the changed file.

**Changelog** (none): CI-only change, no user-facing effect.


Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
