### PR TITLE
feat: replace the presets' random-prefix init with top-8 sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- `InitializationStrategy.farthest_point()` accepts an optional `top_k`: each greedy pick samples uniformly among the `top_k` best candidates (default 1 keeps the exact greedy construction)
 
 ### Changed
 - The presets' farthest-point construction picks a little less greedily instead of starting with random picks: short-budget results improve further, and a given seed again selects different (equally good) items

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- The presets' farthest-point construction picks a little less greedily instead of starting with random picks: short-budget results improve further, and a given seed again selects different (equally good) items
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `InitializationStrategy.farthest_point()` accepts an optional `top_k`: each greedy pick samples uniformly among the `top_k` best candidates (default 1 keeps the exact greedy construction)
 
 ### Changed
-- The presets' farthest-point construction picks a little less greedily instead of starting with random picks: short-budget results improve further, and a given seed again selects different (equally good) items
+- The tunable entropy mechanism of the farthest-point initialization procedure has changed from a pure-random fraction to choosing randomly from top_k-farthest-points in each step: short-budget results improve further, while maintaining the effect that seeds sufficiently diversify the search process
 
 ### Deprecated
 

--- a/docs/concepts/solver.md
+++ b/docs/concepts/solver.md
@@ -26,9 +26,9 @@ speed vs quality of the starting point:
 
 | Strategy | How it works |
 |----------|-------------|
-| `random_one_shot` | Selects all `k` items in one batch, with probabilities biased by global separation. **Default for all presets.** |
+| `random_one_shot` | Selects all `k` items in one batch, with probabilities biased by global separation. **Default for the RANDOM and GUIDED presets.** |
 | `random_batched` | Selects in batches of `b`, re-evaluating separations between batches. |
-| `farthest_point` | A seeded random start item, then greedily adds the item farthest from the selection (farthest-point sampling; under `MEAN_PAIRWISE_DISTANCE`, greedily maximizes mean distance to the selection). Constraint-unaware. |
+| `farthest_point` | A seeded random start item, then greedily adds the item farthest from the selection (farthest-point sampling; under `MEAN_PAIRWISE_DISTANCE`, greedily maximizes mean distance to the selection). An optional `top_k` samples each pick uniformly among the `top_k` best candidates (default 1 keeps the exact greedy construction). Constraint-unaware. **The SMART and THOROUGH presets initialize this way.** |
 | `eager` | Evaluates `nc` random candidates per step, picks the best. Slower but higher quality. |
 | `fast` | Selects the first `k` items. Trivial deterministic baseline for testing and benchmarking. |
 

--- a/src/max_div/_core/solver/_presets/preset_smart.py
+++ b/src/max_div/_core/solver/_presets/preset_smart.py
@@ -13,11 +13,12 @@ def get_preset_strategies_smart(
 ) -> tuple[InitializationStrategy, list[OptimizationStep]]:
     # --- initialization ----------------------------------
     # The greedy farthest-point construction reaches competitor-level quality far sooner than a
-    # random start, but its pure form costs quality on unconstrained problems at long budget; a
-    # short random prefix (random_fraction=0.1) removes that penalty while keeping most of the
-    # short-budget edge. random_fraction stays off the public farthest_point() factory, until a
-    # more final implementation has been decided upon.
-    init_strategy = InitFarthestPoint(random_fraction=0.1)
+    # random start; sampling each pick among the top_k=8 highest contributions keeps that quality
+    # (every pick stays among the best candidates) while decorrelating seeds, which is what a
+    # best-of-N portfolio monetizes. Preferred over a random prefix, whose uniform picks cost
+    # several percent at the construction instant. Both knobs stay off the public farthest_point()
+    # factory, until a more final implementation has been decided upon.
+    init_strategy = InitFarthestPoint(top_k=8)
 
     # --- optimization steps ------------------------------
     if thorough:

--- a/src/max_div/_core/solver/_presets/preset_smart.py
+++ b/src/max_div/_core/solver/_presets/preset_smart.py
@@ -13,11 +13,10 @@ def get_preset_strategies_smart(
 ) -> tuple[InitializationStrategy, list[OptimizationStep]]:
     # --- initialization ----------------------------------
     # The greedy farthest-point construction reaches competitor-level quality far sooner than a
-    # random start; sampling each pick among the top_k=8 highest contributions keeps that quality
-    # (every pick stays among the best candidates) while decorrelating seeds, which is what a
-    # best-of-N portfolio monetizes. Preferred over a random prefix, whose uniform picks cost
-    # several percent at the construction instant. Both knobs stay off the public farthest_point()
-    # factory, until a more final implementation has been decided upon.
+    # random start; sampling each pick among the top_k highest contributions keeps that quality
+    # (every pick stays among the best candidates) while decorrelating seeds, so the workers of a
+    # best-of-N portfolio find different solutions. top_k and random_fraction are deliberately not
+    # exposed on the public farthest_point() factory.
     init_strategy = InitFarthestPoint(top_k=8)
 
     # --- optimization steps ------------------------------

--- a/src/max_div/_core/solver/_presets/preset_smart.py
+++ b/src/max_div/_core/solver/_presets/preset_smart.py
@@ -14,9 +14,8 @@ def get_preset_strategies_smart(
     # --- initialization ----------------------------------
     # The greedy farthest-point construction reaches competitor-level quality far sooner than a
     # random start; sampling each pick among the top_k highest contributions keeps that quality
-    # while letting different seeds pick different items, so the workers of a best-of-N portfolio
-    # find different solutions. top_k is deliberately not exposed on the public farthest_point()
-    # factory.
+    # while letting different seeds have sufficient differentiating impact on initialization, so
+    # the workers of a best-of-N portfolio perform a sufficiently broad, differentiated search.
     init_strategy = InitFarthestPoint(top_k=8)
 
     # --- optimization steps ------------------------------

--- a/src/max_div/_core/solver/_presets/preset_smart.py
+++ b/src/max_div/_core/solver/_presets/preset_smart.py
@@ -14,9 +14,9 @@ def get_preset_strategies_smart(
     # --- initialization ----------------------------------
     # The greedy farthest-point construction reaches competitor-level quality far sooner than a
     # random start; sampling each pick among the top_k highest contributions keeps that quality
-    # (every pick stays among the best candidates) while decorrelating seeds, so the workers of a
-    # best-of-N portfolio find different solutions. top_k and random_fraction are deliberately not
-    # exposed on the public farthest_point() factory.
+    # while letting different seeds pick different items, so the workers of a best-of-N portfolio
+    # find different solutions. top_k is deliberately not exposed on the public farthest_point()
+    # factory.
     init_strategy = InitFarthestPoint(top_k=8)
 
     # --- optimization steps ------------------------------

--- a/src/max_div/_core/solver/_strategies/_initialization/_base.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_base.py
@@ -57,14 +57,17 @@ class InitializationStrategy(StrategyBase, ABC):
         return InitFast()
 
     @classmethod
-    def farthest_point(cls) -> InitFarthestPoint:
+    def farthest_point(cls, top_k: int = 1) -> InitFarthestPoint:
         """Farthest-point-sampling initialization: a seeded random start item, then greedy picks.
 
         See `InitFarthestPoint` for the per-metric interpretation and constraint handling.
+
+        :param top_k: Each greedy pick samples uniformly among the `top_k` highest diversity
+            contributions; the default 1 keeps the exact greedy construction.
         """
         from ._init_farthest_point import InitFarthestPoint
 
-        return InitFarthestPoint()
+        return InitFarthestPoint(top_k=top_k)
 
     @classmethod
     def random_one_shot(cls, uniform: bool = False, ignore_constraints: bool = False) -> InitRandomOneShot:

--- a/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
+++ b/src/max_div/_core/solver/_strategies/_initialization/_init_farthest_point.py
@@ -21,12 +21,6 @@ class InitFarthestPoint(InitializationStrategy):
 
     Constraints are ignored by design; feasibility is left to the optimization steps.
 
-    A `random_fraction` above zero widens the random start into a random *prefix*: the first
-    `round(random_fraction * k)` items (at least one) are drawn uniformly at random in a single
-    batch, and the greedy picks fill the rest. At the endpoints, 0.0 is the pure farthest-point
-    construction from a single random seed, and 1.0 is a fully random selection. The prefix trades
-    a little of the pure construction's peak quality for diversity among start points.
-
     A `top_k` above one makes every greedy pick sample uniformly among the `top_k` highest
     contributions instead of taking the argmax, so picks vary while every one stays among the best
     candidates. `top_k=1` is the exact argmax and consumes no randomness.
@@ -38,23 +32,19 @@ class InitFarthestPoint(InitializationStrategy):
        - ~O(n * k), times d when distances are computed on demand from vectors.
     """
 
-    def __init__(self, random_fraction: float = 0.0, top_k: int = 1) -> None:
-        """Create the strategy; `random_fraction` sets the random-prefix size and `top_k` the pick candidate count.
+    def __init__(self, top_k: int = 1) -> None:
+        """Create the strategy.
 
-        :raises ValueError: If `random_fraction` is outside [0, 1], or `top_k` is below 1.
+        :raises ValueError: If `top_k` is below 1.
         """
         super().__init__()
-        if not (0.0 <= random_fraction <= 1.0):
-            raise ValueError(f"random_fraction must be in [0, 1], got {random_fraction}")
         if top_k < 1:
             raise ValueError(f"top_k must be >= 1, got {top_k}")
-        self._random_fraction = random_fraction
         self._top_k = top_k
 
     def get_next_samples(self, state: SolverState, k_remaining: int | np.int32) -> NDArray[np.int32]:
         if state.n_selected == 0:
-            n_random = min(max(round(self._random_fraction * int(state.k)), 1), int(state.k))
-            return randint(n=state.n, k=np.int32(n_random), replace=False, p=P_UNIFORM, rng_state=self._rng_state)
+            return randint(n=state.n, k=np.int32(1), replace=False, p=P_UNIFORM, rng_state=self._rng_state)
         # both arrays below are ascending-index, so positions align
         contributions = state.not_selected_contribution_array
         if self._top_k == 1:

--- a/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
+++ b/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
@@ -78,49 +78,6 @@ def test_init_farthest_point_name():
     assert strategy.name == "InitFarthestPoint"
 
 
-@pytest.mark.parametrize("random_fraction", [-0.1, 1.1, 2.0])
-def test_init_farthest_point_rejects_out_of_range_random_fraction(random_fraction: float):
-    """random_fraction must lie in [0, 1]."""
-    # --- act & assert ------------------------------------
-    with pytest.raises(ValueError, match="random_fraction"):
-        InitFarthestPoint(random_fraction=random_fraction)
-
-
-@pytest.mark.parametrize(
-    "random_fraction, expected_prefix",
-    [(0.0, 1), (0.1, 5), (0.5, 25), (1.0, 50)],  # the shared state has k=50
-)
-def test_init_farthest_point_random_prefix_size(random_fraction: float, expected_prefix: int):
-    """The first batch draws round(random_fraction * k) distinct random items, at least one."""
-    # --- arrange -----------------------------------------
-    solver_state = new_solver_state(has_constraints=False)
-    strategy = InitFarthestPoint(random_fraction=random_fraction)
-
-    # --- act ---------------------------------------------
-    first_batch = strategy.get_next_samples(solver_state, solver_state.k)
-
-    # --- assert ------------------------------------------
-    assert len(first_batch) == expected_prefix
-    assert len({int(i) for i in first_batch}) == expected_prefix  # the drawn items are all distinct
-
-
-def test_init_farthest_point_full_random_prefix_skips_greedy():
-    """random_fraction=1.0 fills the whole selection in one random batch, never running a greedy pick."""
-    # --- arrange -----------------------------------------
-    state_full = new_solver_state(has_constraints=False)
-    state_greedy = new_solver_state(has_constraints=False)
-
-    # --- act ---------------------------------------------
-    InitializationStep(InitFarthestPoint(random_fraction=1.0)).run(state_full)
-    InitializationStep(InitFarthestPoint(random_fraction=0.0)).run(state_greedy)
-
-    # --- assert ------------------------------------------
-    assert state_full.score.size == 1.0  # the single random batch reached full size k
-    full_selection = {int(i) for i in state_full.selected_index_array}
-    greedy_selection = {int(i) for i in state_greedy.selected_index_array}
-    assert full_selection != greedy_selection  # a random fill differs from the greedy construction
-
-
 @pytest.mark.parametrize("top_k", [0, -1])
 def test_init_farthest_point_rejects_top_k_below_one(top_k: int):
     """top_k must be >= 1."""

--- a/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
+++ b/tests/_core/solver/_strategies/_initialization/test_init_farthest_point.py
@@ -86,6 +86,33 @@ def test_init_farthest_point_rejects_top_k_below_one(top_k: int):
         InitFarthestPoint(top_k=top_k)
 
 
+def test_farthest_point_factory_passes_top_k_through():
+    """The public factory's top_k reaches the strategy: same seed, same pick as direct construction."""
+    # --- arrange -----------------------------------------
+    solver_state = new_solver_state(has_constraints=False)
+    solver_state.add(np.int32(0))
+
+    # --- act ---------------------------------------------
+    picks = {}
+    for name, strategy in [
+        ("factory", InitializationStrategy.farthest_point(top_k=5)),
+        ("direct", InitFarthestPoint(top_k=5)),
+    ]:
+        strategy.set_seed(3)
+        picks[name] = int(strategy.get_next_samples(solver_state, solver_state.k)[0])
+
+    # --- assert ------------------------------------------
+    assert picks["factory"] == picks["direct"]
+
+
+@pytest.mark.parametrize("top_k", [0, -1])
+def test_farthest_point_factory_rejects_top_k_below_one(top_k: int):
+    """The strategy's top_k validation raises through the public factory."""
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError, match="top_k"):
+        InitializationStrategy.farthest_point(top_k=top_k)
+
+
 def test_init_farthest_point_top_k_1_is_the_argmax_pick():
     """top_k=1 takes the plain argmax pick, identical to the default strategy."""
     # --- arrange -----------------------------------------

--- a/tests/_core/solver/golden_master_data_jit.json
+++ b/tests/_core/solver/golden_master_data_jit.json
@@ -971,15 +971,15 @@
   "U1|SMART|42": {
    "i_selected": [
     0,
-    19,
-    36,
-    47,
-    56,
-    66,
+    13,
+    25,
+    33,
+    45,
+    51,
+    61,
     70,
-    82,
-    89,
-    99
+    84,
+    94
    ],
    "score_checkpoints": [
     {
@@ -995,7 +995,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.08969675749540329,
      "div_tie_breakers": [
       1.0
      ]
@@ -1004,7 +1004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.08969675749540329,
      "div_tie_breakers": [
       1.0
      ]
@@ -1013,7 +1013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09388004243373871,
      "div_tie_breakers": [
       1.0
      ]
@@ -1022,7 +1022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1031,7 +1031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1040,7 +1040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1049,7 +1049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1058,7 +1058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1067,7 +1067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1076,7 +1076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1085,7 +1085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1094,7 +1094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1103,7 +1103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1112,7 +1112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1121,7 +1121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1130,7 +1130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855968236923,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1139,7 +1139,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855968236923,
+     "diversity": 0.10169428586959839,
      "div_tie_breakers": [
       1.0
      ]
@@ -1148,7 +1148,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10169428586959839,
      "div_tie_breakers": [
       1.0
      ]
@@ -1157,7 +1157,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10169428586959839,
      "div_tie_breakers": [
       1.0
      ]
@@ -1166,7 +1166,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10169428586959839,
      "div_tie_breakers": [
       1.0
      ]
@@ -1175,7 +1175,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1184,7 +1184,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1193,7 +1193,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1202,7 +1202,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1211,16 +1211,16 @@
   },
   "U1|SMART|123": {
    "i_selected": [
-    3,
-    13,
-    25,
-    32,
-    45,
-    53,
-    67,
-    76,
-    88,
-    99
+    0,
+    18,
+    29,
+    41,
+    49,
+    56,
+    60,
+    72,
+    84,
+    95
    ],
    "score_checkpoints": [
     {
@@ -1236,7 +1236,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1245,7 +1245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1254,7 +1254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1263,7 +1263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1272,7 +1272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09335370361804962,
      "div_tie_breakers": [
       1.0
      ]
@@ -1281,7 +1281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09335370361804962,
      "div_tie_breakers": [
       1.0
      ]
@@ -1290,7 +1290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1299,7 +1299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1308,7 +1308,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1317,7 +1317,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1326,7 +1326,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1335,7 +1335,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1344,7 +1344,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1353,7 +1353,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1362,7 +1362,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1371,7 +1371,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1380,7 +1380,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1389,7 +1389,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1398,7 +1398,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1407,7 +1407,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1416,7 +1416,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1425,7 +1425,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1434,7 +1434,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1443,7 +1443,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1453,15 +1453,15 @@
   "U1|THOROUGH|42": {
    "i_selected": [
     0,
-    19,
-    36,
-    47,
-    56,
-    66,
+    13,
+    25,
+    32,
+    45,
+    51,
+    61,
     70,
-    82,
-    89,
-    99
+    84,
+    94
    ],
    "score_checkpoints": [
     {
@@ -1477,7 +1477,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.08969675749540329,
      "div_tie_breakers": [
       1.0
      ]
@@ -1486,7 +1486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.08969675749540329,
      "div_tie_breakers": [
       1.0
      ]
@@ -1495,7 +1495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09388004243373871,
      "div_tie_breakers": [
       1.0
      ]
@@ -1504,7 +1504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1513,7 +1513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1522,7 +1522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1531,7 +1531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1540,7 +1540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09624192863702774,
      "div_tie_breakers": [
       1.0
      ]
@@ -1549,7 +1549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1558,7 +1558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1567,7 +1567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1576,7 +1576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1585,7 +1585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1594,7 +1594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1603,7 +1603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229168832302094,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1612,7 +1612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855968236923,
+     "diversity": 0.09754430502653122,
      "div_tie_breakers": [
       1.0
      ]
@@ -1621,7 +1621,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855968236923,
+     "diversity": 0.10169428586959839,
      "div_tie_breakers": [
       1.0
      ]
@@ -1630,7 +1630,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10169428586959839,
      "div_tie_breakers": [
       1.0
      ]
@@ -1639,7 +1639,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10169428586959839,
      "div_tie_breakers": [
       1.0
      ]
@@ -1648,7 +1648,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1657,7 +1657,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1666,7 +1666,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1675,7 +1675,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1684,7 +1684,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649915456772,
+     "diversity": 0.10281588137149811,
      "div_tie_breakers": [
       1.0
      ]
@@ -1693,16 +1693,16 @@
   },
   "U1|THOROUGH|123": {
    "i_selected": [
-    3,
-    13,
-    25,
-    32,
-    45,
-    53,
-    67,
-    76,
-    88,
-    99
+    0,
+    18,
+    29,
+    41,
+    49,
+    56,
+    60,
+    72,
+    84,
+    95
    ],
    "score_checkpoints": [
     {
@@ -1718,7 +1718,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1727,7 +1727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1736,7 +1736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1745,7 +1745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09278477728366852,
      "div_tie_breakers": [
       1.0
      ]
@@ -1754,7 +1754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09335370361804962,
      "div_tie_breakers": [
       1.0
      ]
@@ -1763,7 +1763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09335370361804962,
      "div_tie_breakers": [
       1.0
      ]
@@ -1772,7 +1772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1781,7 +1781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1790,7 +1790,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1799,7 +1799,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1808,7 +1808,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1817,7 +1817,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1826,7 +1826,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891639709473,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1835,7 +1835,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1844,7 +1844,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1853,7 +1853,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1862,7 +1862,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1871,7 +1871,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768631309270859,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1880,7 +1880,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1889,7 +1889,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1898,7 +1898,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1907,7 +1907,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1916,7 +1916,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -1925,7 +1925,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120121389627457,
+     "diversity": 0.09571453928947449,
      "div_tie_breakers": [
       1.0
      ]
@@ -2898,15 +2898,15 @@
   },
   "U2|SMART|42": {
    "i_selected": [
-    11,
-    29,
-    56,
+    0,
+    22,
+    46,
+    51,
     66,
-    75,
-    81,
-    86,
-    93,
-    95,
+    70,
+    80,
+    92,
+    94,
     99
    ],
    "score_checkpoints": [
@@ -2923,7 +2923,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.3759072721004486,
      "div_tie_breakers": [
       1.0
      ]
@@ -2932,7 +2932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.3759072721004486,
      "div_tie_breakers": [
       1.0
      ]
@@ -2941,7 +2941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.3759072721004486,
      "div_tie_breakers": [
       1.0
      ]
@@ -2950,7 +2950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -2959,7 +2959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -2968,7 +2968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -2977,7 +2977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -2986,7 +2986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -2995,7 +2995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3004,7 +3004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3013,7 +3013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3022,7 +3022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3031,7 +3031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3040,7 +3040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3049,7 +3049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3058,7 +3058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3067,7 +3067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3076,7 +3076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3085,7 +3085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3094,7 +3094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.41234201192855835,
      "div_tie_breakers": [
       1.0
      ]
@@ -3103,7 +3103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.41234201192855835,
      "div_tie_breakers": [
       1.0
      ]
@@ -3112,7 +3112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.41234201192855835,
      "div_tie_breakers": [
       1.0
      ]
@@ -3121,7 +3121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.41234201192855835,
      "div_tie_breakers": [
       1.0
      ]
@@ -3130,7 +3130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.41234201192855835,
      "div_tie_breakers": [
       1.0
      ]
@@ -3140,14 +3140,14 @@
   "U2|SMART|123": {
    "i_selected": [
     3,
-    46,
-    51,
+    37,
+    49,
+    62,
     70,
-    73,
+    80,
     82,
-    85,
+    94,
     95,
-    98,
     99
    ],
    "score_checkpoints": [
@@ -3164,7 +3164,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3173,7 +3173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3182,7 +3182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3191,7 +3191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3200,7 +3200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3209,7 +3209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3218,7 +3218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3227,7 +3227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4478932023048401,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3236,7 +3236,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4478932023048401,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3245,7 +3245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4478932023048401,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3254,7 +3254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4557018280029297,
+     "diversity": 0.46251529455184937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3263,7 +3263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4557018280029297,
+     "diversity": 0.46251529455184937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3272,7 +3272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4557018280029297,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3281,7 +3281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201707839966,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3290,7 +3290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201707839966,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3299,7 +3299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201707839966,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3308,7 +3308,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201707839966,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3317,7 +3317,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201707839966,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3326,7 +3326,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201707839966,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3335,7 +3335,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201707839966,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3344,7 +3344,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46346214413642883,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3353,7 +3353,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46346214413642883,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3362,7 +3362,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46346214413642883,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3371,7 +3371,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46346214413642883,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3380,15 +3380,15 @@
   },
   "U2|THOROUGH|42": {
    "i_selected": [
-    11,
-    29,
-    56,
+    0,
+    22,
+    33,
+    51,
     66,
-    75,
-    81,
-    86,
-    93,
-    95,
+    70,
+    80,
+    92,
+    94,
     99
    ],
    "score_checkpoints": [
@@ -3405,7 +3405,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.3759072721004486,
      "div_tie_breakers": [
       1.0
      ]
@@ -3414,7 +3414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.3759072721004486,
      "div_tie_breakers": [
       1.0
      ]
@@ -3423,7 +3423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.3759072721004486,
      "div_tie_breakers": [
       1.0
      ]
@@ -3432,7 +3432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3441,7 +3441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41756176948547363,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3450,7 +3450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3459,7 +3459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3468,7 +3468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3477,7 +3477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3486,7 +3486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3495,7 +3495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3504,7 +3504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3513,7 +3513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3522,7 +3522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3531,7 +3531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3540,7 +3540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.40882572531700134,
      "div_tie_breakers": [
       1.0
      ]
@@ -3549,7 +3549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3558,7 +3558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4308570325374603,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3567,7 +3567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3576,7 +3576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3585,7 +3585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3594,7 +3594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3603,7 +3603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3612,7 +3612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439661026001,
+     "diversity": 0.4119873344898224,
      "div_tie_breakers": [
       1.0
      ]
@@ -3622,14 +3622,14 @@
   "U2|THOROUGH|123": {
    "i_selected": [
     3,
-    41,
-    46,
-    67,
-    69,
+    37,
+    49,
+    62,
+    70,
+    80,
     82,
-    83,
+    94,
     95,
-    96,
     99
    ],
    "score_checkpoints": [
@@ -3646,7 +3646,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3655,7 +3655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3664,7 +3664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3673,7 +3673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3682,7 +3682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3691,7 +3691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3700,7 +3700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518683314323425,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3709,7 +3709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4478932023048401,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3718,7 +3718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4478932023048401,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3727,7 +3727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4478932023048401,
+     "diversity": 0.45047876238822937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3736,7 +3736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.46251529455184937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3745,7 +3745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.46251529455184937,
      "div_tie_breakers": [
       1.0
      ]
@@ -3754,7 +3754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3763,7 +3763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3772,7 +3772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3781,7 +3781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3790,7 +3790,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.46664905548095703,
      "div_tie_breakers": [
       1.0
      ]
@@ -3799,7 +3799,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3808,7 +3808,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3817,7 +3817,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4691455662250519,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3826,7 +3826,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.47511792182922363,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3835,7 +3835,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.47511792182922363,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3844,7 +3844,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.47511792182922363,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -3853,7 +3853,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.47511792182922363,
+     "diversity": 0.4680502116680145,
      "div_tie_breakers": [
       1.0
      ]
@@ -4827,12 +4827,12 @@
   "U3|SMART|42": {
    "i_selected": [
     0,
+    51,
     66,
     72,
     80,
-    85,
-    88,
-    91,
+    86,
+    89,
     93,
     96,
     99
@@ -4851,7 +4851,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.7713391780853271,
      "div_tie_breakers": [
       1.0
      ]
@@ -4860,7 +4860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.7713391780853271,
      "div_tie_breakers": [
       1.0
      ]
@@ -4869,7 +4869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.7713391780853271,
      "div_tie_breakers": [
       1.0
      ]
@@ -4878,7 +4878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8676490783691406,
      "div_tie_breakers": [
       1.0
      ]
@@ -4887,7 +4887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8676490783691406,
      "div_tie_breakers": [
       1.0
      ]
@@ -4896,7 +4896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -4905,7 +4905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -4914,7 +4914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -4923,7 +4923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -4932,7 +4932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -4941,7 +4941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -4950,7 +4950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -4959,7 +4959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -4968,7 +4968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -4977,7 +4977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -4986,7 +4986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -4995,7 +4995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9125753045082092,
      "div_tie_breakers": [
       1.0
      ]
@@ -5004,7 +5004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5013,7 +5013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5022,7 +5022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5031,7 +5031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5040,7 +5040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5049,7 +5049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9249761700630188,
      "div_tie_breakers": [
       1.0
      ]
@@ -5058,7 +5058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9249761700630188,
      "div_tie_breakers": [
       1.0
      ]
@@ -5067,15 +5067,15 @@
   },
   "U3|SMART|123": {
    "i_selected": [
-    3,
-    57,
-    69,
-    77,
-    86,
-    89,
-    92,
+    0,
+    52,
+    66,
+    70,
+    80,
+    85,
+    88,
+    91,
     94,
-    97,
     99
    ],
    "score_checkpoints": [
@@ -5092,7 +5092,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.8708903193473816,
      "div_tie_breakers": [
       1.0
      ]
@@ -5101,7 +5101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.8708903193473816,
      "div_tie_breakers": [
       1.0
      ]
@@ -5110,7 +5110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5119,7 +5119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5128,7 +5128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5137,7 +5137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5146,7 +5146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.953353762626648,
      "div_tie_breakers": [
       1.0
      ]
@@ -5155,7 +5155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9555670022964478,
      "div_tie_breakers": [
       1.0
      ]
@@ -5164,7 +5164,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5173,7 +5173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5182,7 +5182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5191,7 +5191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5200,7 +5200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5209,7 +5209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5218,7 +5218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5227,7 +5227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5236,7 +5236,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5245,7 +5245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5254,7 +5254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5263,7 +5263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5272,7 +5272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5281,7 +5281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5290,7 +5290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5299,7 +5299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5309,12 +5309,12 @@
   "U3|THOROUGH|42": {
    "i_selected": [
     0,
+    51,
     66,
     72,
     80,
     85,
-    88,
-    91,
+    89,
     93,
     96,
     99
@@ -5333,7 +5333,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.7713391780853271,
      "div_tie_breakers": [
       1.0
      ]
@@ -5342,7 +5342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.7713391780853271,
      "div_tie_breakers": [
       1.0
      ]
@@ -5351,7 +5351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.7713391780853271,
      "div_tie_breakers": [
       1.0
      ]
@@ -5360,7 +5360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8676490783691406,
      "div_tie_breakers": [
       1.0
      ]
@@ -5369,7 +5369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8676490783691406,
      "div_tie_breakers": [
       1.0
      ]
@@ -5378,7 +5378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -5387,7 +5387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -5396,7 +5396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -5405,7 +5405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -5414,7 +5414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -5423,7 +5423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -5432,7 +5432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.8903851509094238,
      "div_tie_breakers": [
       1.0
      ]
@@ -5441,7 +5441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -5450,7 +5450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -5459,7 +5459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -5468,7 +5468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.894436240196228,
      "div_tie_breakers": [
       1.0
      ]
@@ -5477,7 +5477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9125753045082092,
      "div_tie_breakers": [
       1.0
      ]
@@ -5486,7 +5486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5495,7 +5495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5504,7 +5504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5513,7 +5513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5522,7 +5522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5531,7 +5531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5540,7 +5540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768746376038,
+     "diversity": 0.9238318204879761,
      "div_tie_breakers": [
       1.0
      ]
@@ -5549,15 +5549,15 @@
   },
   "U3|THOROUGH|123": {
    "i_selected": [
-    3,
-    57,
-    69,
-    77,
-    86,
-    89,
-    92,
+    0,
+    52,
+    66,
+    70,
+    80,
+    85,
+    88,
+    91,
     94,
-    97,
     99
    ],
    "score_checkpoints": [
@@ -5574,7 +5574,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.8708903193473816,
      "div_tie_breakers": [
       1.0
      ]
@@ -5583,7 +5583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.8708903193473816,
      "div_tie_breakers": [
       1.0
      ]
@@ -5592,7 +5592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5601,7 +5601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5610,7 +5610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5619,7 +5619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9289576411247253,
      "div_tie_breakers": [
       1.0
      ]
@@ -5628,7 +5628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.953353762626648,
      "div_tie_breakers": [
       1.0
      ]
@@ -5637,7 +5637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9555670022964478,
      "div_tie_breakers": [
       1.0
      ]
@@ -5646,7 +5646,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5655,7 +5655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5664,7 +5664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5673,7 +5673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5682,7 +5682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9704312682151794,
      "div_tie_breakers": [
       1.0
      ]
@@ -5691,7 +5691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5700,7 +5700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5709,7 +5709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5718,7 +5718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5727,7 +5727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5736,7 +5736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5745,7 +5745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085480690002,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5754,7 +5754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5763,7 +5763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5772,7 +5772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -5781,7 +5781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219401359558,
+     "diversity": 0.9726225137710571,
      "div_tie_breakers": [
       1.0
      ]
@@ -6754,16 +6754,16 @@
   },
   "U4|SMART|42": {
    "i_selected": [
-    0,
-    20,
-    41,
-    49,
-    59,
-    66,
-    76,
-    86,
-    91,
-    99
+    1,
+    16,
+    23,
+    33,
+    47,
+    54,
+    60,
+    67,
+    82,
+    97
    ],
    "score_checkpoints": [
     {
@@ -6779,7 +6779,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10113362222909927,
+     "diversity": 0.09624193608760834,
      "div_tie_breakers": [
       1.0
      ]
@@ -6788,7 +6788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.09624193608760834,
      "div_tie_breakers": [
       1.0
      ]
@@ -6797,7 +6797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10140421986579895,
      "div_tie_breakers": [
       1.0
      ]
@@ -6806,7 +6806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -6815,7 +6815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -6824,7 +6824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -6833,7 +6833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -6842,7 +6842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -6851,7 +6851,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -6860,7 +6860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -6869,7 +6869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6878,7 +6878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6887,7 +6887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6896,7 +6896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6905,7 +6905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6914,7 +6914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10395938158035278,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6923,7 +6923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10395938158035278,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6932,7 +6932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6941,7 +6941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6950,7 +6950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6959,7 +6959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6968,7 +6968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6977,7 +6977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678783059120178,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6986,7 +6986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678783059120178,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -6996,15 +6996,15 @@
   "U4|SMART|123": {
    "i_selected": [
     0,
-    19,
-    30,
-    48,
-    57,
-    68,
-    80,
-    87,
-    93,
-    99
+    12,
+    20,
+    25,
+    44,
+    53,
+    60,
+    69,
+    83,
+    94
    ],
    "score_checkpoints": [
     {
@@ -7020,7 +7020,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7029,7 +7029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7038,7 +7038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7047,7 +7047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7056,7 +7056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7065,7 +7065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7074,7 +7074,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208819389343,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7083,7 +7083,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208819389343,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7092,7 +7092,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208819389343,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7101,7 +7101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7110,7 +7110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7119,7 +7119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7128,7 +7128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7137,7 +7137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7146,7 +7146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7155,7 +7155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7164,7 +7164,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7173,7 +7173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10961883515119553,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7182,7 +7182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10961883515119553,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7191,7 +7191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10961883515119553,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7200,7 +7200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10961883515119553,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7209,7 +7209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10961883515119553,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7218,7 +7218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10961883515119553,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7227,7 +7227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10961883515119553,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7236,16 +7236,16 @@
   },
   "U4|THOROUGH|42": {
    "i_selected": [
-    0,
-    20,
-    41,
-    49,
-    59,
-    66,
-    76,
-    86,
-    91,
-    99
+    1,
+    16,
+    23,
+    34,
+    44,
+    54,
+    60,
+    67,
+    82,
+    97
    ],
    "score_checkpoints": [
     {
@@ -7261,7 +7261,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10113362222909927,
+     "diversity": 0.09624193608760834,
      "div_tie_breakers": [
       1.0
      ]
@@ -7270,7 +7270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.09624193608760834,
      "div_tie_breakers": [
       1.0
      ]
@@ -7279,7 +7279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10140421986579895,
      "div_tie_breakers": [
       1.0
      ]
@@ -7288,7 +7288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -7297,7 +7297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -7306,7 +7306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -7315,7 +7315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -7324,7 +7324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -7333,7 +7333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -7342,7 +7342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10301018506288528,
      "div_tie_breakers": [
       1.0
      ]
@@ -7351,7 +7351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7360,7 +7360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7369,7 +7369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7378,7 +7378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7387,7 +7387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308264195919037,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7396,7 +7396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10395938158035278,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7405,7 +7405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10395938158035278,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7414,7 +7414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7423,7 +7423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7432,7 +7432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7441,7 +7441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7450,7 +7450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467449426651,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7459,7 +7459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678783059120178,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7468,7 +7468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678783059120178,
+     "diversity": 0.10371372848749161,
      "div_tie_breakers": [
       1.0
      ]
@@ -7477,16 +7477,16 @@
   },
   "U4|THOROUGH|123": {
    "i_selected": [
-    1,
-    19,
-    30,
-    48,
-    57,
-    66,
-    80,
-    89,
-    93,
-    99
+    0,
+    12,
+    20,
+    25,
+    44,
+    53,
+    60,
+    69,
+    83,
+    94
    ],
    "score_checkpoints": [
     {
@@ -7502,7 +7502,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7511,7 +7511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7520,7 +7520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7529,7 +7529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7538,7 +7538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7547,7 +7547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1047920435667038,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7556,7 +7556,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208819389343,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7565,7 +7565,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208819389343,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7574,7 +7574,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208819389343,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7583,7 +7583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.09622035175561905,
      "div_tie_breakers": [
       1.0
      ]
@@ -7592,7 +7592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7601,7 +7601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7610,7 +7610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7619,7 +7619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7628,7 +7628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7637,7 +7637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.0971556082367897,
      "div_tie_breakers": [
       1.0
      ]
@@ -7646,7 +7646,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7655,7 +7655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7664,7 +7664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7673,7 +7673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7682,7 +7682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7691,7 +7691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7700,7 +7700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -7709,7 +7709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10804302245378494,
+     "diversity": 0.10005737841129303,
      "div_tie_breakers": [
       1.0
      ]
@@ -8682,735 +8682,12 @@
   },
   "C1|SMART|42": {
    "i_selected": [
-    5,
-    29,
-    41,
-    69,
-    76,
-    82,
-    86,
-    95,
-    96,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.11111111111111116,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363571524620056,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363571524620056,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363571524620056,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.752679169178009,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.752679169178009,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7887588143348694,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950266838074,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950266838074,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C1|SMART|123": {
-   "i_selected": [
-    3,
-    41,
-    50,
-    66,
-    69,
-    76,
-    83,
-    95,
-    97,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.11111111111111116,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298109531402588,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298109531402588,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298109531402588,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298109531402588,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298109531402588,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304893732070923,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453342080116272,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C1|THOROUGH|42": {
-   "i_selected": [
-    5,
-    29,
-    41,
-    69,
-    76,
-    82,
-    86,
-    95,
-    96,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.11111111111111116,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363571524620056,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363571524620056,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363571524620056,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.752679169178009,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.752679169178009,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7664602994918823,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7887588143348694,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809320449829,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950266838074,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950266838074,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C1|THOROUGH|123": {
-   "i_selected": [
-    5,
-    51,
-    66,
-    71,
-    76,
+    0,
+    45,
+    58,
+    65,
     85,
+    86,
     91,
     95,
     97,
@@ -9430,7 +8707,489 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298109531402588,
+     "diversity": 0.6177579164505005,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380692481995,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380692481995,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380692481995,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380692481995,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380692481995,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380692481995,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380692481995,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407591819763,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407591819763,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407591819763,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407591819763,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407591819763,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407591819763,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6856381893157959,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6856381893157959,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6948826909065247,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7033566236495972,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7461032271385193,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7540906071662903,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7540906071662903,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7540906071662903,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7718172669410706,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7718172669410706,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C1|SMART|123": {
+   "i_selected": [
+    1,
+    32,
+    50,
+    55,
+    76,
+    82,
+    91,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.11111111111111116,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484526634216,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484526634216,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.869873583316803,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953887939453,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C1|THOROUGH|42": {
+   "i_selected": [
+    0,
+    45,
+    51,
+    52,
+    58,
+    85,
+    91,
+    93,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.11111111111111116,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6177579164505005,
      "div_tie_breakers": [
       1.0
      ]
@@ -9439,7 +9198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298109531402588,
+     "diversity": 0.6565380692481995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9448,7 +9207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298109531402588,
+     "diversity": 0.6565380692481995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9457,7 +9216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298109531402588,
+     "diversity": 0.6565380692481995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9466,7 +9225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298109531402588,
+     "diversity": 0.6565380692481995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9475,7 +9234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304893732070923,
+     "diversity": 0.6565380692481995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9484,7 +9243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304893732070923,
+     "diversity": 0.6565380692481995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9493,7 +9252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304893732070923,
+     "diversity": 0.6565380692481995,
      "div_tie_breakers": [
       1.0
      ]
@@ -9502,7 +9261,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304893732070923,
+     "diversity": 0.6684407591819763,
      "div_tie_breakers": [
       1.0
      ]
@@ -9511,7 +9270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570629715919495,
+     "diversity": 0.6684407591819763,
      "div_tie_breakers": [
       1.0
      ]
@@ -9520,7 +9279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570629715919495,
+     "diversity": 0.6684407591819763,
      "div_tie_breakers": [
       1.0
      ]
@@ -9529,7 +9288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570629715919495,
+     "diversity": 0.6684407591819763,
      "div_tie_breakers": [
       1.0
      ]
@@ -9538,7 +9297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7782083749771118,
+     "diversity": 0.6684407591819763,
      "div_tie_breakers": [
       1.0
      ]
@@ -9547,7 +9306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.784830629825592,
+     "diversity": 0.6684407591819763,
      "div_tie_breakers": [
       1.0
      ]
@@ -9556,7 +9315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.784830629825592,
+     "diversity": 0.6856381893157959,
      "div_tie_breakers": [
       1.0
      ]
@@ -9565,7 +9324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.784830629825592,
+     "diversity": 0.6856381893157959,
      "div_tie_breakers": [
       1.0
      ]
@@ -9574,7 +9333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.6948826909065247,
      "div_tie_breakers": [
       1.0
      ]
@@ -9583,7 +9342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.7033566236495972,
      "div_tie_breakers": [
       1.0
      ]
@@ -9592,7 +9351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.7240328788757324,
      "div_tie_breakers": [
       1.0
      ]
@@ -9601,7 +9360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.7240328788757324,
      "div_tie_breakers": [
       1.0
      ]
@@ -9610,7 +9369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.7240328788757324,
      "div_tie_breakers": [
       1.0
      ]
@@ -9619,7 +9378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.7240328788757324,
      "div_tie_breakers": [
       1.0
      ]
@@ -9628,7 +9387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.7240328788757324,
      "div_tie_breakers": [
       1.0
      ]
@@ -9637,7 +9396,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164417266846,
+     "diversity": 0.7240328788757324,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C1|THOROUGH|123": {
+   "i_selected": [
+    1,
+    32,
+    50,
+    55,
+    74,
+    82,
+    91,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.11111111111111116,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484526634216,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484526634216,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8667120933532715,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329451560974,
      "div_tie_breakers": [
       1.0
      ]
@@ -10610,13 +10610,13 @@
   },
   "C2|SMART|42": {
    "i_selected": [
-    24,
-    32,
-    66,
-    79,
-    85,
+    1,
+    38,
+    50,
+    54,
+    67,
+    69,
     86,
-    91,
     95,
     97,
     99
@@ -10634,8 +10634,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7363571524620056,
+     "constraints": 1.0,
+     "diversity": 0.6177579164505005,
      "div_tie_breakers": [
       1.0
      ]
@@ -10644,7 +10644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7113420367240906,
+     "diversity": 0.6492426991462708,
      "div_tie_breakers": [
       1.0
      ]
@@ -10653,7 +10653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6646372675895691,
      "div_tie_breakers": [
       1.0
      ]
@@ -10662,7 +10662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10671,7 +10671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10680,7 +10680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10689,7 +10689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10698,7 +10698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10707,7 +10707,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10716,7 +10716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10725,7 +10725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10734,7 +10734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -10743,7 +10743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10752,7 +10752,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10761,7 +10761,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10770,7 +10770,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10779,7 +10779,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.757997453212738,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10788,7 +10788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10797,7 +10797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10806,7 +10806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10815,7 +10815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10824,7 +10824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -10833,7 +10833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8031050562858582,
+     "diversity": 0.7374700903892517,
      "div_tie_breakers": [
       1.0
      ]
@@ -10842,7 +10842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8065439462661743,
+     "diversity": 0.7374700903892517,
      "div_tie_breakers": [
       1.0
      ]
@@ -10851,16 +10851,16 @@
   },
   "C2|SMART|123": {
    "i_selected": [
-    20,
-    25,
-    65,
-    81,
-    85,
-    86,
+    4,
+    32,
+    55,
+    71,
+    74,
+    82,
     91,
     95,
     97,
-    99
+    98
    ],
    "score_checkpoints": [
     {
@@ -10875,17 +10875,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7298109531402588,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.6353946328163147,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -10894,7 +10885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.618280291557312,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -10903,7 +10894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.618280291557312,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -10912,7 +10903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201636791229248,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -10921,7 +10912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201636791229248,
+     "diversity": 0.7817785143852234,
      "div_tie_breakers": [
       1.0
      ]
@@ -10930,7 +10921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.669047474861145,
+     "diversity": 0.7817785143852234,
      "div_tie_breakers": [
       1.0
      ]
@@ -10939,7 +10930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.672282874584198,
+     "diversity": 0.7817785143852234,
      "div_tie_breakers": [
       1.0
      ]
@@ -10948,7 +10939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7110719084739685,
+     "diversity": 0.7817785143852234,
      "div_tie_breakers": [
       1.0
      ]
@@ -10957,7 +10948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570779323577881,
+     "diversity": 0.7893818616867065,
      "div_tie_breakers": [
       1.0
      ]
@@ -10966,7 +10957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570779323577881,
+     "diversity": 0.7893818616867065,
      "div_tie_breakers": [
       1.0
      ]
@@ -10975,7 +10966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570779323577881,
+     "diversity": 0.7893818616867065,
      "div_tie_breakers": [
       1.0
      ]
@@ -10984,7 +10975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.7893818616867065,
      "div_tie_breakers": [
       1.0
      ]
@@ -10993,7 +10984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8003093004226685,
      "div_tie_breakers": [
       1.0
      ]
@@ -11002,7 +10993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8003093004226685,
      "div_tie_breakers": [
       1.0
      ]
@@ -11011,7 +11002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8003093004226685,
      "div_tie_breakers": [
       1.0
      ]
@@ -11020,7 +11011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8003093004226685,
      "div_tie_breakers": [
       1.0
      ]
@@ -11029,7 +11020,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8370375037193298,
      "div_tie_breakers": [
       1.0
      ]
@@ -11038,7 +11029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8370375037193298,
      "div_tie_breakers": [
       1.0
      ]
@@ -11047,7 +11038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8370375037193298,
      "div_tie_breakers": [
       1.0
      ]
@@ -11056,7 +11047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8505820631980896,
      "div_tie_breakers": [
       1.0
      ]
@@ -11065,7 +11056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8505820631980896,
      "div_tie_breakers": [
       1.0
      ]
@@ -11074,7 +11065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8505820631980896,
      "div_tie_breakers": [
       1.0
      ]
@@ -11083,7 +11074,16 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988981604576111,
+     "diversity": 0.8505820631980896,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8505820631980896,
      "div_tie_breakers": [
       1.0
      ]
@@ -11092,15 +11092,15 @@
   },
   "C2|THOROUGH|42": {
    "i_selected": [
-    24,
-    32,
-    66,
+    1,
+    42,
+    54,
+    58,
+    69,
     79,
-    85,
     86,
-    91,
+    92,
     95,
-    97,
     99
    ],
    "score_checkpoints": [
@@ -11116,8 +11116,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7363571524620056,
+     "constraints": 1.0,
+     "diversity": 0.6177579164505005,
      "div_tie_breakers": [
       1.0
      ]
@@ -11126,7 +11126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7113420367240906,
+     "diversity": 0.6492426991462708,
      "div_tie_breakers": [
       1.0
      ]
@@ -11135,7 +11135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6646372675895691,
      "div_tie_breakers": [
       1.0
      ]
@@ -11144,7 +11144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11153,7 +11153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11162,7 +11162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11171,7 +11171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11180,7 +11180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11189,7 +11189,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11198,7 +11198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11207,7 +11207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288918495178223,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11216,7 +11216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6705297231674194,
      "div_tie_breakers": [
       1.0
      ]
@@ -11225,7 +11225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -11234,7 +11234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -11243,7 +11243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -11252,7 +11252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197931289673,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -11261,7 +11261,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.757997453212738,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -11270,7 +11270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -11279,7 +11279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.6812641024589539,
      "div_tie_breakers": [
       1.0
      ]
@@ -11288,7 +11288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.7310718894004822,
      "div_tie_breakers": [
       1.0
      ]
@@ -11297,7 +11297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.7310718894004822,
      "div_tie_breakers": [
       1.0
      ]
@@ -11306,7 +11306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.785374641418457,
+     "diversity": 0.7310718894004822,
      "div_tie_breakers": [
       1.0
      ]
@@ -11315,7 +11315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8031050562858582,
+     "diversity": 0.7425635457038879,
      "div_tie_breakers": [
       1.0
      ]
@@ -11324,7 +11324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8065439462661743,
+     "diversity": 0.7425635457038879,
      "div_tie_breakers": [
       1.0
      ]
@@ -11333,14 +11333,14 @@
   },
   "C2|THOROUGH|123": {
    "i_selected": [
-    25,
-    29,
-    65,
-    69,
-    81,
+    2,
+    32,
+    40,
+    71,
+    74,
     82,
-    86,
-    95,
+    91,
+    94,
     97,
     99
    ],
@@ -11357,17 +11357,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7298109531402588,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.6353946328163147,
+     "constraints": 1.0,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -11376,7 +11367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.618280291557312,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -11385,7 +11376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.618280291557312,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -11394,7 +11385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201636791229248,
+     "diversity": 0.7608301639556885,
      "div_tie_breakers": [
       1.0
      ]
@@ -11403,7 +11394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201636791229248,
+     "diversity": 0.7817785143852234,
      "div_tie_breakers": [
       1.0
      ]
@@ -11412,7 +11403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.669047474861145,
+     "diversity": 0.7817785143852234,
      "div_tie_breakers": [
       1.0
      ]
@@ -11421,7 +11412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6807375550270081,
+     "diversity": 0.7817785143852234,
      "div_tie_breakers": [
       1.0
      ]
@@ -11430,7 +11421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7190234661102295,
+     "diversity": 0.8344119191169739,
      "div_tie_breakers": [
       1.0
      ]
@@ -11439,7 +11430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701591491699,
+     "diversity": 0.8344119191169739,
      "div_tie_breakers": [
       1.0
      ]
@@ -11448,7 +11439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701591491699,
+     "diversity": 0.8344119191169739,
      "div_tie_breakers": [
       1.0
      ]
@@ -11457,7 +11448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701591491699,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11466,7 +11457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701591491699,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11475,7 +11466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664481163025,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11484,7 +11475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664481163025,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11493,7 +11484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664481163025,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11502,7 +11493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664481163025,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11511,7 +11502,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.806788980960846,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11520,7 +11511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.806788980960846,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11529,7 +11520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.806788980960846,
+     "diversity": 0.8500238060951233,
      "div_tie_breakers": [
       1.0
      ]
@@ -11538,7 +11529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.806788980960846,
+     "diversity": 0.8525834679603577,
      "div_tie_breakers": [
       1.0
      ]
@@ -11547,7 +11538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.806788980960846,
+     "diversity": 0.8525834679603577,
      "div_tie_breakers": [
       1.0
      ]
@@ -11556,7 +11547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.806788980960846,
+     "diversity": 0.8525834679603577,
      "div_tie_breakers": [
       1.0
      ]
@@ -11565,7 +11556,16 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.806788980960846,
+     "diversity": 0.8525834679603577,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8525834679603577,
      "div_tie_breakers": [
       1.0
      ]
@@ -12539,14 +12539,14 @@
   "C3|SMART|42": {
    "i_selected": [
     16,
-    44,
-    86,
-    98,
+    36,
+    75,
+    79,
+    109,
     124,
-    127,
-    137,
+    130,
+    143,
     145,
-    147,
     149
    ],
    "score_checkpoints": [
@@ -12563,7 +12563,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.51189786195755,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -12572,7 +12572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.51189786195755,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -12581,7 +12581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5135583877563477,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -12590,7 +12590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12599,7 +12599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12608,7 +12608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12617,7 +12617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12626,7 +12626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12635,7 +12635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12644,7 +12644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12653,7 +12653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12662,7 +12662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12671,7 +12671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12680,7 +12680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12689,7 +12689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12698,7 +12698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12707,7 +12707,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5210878849029541,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12716,7 +12716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12725,7 +12725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12734,7 +12734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12743,7 +12743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12752,7 +12752,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12761,7 +12761,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.530687153339386,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12770,7 +12770,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.530687153339386,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -12779,13 +12779,13 @@
   },
   "C3|SMART|123": {
    "i_selected": [
-    26,
-    42,
-    102,
+    13,
+    50,
+    73,
     103,
-    127,
+    115,
     131,
-    139,
+    138,
     145,
     147,
     149
@@ -12804,7 +12804,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12813,7 +12813,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12822,7 +12822,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12831,7 +12831,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12840,7 +12840,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12849,7 +12849,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12858,7 +12858,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12867,7 +12867,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12876,7 +12876,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12885,7 +12885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12894,7 +12894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12903,7 +12903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12912,7 +12912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12921,7 +12921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12930,7 +12930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12939,7 +12939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12948,7 +12948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12957,7 +12957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12966,7 +12966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12975,7 +12975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -12984,7 +12984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220048904419,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -12993,7 +12993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220048904419,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -13002,7 +13002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220048904419,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -13011,7 +13011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220048904419,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -13020,15 +13020,15 @@
   },
   "C3|THOROUGH|42": {
    "i_selected": [
-    16,
-    44,
-    86,
-    102,
+    26,
+    36,
+    75,
+    80,
+    109,
     124,
     130,
-    137,
+    143,
     145,
-    147,
     149
    ],
    "score_checkpoints": [
@@ -13045,7 +13045,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.51189786195755,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -13054,7 +13054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.51189786195755,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -13063,7 +13063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5135583877563477,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -13072,7 +13072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13081,7 +13081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13090,7 +13090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13099,7 +13099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13108,7 +13108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13117,7 +13117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13126,7 +13126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13135,7 +13135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13144,7 +13144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13153,7 +13153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13162,7 +13162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13171,7 +13171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13180,7 +13180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206162929534912,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13189,7 +13189,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5210878849029541,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13198,7 +13198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13207,7 +13207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13216,7 +13216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13225,7 +13225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13234,7 +13234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596969604492,
+     "diversity": 0.5194352865219116,
      "div_tie_breakers": [
       1.0
      ]
@@ -13243,7 +13243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.52920001745224,
+     "diversity": 0.521564781665802,
      "div_tie_breakers": [
       1.0
      ]
@@ -13252,7 +13252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.52920001745224,
+     "diversity": 0.521564781665802,
      "div_tie_breakers": [
       1.0
      ]
@@ -13261,13 +13261,13 @@
   },
   "C3|THOROUGH|123": {
    "i_selected": [
-    26,
-    54,
-    102,
+    13,
+    50,
+    73,
     103,
-    127,
+    115,
     131,
-    139,
+    138,
     145,
     147,
     149
@@ -13286,7 +13286,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13295,7 +13295,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13304,7 +13304,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13313,7 +13313,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13322,7 +13322,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13331,7 +13331,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13340,7 +13340,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13349,7 +13349,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13358,7 +13358,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13367,7 +13367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13376,7 +13376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13385,7 +13385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13394,7 +13394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13403,7 +13403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13412,7 +13412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486265659332,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13421,7 +13421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13430,7 +13430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13439,7 +13439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13448,7 +13448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13457,7 +13457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
@@ -13466,7 +13466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -13475,7 +13475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -13484,7 +13484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -13493,7 +13493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175274848938,
+     "diversity": 0.5300056338310242,
      "div_tie_breakers": [
       1.0
      ]
@@ -14466,16 +14466,16 @@
   },
   "C4|SMART|42": {
    "i_selected": [
-    4,
-    27,
-    28,
-    54,
-    58,
-    100,
+    20,
+    21,
+    43,
+    57,
+    75,
+    80,
     103,
-    132,
-    145,
-    149
+    124,
+    130,
+    143
    ],
    "score_checkpoints": [
     {
@@ -14490,26 +14490,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.51189786195755,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
      "constraints": 0.875,
-     "diversity": 0.4092804491519928,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.875,
-     "diversity": 0.4927343428134918,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -14518,7 +14500,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.45410990715026855,
+     "diversity": 0.3637445867061615,
      "div_tie_breakers": [
       1.0
      ]
@@ -14527,7 +14509,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.28410547971725464,
+     "diversity": 0.31983986496925354,
      "div_tie_breakers": [
       1.0
      ]
@@ -14536,7 +14518,25 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.28027448058128357,
+     "diversity": 0.2658715844154358,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.3372017443180084,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.374294251203537,
      "div_tie_breakers": [
       1.0
      ]
@@ -14545,7 +14545,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290870010852814,
+     "diversity": 0.16571849584579468,
      "div_tie_breakers": [
       1.0
      ]
@@ -14554,7 +14554,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290870010852814,
+     "diversity": 0.16643404960632324,
      "div_tie_breakers": [
       1.0
      ]
@@ -14563,7 +14563,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771110594272614,
+     "diversity": 0.16643404960632324,
      "div_tie_breakers": [
       1.0
      ]
@@ -14572,7 +14572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771110594272614,
+     "diversity": 0.18159228563308716,
      "div_tie_breakers": [
       1.0
      ]
@@ -14581,7 +14581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.2067382037639618,
      "div_tie_breakers": [
       1.0
      ]
@@ -14590,7 +14590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.25469017028808594,
      "div_tie_breakers": [
       1.0
      ]
@@ -14599,7 +14599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -14608,7 +14608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -14617,7 +14617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3234667479991913,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -14626,7 +14626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3234667479991913,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -14635,7 +14635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3402751684188843,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -14644,7 +14644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3619333803653717,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -14653,7 +14653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.36519527435302734,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -14662,7 +14662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40812453627586365,
+     "diversity": 0.30401331186294556,
      "div_tie_breakers": [
       1.0
      ]
@@ -14671,7 +14671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40812453627586365,
+     "diversity": 0.30401331186294556,
      "div_tie_breakers": [
       1.0
      ]
@@ -14680,7 +14680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40812453627586365,
+     "diversity": 0.30401331186294556,
      "div_tie_breakers": [
       1.0
      ]
@@ -14689,7 +14689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4196354150772095,
+     "diversity": 0.3126353323459625,
      "div_tie_breakers": [
       1.0
      ]
@@ -14698,7 +14698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4196354150772095,
+     "diversity": 0.3186250627040863,
      "div_tie_breakers": [
       1.0
      ]
@@ -14707,255 +14707,14 @@
   },
   "C4|SMART|123": {
    "i_selected": [
+    12,
     17,
-    19,
-    48,
-    53,
-    77,
-    102,
+    35,
+    44,
+    64,
+    76,
     103,
-    133,
-    145,
-    147
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.0625,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.4976486265659332,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.5008677840232849,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.9375,
-     "diversity": 0.4048536717891693,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.35185307264328003,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3708398938179016,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3804384171962738,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3804384171962738,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3804384171962738,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41467854380607605,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41467854380607605,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41467854380607605,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41467854380607605,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41467854380607605,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677404403687,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C4|THOROUGH|42": {
-   "i_selected": [
-    4,
-    19,
-    27,
-    50,
-    56,
-    100,
-    103,
-    132,
+    138,
     145,
     149
    ],
@@ -14972,233 +14731,233 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.51189786195755,
+     "constraints": 0.875,
+     "diversity": 0.48836734890937805,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 0.4092804491519928,
+     "diversity": 0.37607985734939575,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 0.4927343428134918,
+     "diversity": 0.45160749554634094,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.45410990715026855,
+     "diversity": 0.3736459016799927,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.9375,
-     "diversity": 0.28410547971725464,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.9375,
-     "diversity": 0.28027448058128357,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290870010852814,
+     "diversity": 0.33355847001075745,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290870010852814,
+     "diversity": 0.3623562455177307,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771110594272614,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771110594272614,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943537712097,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3234667479991913,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3234667479991913,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3402751684188843,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3619333803653717,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907859802246094,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907859802246094,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907859802246094,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907859802246094,
+     "diversity": 0.4194351136684418,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4127112627029419,
+     "diversity": 0.4194351136684418,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4127112627029419,
+     "diversity": 0.4194351136684418,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4194351136684418,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4194351136684418,
      "div_tie_breakers": [
       1.0
      ]
     }
    ]
   },
-  "C4|THOROUGH|123": {
+  "C4|THOROUGH|42": {
    "i_selected": [
-    17,
-    26,
-    48,
-    53,
-    77,
-    102,
-    103,
-    133,
-    145,
-    147
+    20,
+    21,
+    43,
+    57,
+    75,
+    80,
+    101,
+    124,
+    130,
+    143
    ],
    "score_checkpoints": [
     {
@@ -15213,17 +14972,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.4976486265659332,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.5008677840232849,
+     "constraints": 0.875,
+     "diversity": 0.4900108277797699,
      "div_tie_breakers": [
       1.0
      ]
@@ -15232,7 +14982,43 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.4048536717891693,
+     "diversity": 0.3637445867061615,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.31983986496925354,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.2658715844154358,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.3372017443180084,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.374294251203537,
      "div_tie_breakers": [
       1.0
      ]
@@ -15241,7 +15027,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.35185307264328003,
+     "diversity": 0.16571849584579468,
      "div_tie_breakers": [
       1.0
      ]
@@ -15250,7 +15036,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3708398938179016,
+     "diversity": 0.16643404960632324,
      "div_tie_breakers": [
       1.0
      ]
@@ -15259,7 +15045,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3804384171962738,
+     "diversity": 0.16643404960632324,
      "div_tie_breakers": [
       1.0
      ]
@@ -15268,7 +15054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3804384171962738,
+     "diversity": 0.18159228563308716,
      "div_tie_breakers": [
       1.0
      ]
@@ -15277,7 +15063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3804384171962738,
+     "diversity": 0.2067382037639618,
      "div_tie_breakers": [
       1.0
      ]
@@ -15286,7 +15072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.25469017028808594,
      "div_tie_breakers": [
       1.0
      ]
@@ -15295,7 +15081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15304,7 +15090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15313,7 +15099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15322,7 +15108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15331,7 +15117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15340,7 +15126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15349,7 +15135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15358,7 +15144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15367,7 +15153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15376,7 +15162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.29301267862319946,
      "div_tie_breakers": [
       1.0
      ]
@@ -15385,7 +15171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.31657934188842773,
      "div_tie_breakers": [
       1.0
      ]
@@ -15394,7 +15180,68 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.31657934188842773,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C4|THOROUGH|123": {
+   "i_selected": [
+    12,
+    17,
+    35,
+    43,
+    64,
+    76,
+    103,
+    138,
+    145,
+    149
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.0625,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.48836734890937805,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.37607985734939575,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.45160749554634094,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.3736459016799927,
      "div_tie_breakers": [
       1.0
      ]
@@ -15403,7 +15250,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.33355847001075745,
      "div_tie_breakers": [
       1.0
      ]
@@ -15412,7 +15259,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.3623562455177307,
      "div_tie_breakers": [
       1.0
      ]
@@ -15421,7 +15268,160 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41467854380607605,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924941539764404,
      "div_tie_breakers": [
       1.0
      ]

--- a/tests/_core/solver/golden_master_data_nojit.json
+++ b/tests/_core/solver/golden_master_data_nojit.json
@@ -971,15 +971,15 @@
   "U1|SMART|42": {
    "i_selected": [
     0,
-    19,
-    36,
-    47,
-    56,
-    66,
+    13,
+    25,
+    33,
+    45,
+    51,
+    61,
     70,
-    82,
-    89,
-    99
+    84,
+    94
    ],
    "score_checkpoints": [
     {
@@ -995,7 +995,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.08969675454514824,
      "div_tie_breakers": [
       1.0
      ]
@@ -1004,7 +1004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.08969675454514824,
      "div_tie_breakers": [
       1.0
      ]
@@ -1013,7 +1013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09388003315822316,
      "div_tie_breakers": [
       1.0
      ]
@@ -1022,7 +1022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1031,7 +1031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1040,7 +1040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1049,7 +1049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1058,7 +1058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1067,7 +1067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1076,7 +1076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1085,7 +1085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1094,7 +1094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1103,7 +1103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1112,7 +1112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1121,7 +1121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1130,7 +1130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855821829945,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1139,7 +1139,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855821829945,
+     "diversity": 0.10169428489995033,
      "div_tie_breakers": [
       1.0
      ]
@@ -1148,7 +1148,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.10169428489995033,
      "div_tie_breakers": [
       1.0
      ]
@@ -1157,7 +1157,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.10169428489995033,
      "div_tie_breakers": [
       1.0
      ]
@@ -1166,7 +1166,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.10169428489995033,
      "div_tie_breakers": [
       1.0
      ]
@@ -1175,7 +1175,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1184,7 +1184,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1193,7 +1193,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1202,7 +1202,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1211,16 +1211,16 @@
   },
   "U1|SMART|123": {
    "i_selected": [
-    3,
-    13,
-    25,
-    32,
-    45,
-    53,
-    67,
-    76,
-    88,
-    99
+    0,
+    18,
+    29,
+    41,
+    49,
+    56,
+    60,
+    72,
+    84,
+    95
    ],
    "score_checkpoints": [
     {
@@ -1236,7 +1236,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1245,7 +1245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1254,7 +1254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1263,7 +1263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1272,7 +1272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09335370342301424,
      "div_tie_breakers": [
       1.0
      ]
@@ -1281,7 +1281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09335370342301424,
      "div_tie_breakers": [
       1.0
      ]
@@ -1290,7 +1290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1299,7 +1299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1308,7 +1308,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1317,7 +1317,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1326,7 +1326,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1335,7 +1335,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1344,7 +1344,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1353,7 +1353,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1362,7 +1362,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1371,7 +1371,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1380,7 +1380,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1389,7 +1389,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1398,7 +1398,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1407,7 +1407,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1416,7 +1416,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1425,7 +1425,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1434,7 +1434,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1443,7 +1443,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1453,15 +1453,15 @@
   "U1|THOROUGH|42": {
    "i_selected": [
     0,
-    19,
-    36,
-    47,
-    56,
-    66,
+    13,
+    25,
+    32,
+    45,
+    51,
+    61,
     70,
-    82,
-    89,
-    99
+    84,
+    94
    ],
    "score_checkpoints": [
     {
@@ -1477,7 +1477,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.08969675454514824,
      "div_tie_breakers": [
       1.0
      ]
@@ -1486,7 +1486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.08969675454514824,
      "div_tie_breakers": [
       1.0
      ]
@@ -1495,7 +1495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09388003315822316,
      "div_tie_breakers": [
       1.0
      ]
@@ -1504,7 +1504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1513,7 +1513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1522,7 +1522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1531,7 +1531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1540,7 +1540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09624193059351863,
      "div_tie_breakers": [
       1.0
      ]
@@ -1549,7 +1549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1558,7 +1558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1567,7 +1567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1576,7 +1576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1585,7 +1585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1594,7 +1594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1603,7 +1603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10229167996888999,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1612,7 +1612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855821829945,
+     "diversity": 0.09754430789825541,
      "div_tie_breakers": [
       1.0
      ]
@@ -1621,7 +1621,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10346855821829945,
+     "diversity": 0.10169428489995033,
      "div_tie_breakers": [
       1.0
      ]
@@ -1630,7 +1630,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.10169428489995033,
      "div_tie_breakers": [
       1.0
      ]
@@ -1639,7 +1639,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.10169428489995033,
      "div_tie_breakers": [
       1.0
      ]
@@ -1648,7 +1648,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1657,7 +1657,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1666,7 +1666,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1675,7 +1675,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1684,7 +1684,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10383649864953591,
+     "diversity": 0.1028158840951564,
      "div_tie_breakers": [
       1.0
      ]
@@ -1693,16 +1693,16 @@
   },
   "U1|THOROUGH|123": {
    "i_selected": [
-    3,
-    13,
-    25,
-    32,
-    45,
-    53,
-    67,
-    76,
-    88,
-    99
+    0,
+    18,
+    29,
+    41,
+    49,
+    56,
+    60,
+    72,
+    84,
+    95
    ],
    "score_checkpoints": [
     {
@@ -1718,7 +1718,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1727,7 +1727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1736,7 +1736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1745,7 +1745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09278477786615522,
      "div_tie_breakers": [
       1.0
      ]
@@ -1754,7 +1754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09335370342301424,
      "div_tie_breakers": [
       1.0
      ]
@@ -1763,7 +1763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09335370342301424,
      "div_tie_breakers": [
       1.0
      ]
@@ -1772,7 +1772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1781,7 +1781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1790,7 +1790,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1799,7 +1799,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1808,7 +1808,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1817,7 +1817,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1826,7 +1826,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09698891137525609,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1835,7 +1835,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1844,7 +1844,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1853,7 +1853,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1862,7 +1862,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1871,7 +1871,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.09768630992542932,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1880,7 +1880,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1889,7 +1889,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1898,7 +1898,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1907,7 +1907,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1916,7 +1916,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -1925,7 +1925,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10120120636665464,
+     "diversity": 0.09571453729466345,
      "div_tie_breakers": [
       1.0
      ]
@@ -2898,15 +2898,15 @@
   },
   "U2|SMART|42": {
    "i_selected": [
-    11,
-    29,
-    56,
+    0,
+    22,
+    46,
+    51,
     66,
-    75,
-    81,
-    86,
-    93,
-    95,
+    70,
+    80,
+    92,
+    94,
     99
    ],
    "score_checkpoints": [
@@ -2923,7 +2923,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.375907267691587,
      "div_tie_breakers": [
       1.0
      ]
@@ -2932,7 +2932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.375907267691587,
      "div_tie_breakers": [
       1.0
      ]
@@ -2941,7 +2941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.375907267691587,
      "div_tie_breakers": [
       1.0
      ]
@@ -2950,7 +2950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -2959,7 +2959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -2968,7 +2968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -2977,7 +2977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -2986,7 +2986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -2995,7 +2995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3004,7 +3004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3013,7 +3013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3022,7 +3022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3031,7 +3031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3040,7 +3040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3049,7 +3049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3058,7 +3058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3067,7 +3067,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3076,7 +3076,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3085,7 +3085,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3094,7 +3094,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.41234201770747636,
      "div_tie_breakers": [
       1.0
      ]
@@ -3103,7 +3103,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.41234201770747636,
      "div_tie_breakers": [
       1.0
      ]
@@ -3112,7 +3112,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.41234201770747636,
      "div_tie_breakers": [
       1.0
      ]
@@ -3121,7 +3121,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.41234201770747636,
      "div_tie_breakers": [
       1.0
      ]
@@ -3130,7 +3130,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.41234201770747636,
      "div_tie_breakers": [
       1.0
      ]
@@ -3140,14 +3140,14 @@
   "U2|SMART|123": {
    "i_selected": [
     3,
-    46,
-    51,
+    37,
+    49,
+    62,
     70,
-    73,
+    80,
     82,
-    85,
+    94,
     95,
-    98,
     99
    ],
    "score_checkpoints": [
@@ -3164,7 +3164,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3173,7 +3173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3182,7 +3182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3191,7 +3191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3200,7 +3200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3209,7 +3209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3218,7 +3218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3227,7 +3227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44789320385101994,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3236,7 +3236,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44789320385101994,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3245,7 +3245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44789320385101994,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3254,7 +3254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45570183587067703,
+     "diversity": 0.46251530261164464,
      "div_tie_breakers": [
       1.0
      ]
@@ -3263,7 +3263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45570183587067703,
+     "diversity": 0.46251530261164464,
      "div_tie_breakers": [
       1.0
      ]
@@ -3272,7 +3272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.45570183587067703,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3281,7 +3281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201855639255,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3290,7 +3290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201855639255,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3299,7 +3299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201855639255,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3308,7 +3308,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201855639255,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3317,7 +3317,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201855639255,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3326,7 +3326,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201855639255,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3335,7 +3335,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46194201855639255,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3344,7 +3344,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.463462157559891,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3353,7 +3353,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.463462157559891,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3362,7 +3362,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.463462157559891,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3371,7 +3371,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.463462157559891,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3380,15 +3380,15 @@
   },
   "U2|THOROUGH|42": {
    "i_selected": [
-    11,
-    29,
-    56,
+    0,
+    22,
+    33,
+    51,
     66,
-    75,
-    81,
-    86,
-    93,
-    95,
+    70,
+    80,
+    92,
+    94,
     99
    ],
    "score_checkpoints": [
@@ -3405,7 +3405,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.375907267691587,
      "div_tie_breakers": [
       1.0
      ]
@@ -3414,7 +3414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.375907267691587,
      "div_tie_breakers": [
       1.0
      ]
@@ -3423,7 +3423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.375907267691587,
      "div_tie_breakers": [
       1.0
      ]
@@ -3432,7 +3432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3441,7 +3441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4175617748828994,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3450,7 +3450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3459,7 +3459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3468,7 +3468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3477,7 +3477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3486,7 +3486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3495,7 +3495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3504,7 +3504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3513,7 +3513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3522,7 +3522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3531,7 +3531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3540,7 +3540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4088257109274196,
      "div_tie_breakers": [
       1.0
      ]
@@ -3549,7 +3549,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3558,7 +3558,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43085704024781896,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3567,7 +3567,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3576,7 +3576,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3585,7 +3585,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3594,7 +3594,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3603,7 +3603,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3612,7 +3612,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4582439495539895,
+     "diversity": 0.4119873345571599,
      "div_tie_breakers": [
       1.0
      ]
@@ -3622,14 +3622,14 @@
   "U2|THOROUGH|123": {
    "i_selected": [
     3,
-    41,
-    46,
-    67,
-    69,
+    37,
+    49,
+    62,
+    70,
+    80,
     82,
-    83,
+    94,
     95,
-    96,
     99
    ],
    "score_checkpoints": [
@@ -3646,7 +3646,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3655,7 +3655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3664,7 +3664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3673,7 +3673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3682,7 +3682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3691,7 +3691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3700,7 +3700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.43518682078110227,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3709,7 +3709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44789320385101994,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3718,7 +3718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44789320385101994,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3727,7 +3727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.44789320385101994,
+     "diversity": 0.45047875045908764,
      "div_tie_breakers": [
       1.0
      ]
@@ -3736,7 +3736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.46251530261164464,
      "div_tie_breakers": [
       1.0
      ]
@@ -3745,7 +3745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.46251530261164464,
      "div_tie_breakers": [
       1.0
      ]
@@ -3754,7 +3754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3763,7 +3763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3772,7 +3772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3781,7 +3781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3790,7 +3790,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.466649038269555,
      "div_tie_breakers": [
       1.0
      ]
@@ -3799,7 +3799,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3808,7 +3808,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3817,7 +3817,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.46914555500451416,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3826,7 +3826,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4751178979914219,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3835,7 +3835,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4751178979914219,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3844,7 +3844,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4751178979914219,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -3853,7 +3853,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4751178979914219,
+     "diversity": 0.4680502245436881,
      "div_tie_breakers": [
       1.0
      ]
@@ -4827,12 +4827,12 @@
   "U3|SMART|42": {
    "i_selected": [
     0,
+    51,
     66,
     72,
     80,
-    85,
-    88,
-    91,
+    86,
+    89,
     93,
     96,
     99
@@ -4851,7 +4851,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.7713391301053636,
      "div_tie_breakers": [
       1.0
      ]
@@ -4860,7 +4860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.7713391301053636,
      "div_tie_breakers": [
       1.0
      ]
@@ -4869,7 +4869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.7713391301053636,
      "div_tie_breakers": [
       1.0
      ]
@@ -4878,7 +4878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8676490233721347,
      "div_tie_breakers": [
       1.0
      ]
@@ -4887,7 +4887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8676490233721347,
      "div_tie_breakers": [
       1.0
      ]
@@ -4896,7 +4896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -4905,7 +4905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -4914,7 +4914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -4923,7 +4923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -4932,7 +4932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -4941,7 +4941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -4950,7 +4950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -4959,7 +4959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -4968,7 +4968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -4977,7 +4977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -4986,7 +4986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -4995,7 +4995,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9125753110887411,
      "div_tie_breakers": [
       1.0
      ]
@@ -5004,7 +5004,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5013,7 +5013,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5022,7 +5022,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5031,7 +5031,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5040,7 +5040,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5049,7 +5049,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9249761544176485,
      "div_tie_breakers": [
       1.0
      ]
@@ -5058,7 +5058,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9249761544176485,
      "div_tie_breakers": [
       1.0
      ]
@@ -5067,15 +5067,15 @@
   },
   "U3|SMART|123": {
    "i_selected": [
-    3,
-    57,
-    69,
-    77,
-    86,
-    89,
-    92,
+    0,
+    52,
+    66,
+    70,
+    80,
+    85,
+    88,
+    91,
     94,
-    97,
     99
    ],
    "score_checkpoints": [
@@ -5092,7 +5092,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.870890342338724,
      "div_tie_breakers": [
       1.0
      ]
@@ -5101,7 +5101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.870890342338724,
      "div_tie_breakers": [
       1.0
      ]
@@ -5110,7 +5110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5119,7 +5119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5128,7 +5128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5137,7 +5137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5146,7 +5146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9533537711967724,
      "div_tie_breakers": [
       1.0
      ]
@@ -5155,7 +5155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9555669931233807,
      "div_tie_breakers": [
       1.0
      ]
@@ -5164,7 +5164,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5173,7 +5173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5182,7 +5182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5191,7 +5191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5200,7 +5200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5209,7 +5209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5218,7 +5218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5227,7 +5227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5236,7 +5236,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5245,7 +5245,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5254,7 +5254,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5263,7 +5263,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5272,7 +5272,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5281,7 +5281,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5290,7 +5290,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5299,7 +5299,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5309,12 +5309,12 @@
   "U3|THOROUGH|42": {
    "i_selected": [
     0,
+    51,
     66,
     72,
     80,
     85,
-    88,
-    91,
+    89,
     93,
     96,
     99
@@ -5333,7 +5333,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.7713391301053636,
      "div_tie_breakers": [
       1.0
      ]
@@ -5342,7 +5342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.7713391301053636,
      "div_tie_breakers": [
       1.0
      ]
@@ -5351,7 +5351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.7713391301053636,
      "div_tie_breakers": [
       1.0
      ]
@@ -5360,7 +5360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8676490233721347,
      "div_tie_breakers": [
       1.0
      ]
@@ -5369,7 +5369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8676490233721347,
      "div_tie_breakers": [
       1.0
      ]
@@ -5378,7 +5378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -5387,7 +5387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -5396,7 +5396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -5405,7 +5405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -5414,7 +5414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -5423,7 +5423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -5432,7 +5432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8903851293669001,
      "div_tie_breakers": [
       1.0
      ]
@@ -5441,7 +5441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -5450,7 +5450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -5459,7 +5459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -5468,7 +5468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.8944362048709775,
      "div_tie_breakers": [
       1.0
      ]
@@ -5477,7 +5477,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9125753110887411,
      "div_tie_breakers": [
       1.0
      ]
@@ -5486,7 +5486,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5495,7 +5495,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5504,7 +5504,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5513,7 +5513,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5522,7 +5522,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5531,7 +5531,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5540,7 +5540,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9586768721869489,
+     "diversity": 0.9238317778488672,
      "div_tie_breakers": [
       1.0
      ]
@@ -5549,15 +5549,15 @@
   },
   "U3|THOROUGH|123": {
    "i_selected": [
-    3,
-    57,
-    69,
-    77,
-    86,
-    89,
-    92,
+    0,
+    52,
+    66,
+    70,
+    80,
+    85,
+    88,
+    91,
     94,
-    97,
     99
    ],
    "score_checkpoints": [
@@ -5574,7 +5574,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.870890342338724,
      "div_tie_breakers": [
       1.0
      ]
@@ -5583,7 +5583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.870890342338724,
      "div_tie_breakers": [
       1.0
      ]
@@ -5592,7 +5592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5601,7 +5601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5610,7 +5610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5619,7 +5619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9289576073387819,
      "div_tie_breakers": [
       1.0
      ]
@@ -5628,7 +5628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9533537711967724,
      "div_tie_breakers": [
       1.0
      ]
@@ -5637,7 +5637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9555669931233807,
      "div_tie_breakers": [
       1.0
      ]
@@ -5646,7 +5646,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5655,7 +5655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5664,7 +5664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5673,7 +5673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5682,7 +5682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9704312428872592,
      "div_tie_breakers": [
       1.0
      ]
@@ -5691,7 +5691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5700,7 +5700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5709,7 +5709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5718,7 +5718,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5727,7 +5727,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5736,7 +5736,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5745,7 +5745,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9592085315386292,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5754,7 +5754,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5763,7 +5763,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5772,7 +5772,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -5781,7 +5781,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.9616219704075679,
+     "diversity": 0.9726224713595232,
      "div_tie_breakers": [
       1.0
      ]
@@ -6754,16 +6754,16 @@
   },
   "U4|SMART|42": {
    "i_selected": [
-    0,
-    20,
-    41,
-    49,
-    59,
-    66,
-    76,
-    86,
-    91,
-    99
+    1,
+    16,
+    23,
+    33,
+    47,
+    54,
+    60,
+    67,
+    82,
+    97
    ],
    "score_checkpoints": [
     {
@@ -6779,7 +6779,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1011336180134603,
+     "diversity": 0.09624193300508338,
      "div_tie_breakers": [
       1.0
      ]
@@ -6788,7 +6788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.09624193300508338,
      "div_tie_breakers": [
       1.0
      ]
@@ -6797,7 +6797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10140422012948327,
      "div_tie_breakers": [
       1.0
      ]
@@ -6806,7 +6806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -6815,7 +6815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -6824,7 +6824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -6833,7 +6833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -6842,7 +6842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -6851,7 +6851,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -6860,7 +6860,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -6869,7 +6869,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6878,7 +6878,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6887,7 +6887,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6896,7 +6896,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6905,7 +6905,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6914,7 +6914,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1039593845716412,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6923,7 +6923,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1039593845716412,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6932,7 +6932,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6941,7 +6941,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6950,7 +6950,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6959,7 +6959,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6968,7 +6968,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6977,7 +6977,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678782570174046,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6986,7 +6986,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678782570174046,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -6996,15 +6996,15 @@
   "U4|SMART|123": {
    "i_selected": [
     0,
-    19,
-    30,
-    48,
-    57,
-    68,
-    80,
-    87,
-    93,
-    99
+    12,
+    20,
+    25,
+    44,
+    53,
+    60,
+    69,
+    83,
+    94
    ],
    "score_checkpoints": [
     {
@@ -7020,7 +7020,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7029,7 +7029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7038,7 +7038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7047,7 +7047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7056,7 +7056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7065,7 +7065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7074,7 +7074,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208466565651,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7083,7 +7083,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208466565651,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7092,7 +7092,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208466565651,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7101,7 +7101,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7110,7 +7110,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7119,7 +7119,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7128,7 +7128,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7137,7 +7137,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7146,7 +7146,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7155,7 +7155,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7164,7 +7164,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7173,7 +7173,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1096188295259058,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7182,7 +7182,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1096188295259058,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7191,7 +7191,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1096188295259058,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7200,7 +7200,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1096188295259058,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7209,7 +7209,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1096188295259058,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7218,7 +7218,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1096188295259058,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7227,7 +7227,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1096188295259058,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7236,16 +7236,16 @@
   },
   "U4|THOROUGH|42": {
    "i_selected": [
-    0,
-    20,
-    41,
-    49,
-    59,
-    66,
-    76,
-    86,
-    91,
-    99
+    1,
+    16,
+    23,
+    34,
+    44,
+    54,
+    60,
+    67,
+    82,
+    97
    ],
    "score_checkpoints": [
     {
@@ -7261,7 +7261,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1011336180134603,
+     "diversity": 0.09624193300508338,
      "div_tie_breakers": [
       1.0
      ]
@@ -7270,7 +7270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.09624193300508338,
      "div_tie_breakers": [
       1.0
      ]
@@ -7279,7 +7279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10140422012948327,
      "div_tie_breakers": [
       1.0
      ]
@@ -7288,7 +7288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -7297,7 +7297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -7306,7 +7306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -7315,7 +7315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -7324,7 +7324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -7333,7 +7333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -7342,7 +7342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.1030101786246515,
      "div_tie_breakers": [
       1.0
      ]
@@ -7351,7 +7351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7360,7 +7360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7369,7 +7369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7378,7 +7378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7387,7 +7387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10308263925612694,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7396,7 +7396,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1039593845716412,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7405,7 +7405,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1039593845716412,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7414,7 +7414,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7423,7 +7423,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7432,7 +7432,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7441,7 +7441,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7450,7 +7450,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10625467383299031,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7459,7 +7459,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678782570174046,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7468,7 +7468,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10678782570174046,
+     "diversity": 0.10371372799445341,
      "div_tie_breakers": [
       1.0
      ]
@@ -7477,16 +7477,16 @@
   },
   "U4|THOROUGH|123": {
    "i_selected": [
-    1,
-    19,
-    30,
-    48,
-    57,
-    66,
-    80,
-    89,
-    93,
-    99
+    0,
+    12,
+    20,
+    25,
+    44,
+    53,
+    60,
+    69,
+    83,
+    94
    ],
    "score_checkpoints": [
     {
@@ -7502,7 +7502,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7511,7 +7511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7520,7 +7520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7529,7 +7529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7538,7 +7538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7547,7 +7547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10479203642621018,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7556,7 +7556,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208466565651,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7565,7 +7565,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208466565651,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7574,7 +7574,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.10637208466565651,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7583,7 +7583,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.09622035163308493,
      "div_tie_breakers": [
       1.0
      ]
@@ -7592,7 +7592,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7601,7 +7601,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7610,7 +7610,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7619,7 +7619,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7628,7 +7628,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7637,7 +7637,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.0971556049521439,
      "div_tie_breakers": [
       1.0
      ]
@@ -7646,7 +7646,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7655,7 +7655,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7664,7 +7664,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7673,7 +7673,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7682,7 +7682,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7691,7 +7691,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7700,7 +7700,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -7709,7 +7709,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.1080430212661147,
+     "diversity": 0.10005737653023501,
      "div_tie_breakers": [
       1.0
      ]
@@ -8682,735 +8682,12 @@
   },
   "C1|SMART|42": {
    "i_selected": [
-    5,
-    29,
-    41,
-    69,
-    76,
-    82,
-    86,
-    95,
-    96,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.11111111111111116,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363570701411459,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363570701411459,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363570701411459,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7526790953239642,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7526790953239642,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7887588041487258,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950067624344,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950067624344,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C1|SMART|123": {
-   "i_selected": [
-    3,
-    41,
-    50,
-    66,
-    69,
-    76,
-    83,
-    95,
-    97,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.11111111111111116,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298108973213604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298108973213604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298108973213604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298108973213604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7298108973213604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7304892759565564,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7453341320533203,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C1|THOROUGH|42": {
-   "i_selected": [
-    5,
-    29,
-    41,
-    69,
-    76,
-    82,
-    86,
-    95,
-    96,
-    99
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.11111111111111116,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363570701411459,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363570701411459,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7363570701411459,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7526790953239642,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7526790953239642,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.766460283393954,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7887588041487258,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.7916809456546168,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950067624344,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.8223950067624344,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C1|THOROUGH|123": {
-   "i_selected": [
-    5,
-    51,
-    66,
-    71,
-    76,
+    0,
+    45,
+    58,
+    65,
     85,
+    86,
     91,
     95,
     97,
@@ -9430,7 +8707,489 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298108973213604,
+     "diversity": 0.6177579363284693,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380965252844,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380965252844,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380965252844,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380965252844,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380965252844,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380965252844,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6565380965252844,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407897189947,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407897189947,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407897189947,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407897189947,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407897189947,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6684407897189947,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6856382032654078,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6856382032654078,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6948827177832265,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7033566410722476,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7461032262733067,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7540905824960332,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7540905824960332,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7540905824960332,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7718172462209694,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7718172462209694,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C1|SMART|123": {
+   "i_selected": [
+    1,
+    32,
+    50,
+    55,
+    76,
+    82,
+    91,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.11111111111111116,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484627928298,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484627928298,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8698735704286789,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8701953592568813,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C1|THOROUGH|42": {
+   "i_selected": [
+    0,
+    45,
+    51,
+    52,
+    58,
+    85,
+    91,
+    93,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.11111111111111116,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.6177579363284693,
      "div_tie_breakers": [
       1.0
      ]
@@ -9439,7 +9198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298108973213604,
+     "diversity": 0.6565380965252844,
      "div_tie_breakers": [
       1.0
      ]
@@ -9448,7 +9207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298108973213604,
+     "diversity": 0.6565380965252844,
      "div_tie_breakers": [
       1.0
      ]
@@ -9457,7 +9216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298108973213604,
+     "diversity": 0.6565380965252844,
      "div_tie_breakers": [
       1.0
      ]
@@ -9466,7 +9225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7298108973213604,
+     "diversity": 0.6565380965252844,
      "div_tie_breakers": [
       1.0
      ]
@@ -9475,7 +9234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304892759565564,
+     "diversity": 0.6565380965252844,
      "div_tie_breakers": [
       1.0
      ]
@@ -9484,7 +9243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304892759565564,
+     "diversity": 0.6565380965252844,
      "div_tie_breakers": [
       1.0
      ]
@@ -9493,7 +9252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304892759565564,
+     "diversity": 0.6565380965252844,
      "div_tie_breakers": [
       1.0
      ]
@@ -9502,7 +9261,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7304892759565564,
+     "diversity": 0.6684407897189947,
      "div_tie_breakers": [
       1.0
      ]
@@ -9511,7 +9270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570629351052995,
+     "diversity": 0.6684407897189947,
      "div_tie_breakers": [
       1.0
      ]
@@ -9520,7 +9279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570629351052995,
+     "diversity": 0.6684407897189947,
      "div_tie_breakers": [
       1.0
      ]
@@ -9529,7 +9288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570629351052995,
+     "diversity": 0.6684407897189947,
      "div_tie_breakers": [
       1.0
      ]
@@ -9538,7 +9297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7782083491457524,
+     "diversity": 0.6684407897189947,
      "div_tie_breakers": [
       1.0
      ]
@@ -9547,7 +9306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7848306111894476,
+     "diversity": 0.6684407897189947,
      "div_tie_breakers": [
       1.0
      ]
@@ -9556,7 +9315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7848306111894476,
+     "diversity": 0.6856382032654078,
      "div_tie_breakers": [
       1.0
      ]
@@ -9565,7 +9324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7848306111894476,
+     "diversity": 0.6856382032654078,
      "div_tie_breakers": [
       1.0
      ]
@@ -9574,7 +9333,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.6948827177832265,
      "div_tie_breakers": [
       1.0
      ]
@@ -9583,7 +9342,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.7033566410722476,
      "div_tie_breakers": [
       1.0
      ]
@@ -9592,7 +9351,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.7240328842472359,
      "div_tie_breakers": [
       1.0
      ]
@@ -9601,7 +9360,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.7240328842472359,
      "div_tie_breakers": [
       1.0
      ]
@@ -9610,7 +9369,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.7240328842472359,
      "div_tie_breakers": [
       1.0
      ]
@@ -9619,7 +9378,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.7240328842472359,
      "div_tie_breakers": [
       1.0
      ]
@@ -9628,7 +9387,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.7240328842472359,
      "div_tie_breakers": [
       1.0
      ]
@@ -9637,7 +9396,248 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8146164172609338,
+     "diversity": 0.7240328842472359,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C1|THOROUGH|123": {
+   "i_selected": [
+    1,
+    32,
+    50,
+    55,
+    74,
+    82,
+    91,
+    95,
+    97,
+    99
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.11111111111111116,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484627928298,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8412484627928298,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.86671207308102,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8670329130558545,
      "div_tie_breakers": [
       1.0
      ]
@@ -10610,13 +10610,13 @@
   },
   "C2|SMART|42": {
    "i_selected": [
-    24,
-    32,
-    66,
-    79,
-    85,
+    1,
+    38,
+    50,
+    54,
+    67,
+    69,
     86,
-    91,
     95,
     97,
     99
@@ -10634,8 +10634,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7363570701411459,
+     "constraints": 1.0,
+     "diversity": 0.6177579363284693,
      "div_tie_breakers": [
       1.0
      ]
@@ -10644,7 +10644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7113419770153667,
+     "diversity": 0.649242679242976,
      "div_tie_breakers": [
       1.0
      ]
@@ -10653,7 +10653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6646372808308582,
      "div_tie_breakers": [
       1.0
      ]
@@ -10662,7 +10662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10671,7 +10671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10680,7 +10680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10689,7 +10689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10698,7 +10698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10707,7 +10707,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10716,7 +10716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10725,7 +10725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10734,7 +10734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -10743,7 +10743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10752,7 +10752,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10761,7 +10761,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10770,7 +10770,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10779,7 +10779,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7579973865561586,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10788,7 +10788,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10797,7 +10797,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10806,7 +10806,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10815,7 +10815,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10824,7 +10824,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -10833,7 +10833,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8031050183938109,
+     "diversity": 0.7374700987641876,
      "div_tie_breakers": [
       1.0
      ]
@@ -10842,7 +10842,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8065439307276416,
+     "diversity": 0.7374700987641876,
      "div_tie_breakers": [
       1.0
      ]
@@ -10851,16 +10851,16 @@
   },
   "C2|SMART|123": {
    "i_selected": [
-    20,
-    25,
-    65,
-    81,
-    85,
-    86,
+    4,
+    32,
+    55,
+    71,
+    74,
+    82,
     91,
     95,
     97,
-    99
+    98
    ],
    "score_checkpoints": [
     {
@@ -10875,17 +10875,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7298108973213604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.6353946074275736,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -10894,7 +10885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6182802810467076,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -10903,7 +10894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6182802810467076,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -10912,7 +10903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201637072046646,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -10921,7 +10912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201637072046646,
+     "diversity": 0.7817784642442129,
      "div_tie_breakers": [
       1.0
      ]
@@ -10930,7 +10921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6690474376130345,
+     "diversity": 0.7817784642442129,
      "div_tie_breakers": [
       1.0
      ]
@@ -10939,7 +10930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6722828315466947,
+     "diversity": 0.7817784642442129,
      "div_tie_breakers": [
       1.0
      ]
@@ -10948,7 +10939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7110718691995466,
+     "diversity": 0.7817784642442129,
      "div_tie_breakers": [
       1.0
      ]
@@ -10957,7 +10948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570778740751692,
+     "diversity": 0.7893817940446117,
      "div_tie_breakers": [
       1.0
      ]
@@ -10966,7 +10957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570778740751692,
+     "diversity": 0.7893817940446117,
      "div_tie_breakers": [
       1.0
      ]
@@ -10975,7 +10966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7570778740751692,
+     "diversity": 0.7893817940446117,
      "div_tie_breakers": [
       1.0
      ]
@@ -10984,7 +10975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.7893817940446117,
      "div_tie_breakers": [
       1.0
      ]
@@ -10993,7 +10984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8003092610068318,
      "div_tie_breakers": [
       1.0
      ]
@@ -11002,7 +10993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8003092610068318,
      "div_tie_breakers": [
       1.0
      ]
@@ -11011,7 +11002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8003092610068318,
      "div_tie_breakers": [
       1.0
      ]
@@ -11020,7 +11011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8003092610068318,
      "div_tie_breakers": [
       1.0
      ]
@@ -11029,7 +11020,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8370374604464654,
      "div_tie_breakers": [
       1.0
      ]
@@ -11038,7 +11029,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8370374604464654,
      "div_tie_breakers": [
       1.0
      ]
@@ -11047,7 +11038,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8370374604464654,
      "div_tie_breakers": [
       1.0
      ]
@@ -11056,7 +11047,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8505820306725573,
      "div_tie_breakers": [
       1.0
      ]
@@ -11065,7 +11056,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8505820306725573,
      "div_tie_breakers": [
       1.0
      ]
@@ -11074,7 +11065,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8505820306725573,
      "div_tie_breakers": [
       1.0
      ]
@@ -11083,7 +11074,16 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7988980972484516,
+     "diversity": 0.8505820306725573,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.8505820306725573,
      "div_tie_breakers": [
       1.0
      ]
@@ -11092,15 +11092,15 @@
   },
   "C2|THOROUGH|42": {
    "i_selected": [
-    24,
-    32,
-    66,
+    1,
+    42,
+    54,
+    58,
+    69,
     79,
-    85,
     86,
-    91,
+    92,
     95,
-    97,
     99
    ],
    "score_checkpoints": [
@@ -11116,8 +11116,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7363570701411459,
+     "constraints": 1.0,
+     "diversity": 0.6177579363284693,
      "div_tie_breakers": [
       1.0
      ]
@@ -11126,7 +11126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7113419770153667,
+     "diversity": 0.649242679242976,
      "div_tie_breakers": [
       1.0
      ]
@@ -11135,7 +11135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6646372808308582,
      "div_tie_breakers": [
       1.0
      ]
@@ -11144,7 +11144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11153,7 +11153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11162,7 +11162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11171,7 +11171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11180,7 +11180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11189,7 +11189,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11198,7 +11198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11207,7 +11207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7288917783016953,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11216,7 +11216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6705296995899798,
      "div_tie_breakers": [
       1.0
      ]
@@ -11225,7 +11225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -11234,7 +11234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -11243,7 +11243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -11252,7 +11252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7529197547830142,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -11261,7 +11261,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7579973865561586,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -11270,7 +11270,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -11279,7 +11279,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.6812640936517538,
      "div_tie_breakers": [
       1.0
      ]
@@ -11288,7 +11288,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.7310718718838178,
      "div_tie_breakers": [
       1.0
      ]
@@ -11297,7 +11297,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.7310718718838178,
      "div_tie_breakers": [
       1.0
      ]
@@ -11306,7 +11306,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7853745910269831,
+     "diversity": 0.7310718718838178,
      "div_tie_breakers": [
       1.0
      ]
@@ -11315,7 +11315,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8031050183938109,
+     "diversity": 0.742563522284864,
      "div_tie_breakers": [
       1.0
      ]
@@ -11324,7 +11324,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8065439307276416,
+     "diversity": 0.742563522284864,
      "div_tie_breakers": [
       1.0
      ]
@@ -11333,14 +11333,14 @@
   },
   "C2|THOROUGH|123": {
    "i_selected": [
-    25,
-    29,
-    65,
-    69,
-    81,
+    2,
+    32,
+    40,
+    71,
+    74,
     82,
-    86,
-    95,
+    91,
+    94,
     97,
     99
    ],
@@ -11357,17 +11357,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.7298108973213604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.8181818181818181,
-     "diversity": 0.6353946074275736,
+     "constraints": 1.0,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -11376,7 +11367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6182802810467076,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -11385,7 +11376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6182802810467076,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -11394,7 +11385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201637072046646,
+     "diversity": 0.7608301643980312,
      "div_tie_breakers": [
       1.0
      ]
@@ -11403,7 +11394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6201637072046646,
+     "diversity": 0.7817784642442129,
      "div_tie_breakers": [
       1.0
      ]
@@ -11412,7 +11403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6690474376130345,
+     "diversity": 0.7817784642442129,
      "div_tie_breakers": [
       1.0
      ]
@@ -11421,7 +11412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.6807375078057238,
+     "diversity": 0.7817784642442129,
      "div_tie_breakers": [
       1.0
      ]
@@ -11430,7 +11421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7190234513421842,
+     "diversity": 0.8344118483791139,
      "div_tie_breakers": [
       1.0
      ]
@@ -11439,7 +11430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701742891664,
+     "diversity": 0.8344118483791139,
      "div_tie_breakers": [
       1.0
      ]
@@ -11448,7 +11439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701742891664,
+     "diversity": 0.8344118483791139,
      "div_tie_breakers": [
       1.0
      ]
@@ -11457,7 +11448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701742891664,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11466,7 +11457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7353701742891664,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11475,7 +11466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664237255899,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11484,7 +11475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664237255899,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11493,7 +11484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664237255899,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11502,7 +11493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.7916664237255899,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11511,7 +11502,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8067889544519562,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11520,7 +11511,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8067889544519562,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11529,7 +11520,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8067889544519562,
+     "diversity": 0.8500238192614871,
      "div_tie_breakers": [
       1.0
      ]
@@ -11538,7 +11529,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8067889544519562,
+     "diversity": 0.852583437548732,
      "div_tie_breakers": [
       1.0
      ]
@@ -11547,7 +11538,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8067889544519562,
+     "diversity": 0.852583437548732,
      "div_tie_breakers": [
       1.0
      ]
@@ -11556,7 +11547,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8067889544519562,
+     "diversity": 0.852583437548732,
      "div_tie_breakers": [
       1.0
      ]
@@ -11565,7 +11556,16 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.8067889544519562,
+     "diversity": 0.852583437548732,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.852583437548732,
      "div_tie_breakers": [
       1.0
      ]
@@ -12539,14 +12539,14 @@
   "C3|SMART|42": {
    "i_selected": [
     16,
-    44,
-    86,
-    98,
+    36,
+    75,
+    79,
+    109,
     124,
-    127,
-    137,
+    130,
+    143,
     145,
-    147,
     149
    ],
    "score_checkpoints": [
@@ -12563,7 +12563,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5118978375515136,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -12572,7 +12572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5118978375515136,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -12581,7 +12581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5135583519982547,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -12590,7 +12590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12599,7 +12599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12608,7 +12608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12617,7 +12617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12626,7 +12626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12635,7 +12635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12644,7 +12644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12653,7 +12653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12662,7 +12662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12671,7 +12671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12680,7 +12680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12689,7 +12689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12698,7 +12698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12707,7 +12707,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5210878923670036,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12716,7 +12716,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12725,7 +12725,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12734,7 +12734,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12743,7 +12743,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12752,7 +12752,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12761,7 +12761,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5306871551193143,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12770,7 +12770,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5306871551193143,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -12779,13 +12779,13 @@
   },
   "C3|SMART|123": {
    "i_selected": [
-    26,
-    42,
-    102,
+    13,
+    50,
+    73,
     103,
-    127,
+    115,
     131,
-    139,
+    138,
     145,
     147,
     149
@@ -12804,7 +12804,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12813,7 +12813,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12822,7 +12822,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12831,7 +12831,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12840,7 +12840,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12849,7 +12849,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12858,7 +12858,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12867,7 +12867,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12876,7 +12876,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12885,7 +12885,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12894,7 +12894,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12903,7 +12903,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12912,7 +12912,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12921,7 +12921,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12930,7 +12930,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12939,7 +12939,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12948,7 +12948,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12957,7 +12957,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12966,7 +12966,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12975,7 +12975,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -12984,7 +12984,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220033479723,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -12993,7 +12993,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220033479723,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -13002,7 +13002,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220033479723,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -13011,7 +13011,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5112220033479723,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -13020,15 +13020,15 @@
   },
   "C3|THOROUGH|42": {
    "i_selected": [
-    16,
-    44,
-    86,
-    102,
+    26,
+    36,
+    75,
+    80,
+    109,
     124,
     130,
-    137,
+    143,
     145,
-    147,
     149
    ],
    "score_checkpoints": [
@@ -13045,7 +13045,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5118978375515136,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -13054,7 +13054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5118978375515136,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -13063,7 +13063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5135583519982547,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -13072,7 +13072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13081,7 +13081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13090,7 +13090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13099,7 +13099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13108,7 +13108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13117,7 +13117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13126,7 +13126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13135,7 +13135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13144,7 +13144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13153,7 +13153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13162,7 +13162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13171,7 +13171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13180,7 +13180,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5206163109481774,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13189,7 +13189,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5210878923670036,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13198,7 +13198,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13207,7 +13207,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13216,7 +13216,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13225,7 +13225,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13234,7 +13234,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5257596951377624,
+     "diversity": 0.5194352753506815,
      "div_tie_breakers": [
       1.0
      ]
@@ -13243,7 +13243,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5291999710853551,
+     "diversity": 0.5215647716270974,
      "div_tie_breakers": [
       1.0
      ]
@@ -13252,7 +13252,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5291999710853551,
+     "diversity": 0.5215647716270974,
      "div_tie_breakers": [
       1.0
      ]
@@ -13261,13 +13261,13 @@
   },
   "C3|THOROUGH|123": {
    "i_selected": [
-    26,
-    54,
-    102,
+    13,
+    50,
+    73,
     103,
-    127,
+    115,
     131,
-    139,
+    138,
     145,
     147,
     149
@@ -13286,7 +13286,7 @@
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13295,7 +13295,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13304,7 +13304,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13313,7 +13313,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13322,7 +13322,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13331,7 +13331,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13340,7 +13340,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13349,7 +13349,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13358,7 +13358,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13367,7 +13367,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13376,7 +13376,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13385,7 +13385,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13394,7 +13394,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13403,7 +13403,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13412,7 +13412,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4976486259207695,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13421,7 +13421,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13430,7 +13430,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13439,7 +13439,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13448,7 +13448,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13457,7 +13457,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
@@ -13466,7 +13466,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -13475,7 +13475,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -13484,7 +13484,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -13493,7 +13493,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.5011175254394495,
+     "diversity": 0.5300056611754443,
      "div_tie_breakers": [
       1.0
      ]
@@ -14466,16 +14466,16 @@
   },
   "C4|SMART|42": {
    "i_selected": [
-    4,
-    27,
-    28,
-    54,
-    58,
-    100,
+    20,
+    21,
+    43,
+    57,
+    75,
+    80,
     103,
-    132,
-    145,
-    149
+    124,
+    130,
+    143
    ],
    "score_checkpoints": [
     {
@@ -14490,26 +14490,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.5118978375515136,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
      "constraints": 0.875,
-     "diversity": 0.40928043264679714,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.875,
-     "diversity": 0.4927343328916696,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -14518,7 +14500,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.45410989741623686,
+     "diversity": 0.36374457649055114,
      "div_tie_breakers": [
       1.0
      ]
@@ -14527,7 +14509,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.2841054804174128,
+     "diversity": 0.3198398532761496,
      "div_tie_breakers": [
       1.0
      ]
@@ -14536,7 +14518,25 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.2802744610422146,
+     "diversity": 0.26587158332119515,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.3372017178707365,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.37429423424636954,
      "div_tie_breakers": [
       1.0
      ]
@@ -14545,7 +14545,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290868199692597,
+     "diversity": 0.16571847896661307,
      "div_tie_breakers": [
       1.0
      ]
@@ -14554,7 +14554,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290868199692597,
+     "diversity": 0.16643403992952593,
      "div_tie_breakers": [
       1.0
      ]
@@ -14563,7 +14563,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771109619351642,
+     "diversity": 0.16643403992952593,
      "div_tie_breakers": [
       1.0
      ]
@@ -14572,7 +14572,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771109619351642,
+     "diversity": 0.18159227781961718,
      "div_tie_breakers": [
       1.0
      ]
@@ -14581,7 +14581,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.20673819274242206,
      "div_tie_breakers": [
       1.0
      ]
@@ -14590,7 +14590,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.2546901718110156,
      "div_tie_breakers": [
       1.0
      ]
@@ -14599,7 +14599,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14608,7 +14608,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14617,7 +14617,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32346674276923104,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14626,7 +14626,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32346674276923104,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14635,7 +14635,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3402751809222351,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14644,7 +14644,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.36193338536533726,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14653,7 +14653,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3651952928769271,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -14662,7 +14662,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4081245487162072,
+     "diversity": 0.30401328925311266,
      "div_tie_breakers": [
       1.0
      ]
@@ -14671,7 +14671,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4081245487162072,
+     "diversity": 0.30401328925311266,
      "div_tie_breakers": [
       1.0
      ]
@@ -14680,7 +14680,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4081245487162072,
+     "diversity": 0.30401328925311266,
      "div_tie_breakers": [
       1.0
      ]
@@ -14689,7 +14689,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41963541223003775,
+     "diversity": 0.3126353325043272,
      "div_tie_breakers": [
       1.0
      ]
@@ -14698,7 +14698,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41963541223003775,
+     "diversity": 0.3186250550890783,
      "div_tie_breakers": [
       1.0
      ]
@@ -14707,255 +14707,14 @@
   },
   "C4|SMART|123": {
    "i_selected": [
+    12,
     17,
-    19,
-    48,
-    53,
-    77,
-    102,
+    35,
+    44,
+    64,
+    76,
     103,
-    133,
-    145,
-    147
-   ],
-   "score_checkpoints": [
-    {
-     "step": "step 0/2 - Init SolverState",
-     "size": 0.09090909090909083,
-     "constraints": 0.0625,
-     "diversity": 0.0,
-     "div_tie_breakers": [
-      0.0
-     ]
-    },
-    {
-     "step": "step 1/2 - InitFarthestPoint",
-     "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.4976486259207695,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.5008678091824328,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 0.9375,
-     "diversity": 0.4048536737792797,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.35185307727968695,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.3708398958431677,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.38043841449326604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.38043841449326604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.38043841449326604,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4146785513512527,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4146785513512527,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4146785513512527,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4146785513512527,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.4146785513512527,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
-     "size": 1.0,
-     "constraints": 1.0,
-     "diversity": 0.41690677256540576,
-     "div_tie_breakers": [
-      1.0
-     ]
-    }
-   ]
-  },
-  "C4|THOROUGH|42": {
-   "i_selected": [
-    4,
-    19,
-    27,
-    50,
-    56,
-    100,
-    103,
-    132,
+    138,
     145,
     149
    ],
@@ -14972,233 +14731,233 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.5118978375515136,
+     "constraints": 0.875,
+     "diversity": 0.48836732873676114,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 0.40928043264679714,
+     "diversity": 0.37607983707590575,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.875,
-     "diversity": 0.4927343328916696,
+     "diversity": 0.4516074885818647,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.45410989741623686,
+     "diversity": 0.37364588117904896,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.9375,
-     "diversity": 0.2841054804174128,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.9375,
-     "diversity": 0.2802744610422146,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290868199692597,
+     "diversity": 0.33355846018689744,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21290868199692597,
+     "diversity": 0.36235622835719294,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771109619351642,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.21771109619351642,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3204943503882744,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32346674276923104,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.32346674276923104,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3402751809222351,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.36193338536533726,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907861427455905,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907861427455905,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907861427455905,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.40907861427455905,
+     "diversity": 0.4194351077196964,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41271125595816494,
+     "diversity": 0.4194351077196964,
      "div_tie_breakers": [
       1.0
      ]
     },
     {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.41271125595816494,
+     "diversity": 0.4194351077196964,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4194351077196964,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-8,8,8)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.4194351077196964,
      "div_tie_breakers": [
       1.0
      ]
     }
    ]
   },
-  "C4|THOROUGH|123": {
+  "C4|THOROUGH|42": {
    "i_selected": [
-    17,
-    26,
-    48,
-    53,
-    77,
-    102,
-    103,
-    133,
-    145,
-    147
+    20,
+    21,
+    43,
+    57,
+    75,
+    80,
+    101,
+    124,
+    130,
+    143
    ],
    "score_checkpoints": [
     {
@@ -15213,17 +14972,8 @@
     {
      "step": "step 1/2 - InitFarthestPoint",
      "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.4976486259207695,
-     "div_tie_breakers": [
-      1.0
-     ]
-    },
-    {
-     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
-     "size": 1.0,
-     "constraints": 0.8125,
-     "diversity": 0.5008678091824328,
+     "constraints": 0.875,
+     "diversity": 0.49001077813950034,
      "div_tie_breakers": [
       1.0
      ]
@@ -15232,7 +14982,43 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 0.9375,
-     "diversity": 0.4048536737792797,
+     "diversity": 0.36374457649055114,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.3198398532761496,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.26587158332119515,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.3372017178707365,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.37429423424636954,
      "div_tie_breakers": [
       1.0
      ]
@@ -15241,7 +15027,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.35185307727968695,
+     "diversity": 0.16571847896661307,
      "div_tie_breakers": [
       1.0
      ]
@@ -15250,7 +15036,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.3708398958431677,
+     "diversity": 0.16643403992952593,
      "div_tie_breakers": [
       1.0
      ]
@@ -15259,7 +15045,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38043841449326604,
+     "diversity": 0.16643403992952593,
      "div_tie_breakers": [
       1.0
      ]
@@ -15268,7 +15054,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38043841449326604,
+     "diversity": 0.18159227781961718,
      "div_tie_breakers": [
       1.0
      ]
@@ -15277,7 +15063,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.38043841449326604,
+     "diversity": 0.20673819274242206,
      "div_tie_breakers": [
       1.0
      ]
@@ -15286,7 +15072,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.2546901718110156,
      "div_tie_breakers": [
       1.0
      ]
@@ -15295,7 +15081,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15304,7 +15090,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15313,7 +15099,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15322,7 +15108,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15331,7 +15117,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15340,7 +15126,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15349,7 +15135,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15358,7 +15144,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15367,7 +15153,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15376,7 +15162,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.29301267842510104,
      "div_tie_breakers": [
       1.0
      ]
@@ -15385,7 +15171,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.31657934444070795,
      "div_tie_breakers": [
       1.0
      ]
@@ -15394,7 +15180,68 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.31657934444070795,
+     "div_tie_breakers": [
+      1.0
+     ]
+    }
+   ]
+  },
+  "C4|THOROUGH|123": {
+   "i_selected": [
+    12,
+    17,
+    35,
+    43,
+    64,
+    76,
+    103,
+    138,
+    145,
+    149
+   ],
+   "score_checkpoints": [
+    {
+     "step": "step 0/2 - Init SolverState",
+     "size": 0.09090909090909083,
+     "constraints": 0.0625,
+     "diversity": 0.0,
+     "div_tie_breakers": [
+      0.0
+     ]
+    },
+    {
+     "step": "step 1/2 - InitFarthestPoint",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.48836732873676114,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.37607983707590575,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.875,
+     "diversity": 0.4516074885818647,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 0.9375,
+     "diversity": 0.37364588117904896,
      "div_tie_breakers": [
       1.0
      ]
@@ -15403,7 +15250,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.33355846018689744,
      "div_tie_breakers": [
       1.0
      ]
@@ -15412,7 +15259,7 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.36235622835719294,
      "div_tie_breakers": [
       1.0
      ]
@@ -15421,7 +15268,160 @@
      "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
      "size": 1.0,
      "constraints": 1.0,
-     "diversity": 0.4146785513512527,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
+     "div_tie_breakers": [
+      1.0
+     ]
+    },
+    {
+     "step": "step 2/2 - OptimSmartSwaps(1-64,64,64)",
+     "size": 1.0,
+     "constraints": 1.0,
+     "diversity": 0.41924939783352677,
      "div_tie_breakers": [
       1.0
      ]


### PR DESCRIPTION
**TL;DR**: SMART/THOROUGH initialization replaces the random prefix with top-k sampling — each farthest-point pick samples uniformly among the 8 highest diversity contributions; the losing `random_fraction` mechanism is removed, and `top_k` goes public on the `farthest_point()` factory.

## Description

### Problem addressed

The presets' farthest-point construction decorrelated seeds with a **random prefix** (first 10% of picks uniformly random). Uniform picks are **bad picks**: they cost several percent of diversity at the freshly built selection and take seconds of swap repair — exactly the short-budget window where the farthest-point construction is the presets' edge.

### Implementation

The shared SMART/THOROUGH preset initialization becomes `InitFarthestPoint(top_k=8)`. Sampling among the **top-8 contributions** means every pick stays near-greedy, so the construction cost is ~0 at every measured problem shape, while cross-seed variety survives — the property a **best-of-N portfolio** turns into its final result.

The value **8 is a constant, deliberately not a scaling rule**: measurements across selection-to-population ratios showed the tolerance for larger `top_k` grows with selection size while the decorrelation benefit shrinks with it, so a modest constant sits in the free zone everywhere.

**`top_k` goes public**: `farthest_point(top_k=1)`. The knob was kept off the factory while the mechanism was unproven; with it now spike-validated and driving the presets, the public API gets the same knob. Default 1 is the exact previous behavior, so existing callers are untouched. The docs strategy table follows (including correcting its stale claim that `random_one_shot` is the default for all presets).

**`random_fraction` is removed outright**, not left dormant: it was the previous decorrelation mechanism and the fallback ingredient for a top-k + prefix hybrid, and the measurements supported neither. The strategy keeps its seeded random start item; only the prefix widening goes.

**Golden masters regenerate once** (SMART/THOROUGH selections change per seed); RANDOM/GUIDED entries verified bit-identical against the pre-change data, both regimes. The removal itself is invisible to them — the start-item draw is unchanged, so the goldens pass the removal commit without regeneration.

## Attention points

- **Seed-to-selection mapping changes** for SMART/THOROUGH, as it did in the previous release — same pre-1.0 latitude, called out in the changelog.
- **Median vs upper tail**: on unconstrained min-separation problems the random prefix keeps a ≤0.06% *median* edge at long budgets. The switch is justified on the portfolio statistic: top-8 owns the best best-of-N tail (widest upward spread), and the median gap is at seed-noise level.
- Feasibility behavior is untouched: constrained problems reach the identical feasibility ceiling under every initialization variant measured.

## Tests / Spikes

- **SPIKE:** overnight 400-run sweep (top_k ∈ {2,4,8,16} at 300 s over six benchmark cells; 1800 s long-budget cells incl. a separation-worst family): construction cost ~0 at every K, top_k=8 best at the asymptote and in the best-of-8 tail.
- **SPIKE:** ratio sweep (k ∈ {200, 2000, 6000} at n=20000, both metric families): falsified a `top_k ∝ n/k` scaling rule — constant 8 stays in the free zone at every ratio.
- **TEST:** preset-only solve verified bit-identical to the spike arm's explicit-override wiring on SMART and THOROUGH cells.
- **TEST:** golden regen diff audited per preset: RANDOM/GUIDED 16/16 cases bit-identical in both regimes, SMART/THOROUGH 16/16 regenerated — and the goldens pass the removal commit unregenerated.
- Full suite green (3942 tests); the prefix's tests go with the mechanism, the `top_k` coverage stays, and the factory gains pass-through + validation tests.

## Changelog entry

Added:
```
`InitializationStrategy.farthest_point()` accepts an optional `top_k`: each greedy pick samples uniformly among the `top_k` best candidates (default 1 keeps the exact greedy construction)
```

Changed:
```
The tunable entropy mechanism of the farthest-point initialization procedure has changed from a pure-random fraction to choosing randomly from top_k-farthest-points in each step: short-budget results improve further, while maintaining the effect that seeds sufficiently diversify the search process
```


Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
