### PR TITLE
chore: add a selection-adoption path to the solver state

### DIFF
--- a/src/max_div/_core/solver/_diversity_contribution/_base.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_base.py
@@ -110,7 +110,8 @@ class DiversityContributionTracker(ABC):
         """Reset contributions to the empty selection, without going through per-point removes.
 
         Callers must only reset when the snapshot stack is empty: a reset does not touch saved
-        snapshots, so resetting inside an open snapshot scope would desync a later restore.
+        snapshots, so after a reset inside an open snapshot scope, a later restore would bring
+        back contributions that no longer match the rest of the solver state.
         """
         raise NotImplementedError
 

--- a/src/max_div/_core/solver/_diversity_contribution/_base.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_base.py
@@ -105,6 +105,15 @@ class DiversityContributionTracker(ABC):
         for index in indices:
             self.remove(index, new_selection)
 
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset contributions to the empty selection, without going through per-point removes.
+
+        Callers must only reset when the snapshot stack is empty: a reset does not touch saved
+        snapshots, so resetting inside an open snapshot scope would desync a later restore.
+        """
+        raise NotImplementedError
+
     # -------------------------------------------------------------------------
     #  Snapshot & copy
     # -------------------------------------------------------------------------

--- a/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_tracker.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_mean_distance/_tracker.py
@@ -121,6 +121,10 @@ class MeanDistanceTracker(DiversityContributionTracker):
         """
         self._backend.remove(self._dist_sums, self._store, index)
 
+    def reset(self) -> None:
+        """Reset distance sums to the empty selection (all zero); the global cache stays valid as-is."""
+        self._dist_sums.fill(0.0)
+
     # -------------------------------------------------------------------------
     #  Snapshot
     # -------------------------------------------------------------------------

--- a/src/max_div/_core/solver/_diversity_contribution/_separation/_tracker.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_separation/_tracker.py
@@ -106,6 +106,10 @@ class SeparationTracker(DiversityContributionTracker):
         """Update separations after removing point `index`, rescanning against `new_selection` where needed."""
         self._backend.remove(self._sep_selected, self._store, index, new_selection)
 
+    def reset(self) -> None:
+        """Reset separations to the empty selection (all +inf); the global cache stays valid as-is."""
+        self._sep_selected.fill(np.inf)
+
     # -------------------------------------------------------------------------
     #  Snapshot
     # -------------------------------------------------------------------------

--- a/src/max_div/_core/solver/_diversity_contribution/_trackers.py
+++ b/src/max_div/_core/solver/_diversity_contribution/_trackers.py
@@ -124,6 +124,11 @@ class DiversityContributionTrackers:
         for tracker in self._trackers:
             tracker.remove_many(indices, new_selection)
 
+    def reset(self) -> None:
+        """Reset all trackers to the empty selection; see the base class for the snapshot caveat."""
+        for tracker in self._trackers:
+            tracker.reset()
+
     # -------------------------------------------------------------------------
     #  Snapshot
     # -------------------------------------------------------------------------

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -277,6 +277,47 @@ class SolverState:
         # --- score ---------------------------------------
         self._score_dirty = True
 
+    def adopt_selection(self, indices: NDArray[np.int32]) -> None:
+        """Replace the current selection with `indices`, updating all incremental state to match.
+
+        Installs a selection produced elsewhere (e.g. another worker's incumbent) as if it had been
+        built through this state's own mutators.  The install goes through the cheaper of two
+        routes: diffing against the current selection and applying the removes/adds, or — when the
+        selections barely overlap, where per-point removes would cost more than starting over —
+        resetting to the empty selection and bulk-adding.  Which route ran is unobservable.
+
+        :param indices: (int32 ndarray) the selection to adopt; duplicate-free, any order.
+        :raises RuntimeError: If a savepoint is open — an adoption cannot be provisional.
+        :raises ValueError: If `indices` contains duplicates or out-of-range values.
+        """
+        # --- validation ----------------------------------
+        if self._depth != 0:
+            raise RuntimeError("Cannot adopt a selection while a savepoint is open.")
+        foreign = np.unique(np.asarray(indices, dtype=np.int32))  # ascending, deduplicated
+        if foreign.size != len(indices):
+            raise ValueError(f"Cannot adopt a selection with duplicate indices ({list(indices)}).")
+        if foreign.size > 0 and (foreign[0] < 0 or foreign[-1] >= self._n):
+            raise ValueError(f"Cannot adopt a selection with out-of-range indices ({list(indices)}).")
+
+        # --- route selection -----------------------------
+        current = self.selected_index_array
+        to_remove = np.setdiff1d(current, foreign, assume_unique=True)
+        to_add = np.setdiff1d(foreign, current, assume_unique=True)
+
+        if to_remove.size + to_add.size <= foreign.size:
+            # --- diff route ------------------------------
+            self.remove_many(to_remove)
+            self.add_many(to_add)
+        else:
+            # --- rebuild route ---------------------------
+            # undo the constraint effect of the current selection while its index view is intact
+            for index in current:
+                self._con_values[self._con_membership[index], :] += 1
+            self._selected.fill(False)
+            self._n_selected = np.int32(0)
+            self._contribution_trackers.reset()
+            self.add_many(foreign)  # also marks the score dirty
+
     def remove_many(self, indices: NDArray[np.int32]) -> None:
         # --- validation ----------------------------------
         if (~self._selected[indices]).any():

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -277,12 +277,35 @@ class SolverState:
         # --- score ---------------------------------------
         self._score_dirty = True
 
+    def remove_many(self, indices: NDArray[np.int32]) -> None:
+        # --- validation ----------------------------------
+        if (~self._selected[indices]).any():
+            raise ValueError(f"Cannot remove index that is not selected ({list(indices)}).")
+
+        # --- selection -----------------------------------
+        self._selected[indices] = False
+        # same reason as in add_many: each delete reads the count as the list's current length
+        for index in indices:
+            self._delete_selected_index(index)
+            self._n_selected -= np.int32(1)
+
+        # --- diversity contributions ---------------------
+        self._contribution_trackers.remove_many(indices, self.selected_index_array)
+
+        # --- constraints ---------------------------------
+        # increase both min_count and max_count for all constraints that include any of 'indices'
+        for index in indices:
+            self._con_values[self._con_membership[index], :] += 1
+
+        # --- score ---------------------------------------
+        self._score_dirty = True
+
     def adopt_selection(self, indices: NDArray[np.int32]) -> None:
         """Replace the current selection with `indices`, updating all incremental state to match.
 
-        Installs a selection produced elsewhere (e.g. another worker's incumbent) as if it had been
-        built through this state's own mutators.  Internally applies the cheaper of a selection
-        diff or a rebuild from the empty selection; which route ran is unobservable.
+        Adoption installs a selection produced elsewhere (e.g. another worker's incumbent) as if it
+        had been built through this state's own mutators, applying the cheaper of a selection diff
+        or a rebuild from the empty selection.
 
         :param indices: (int32 ndarray) the selection to adopt; duplicate-free, any order.
         :raises RuntimeError: If a savepoint is open — an adoption cannot be provisional.
@@ -315,29 +338,6 @@ class SolverState:
             self._n_selected = np.int32(0)
             self._contribution_trackers.reset()
             self.add_many(foreign)  # also marks the score dirty
-
-    def remove_many(self, indices: NDArray[np.int32]) -> None:
-        # --- validation ----------------------------------
-        if (~self._selected[indices]).any():
-            raise ValueError(f"Cannot remove index that is not selected ({list(indices)}).")
-
-        # --- selection -----------------------------------
-        self._selected[indices] = False
-        # same reason as in add_many: each delete reads the count as the list's current length
-        for index in indices:
-            self._delete_selected_index(index)
-            self._n_selected -= np.int32(1)
-
-        # --- diversity contributions ---------------------
-        self._contribution_trackers.remove_many(indices, self.selected_index_array)
-
-        # --- constraints ---------------------------------
-        # increase both min_count and max_count for all constraints that include any of 'indices'
-        for index in indices:
-            self._con_values[self._con_membership[index], :] += 1
-
-        # --- score ---------------------------------------
-        self._score_dirty = True
 
     # -------------------------------------------------------------------------
     #  Properties

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -300,12 +300,39 @@ class SolverState:
         # --- score ---------------------------------------
         self._score_dirty = True
 
+    def reset(self) -> None:
+        """Return the state to the empty selection, updating all incremental state to match.
+
+        Cheaper than removing the selected items one by one: the trackers jump straight to their
+        empty-selection values instead of rescanning after every removal.
+
+        :raises RuntimeError: If a savepoint is open — a reset cannot be provisional.
+        """
+        # --- validation ----------------------------------
+        if self._depth != 0:
+            raise RuntimeError("Cannot reset the selection while a savepoint is open.")
+
+        # --- constraints ---------------------------------
+        # undo the constraint effect of the current selection while its index view is intact
+        for index in self.selected_index_array:
+            self._con_values[self._con_membership[index], :] += 1
+
+        # --- selection -----------------------------------
+        self._selected.fill(False)
+        self._n_selected = np.int32(0)
+
+        # --- diversity contributions ---------------------
+        self._contribution_trackers.reset()
+
+        # --- score ---------------------------------------
+        self._score_dirty = True
+
     def adopt_selection(self, indices: NDArray[np.int32]) -> None:
         """Replace the current selection with `indices`, updating all incremental state to match.
 
         Adoption installs a selection produced elsewhere (e.g. another worker's incumbent) as if it
         had been built through this state's own mutators, applying the cheaper of a selection diff
-        or a rebuild from the empty selection.
+        or a reset-then-rebuild.
 
         :param indices: (int32 ndarray) the selection to adopt; duplicate-free, any order.
         :raises RuntimeError: If a savepoint is open — an adoption cannot be provisional.
@@ -331,13 +358,8 @@ class SolverState:
             self.add_many(to_add)
         else:
             # --- rebuild route ---------------------------
-            # undo the constraint effect of the current selection while its index view is intact
-            for index in current:
-                self._con_values[self._con_membership[index], :] += 1
-            self._selected.fill(False)
-            self._n_selected = np.int32(0)
-            self._contribution_trackers.reset()
-            self.add_many(foreign)  # also marks the score dirty
+            self.reset()
+            self.add_many(foreign)
 
     # -------------------------------------------------------------------------
     #  Properties

--- a/src/max_div/_core/solver/_solver_state.py
+++ b/src/max_div/_core/solver/_solver_state.py
@@ -281,10 +281,8 @@ class SolverState:
         """Replace the current selection with `indices`, updating all incremental state to match.
 
         Installs a selection produced elsewhere (e.g. another worker's incumbent) as if it had been
-        built through this state's own mutators.  The install goes through the cheaper of two
-        routes: diffing against the current selection and applying the removes/adds, or — when the
-        selections barely overlap, where per-point removes would cost more than starting over —
-        resetting to the empty selection and bulk-adding.  Which route ran is unobservable.
+        built through this state's own mutators.  Internally applies the cheaper of a selection
+        diff or a rebuild from the empty selection; which route ran is unobservable.
 
         :param indices: (int32 ndarray) the selection to adopt; duplicate-free, any order.
         :raises RuntimeError: If a savepoint is open — an adoption cannot be provisional.

--- a/tests/_core/solver/_diversity_contribution/test_base.py
+++ b/tests/_core/solver/_diversity_contribution/test_base.py
@@ -22,7 +22,7 @@ class _CallRecordingTracker(DiversityContributionTracker):
         return np.array([], dtype=np.float32)
 
     def contribution_wrt_dataset_for(self, indices: NDArray[np.int32]) -> NDArray[np.float32]:
-        return np.array([], dtype=np.float32)  # pragma: no cover - not exercised by these tests
+        return np.array([], dtype=np.float32)  # not exercised by these tests
 
     def add(self, index: np.int32) -> None:
         self.calls.append(("add", int(index)))
@@ -31,16 +31,16 @@ class _CallRecordingTracker(DiversityContributionTracker):
         self.calls.append(("remove", int(index), list(new_selection)))
 
     def reset(self) -> None:
-        pass  # pragma: no cover - not exercised by these tests
+        pass  # not exercised by these tests
 
     def push_snapshot(self) -> None:
-        pass  # pragma: no cover - not exercised by these tests
+        pass  # not exercised by these tests
 
     def pop_snapshot(self, restore: bool) -> None:
-        pass  # pragma: no cover - not exercised by these tests
+        pass  # not exercised by these tests
 
     def copy(self) -> DiversityContributionTracker:
-        return self  # pragma: no cover - not exercised by these tests
+        return self  # not exercised by these tests
 
 
 # =================================================================================================

--- a/tests/_core/solver/_diversity_contribution/test_base.py
+++ b/tests/_core/solver/_diversity_contribution/test_base.py
@@ -30,6 +30,9 @@ class _CallRecordingTracker(DiversityContributionTracker):
     def remove(self, index: np.int32, new_selection: NDArray[np.int32]) -> None:
         self.calls.append(("remove", int(index), list(new_selection)))
 
+    def reset(self) -> None:
+        pass  # pragma: no cover - not exercised by these tests
+
     def push_snapshot(self) -> None:
         pass  # pragma: no cover - not exercised by these tests
 

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -329,6 +329,7 @@ def test_backend_matches_brute_force_over_random_operations(backend: str):
 
 
 def test_reset_returns_to_empty_selection(tracker: MeanDistanceTracker):
+    """Reset returns distance sums to the empty-selection zeros; the dataset-wide cache stays untouched."""
     # --- arrange -----------------------------------------
     tracker.add(np.int32(0))
     tracker.add(np.int32(2))

--- a/tests/_core/solver/_diversity_contribution/test_mean_distance.py
+++ b/tests/_core/solver/_diversity_contribution/test_mean_distance.py
@@ -326,3 +326,18 @@ def test_backend_matches_brute_force_over_random_operations(backend: str):
             rtol=1e-5,
             err_msg=f"{backend} diverged",
         )
+
+
+def test_reset_returns_to_empty_selection(tracker: MeanDistanceTracker):
+    # --- arrange -----------------------------------------
+    tracker.add(np.int32(0))
+    tracker.add(np.int32(2))
+    global_before = tracker.contribution_wrt_dataset.copy()
+    selected = np.full(N, False, dtype=np.bool)
+
+    # --- act ---------------------------------------------
+    tracker.reset()
+
+    # --- assert ------------------------------------------
+    assert np.all(tracker.contribution_wrt_selection(selected, np.int32(0)) == 0.0)
+    np.testing.assert_array_equal(tracker.contribution_wrt_dataset, global_before)  # cache untouched

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -383,3 +383,18 @@ def test_every_backend_computes_the_same_separations():
         np.testing.assert_allclose(
             values, reference, rtol=tolerance, atol=tolerance * float(np.max(reference)), err_msg=f"{name} disagrees"
         )
+
+
+def test_reset_returns_to_empty_selection(tracker: SeparationTracker):
+    # --- arrange -----------------------------------------
+    tracker.add(np.int32(0))
+    tracker.add(np.int32(2))
+    global_before = tracker.contribution_wrt_dataset.copy()
+    selected, n_selected = _selection_args([], 5)
+
+    # --- act ---------------------------------------------
+    tracker.reset()
+
+    # --- assert ------------------------------------------
+    assert np.all(np.isinf(tracker.contribution_wrt_selection(selected, n_selected)))
+    np.testing.assert_array_equal(tracker.contribution_wrt_dataset, global_before)  # cache untouched

--- a/tests/_core/solver/_diversity_contribution/test_separation.py
+++ b/tests/_core/solver/_diversity_contribution/test_separation.py
@@ -386,6 +386,7 @@ def test_every_backend_computes_the_same_separations():
 
 
 def test_reset_returns_to_empty_selection(tracker: SeparationTracker):
+    """Reset returns separations to the empty-selection +inf values; the dataset-wide cache stays untouched."""
     # --- arrange -----------------------------------------
     tracker.add(np.int32(0))
     tracker.add(np.int32(2))

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -590,3 +590,114 @@ def test_selected_index_array_is_ascending(new_solver_state_unconstrained):
     indices = new_solver_state_unconstrained.selected_index_array
     assert indices.tolist() == sorted(indices.tolist())
     assert indices.tolist() == [0, 4, 5]
+
+
+# =================================================================================================
+#  Adoption
+# =================================================================================================
+def _adoption_state(diversity_metric: DiversityMetric, diversity_tie_breakers: list[DiversityMetric]) -> SolverState:
+    """Build an 8-point constrained state for adoption tests."""
+    vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0], [15.0], [21.0], [28.0]], dtype=np.float32)
+    return SolverState.new(
+        n=vectors.shape[0],
+        store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
+        k=4,
+        diversity_metric=diversity_metric,
+        diversity_tie_breakers=diversity_tie_breakers,
+        constraints=[
+            Constraint(int_set={0, 1, 2, 3}, min_count=1, max_count=3),
+            Constraint(int_set={4, 5, 6, 7}, min_count=1, max_count=3),
+        ],
+    )
+
+
+def _assert_equivalent_to_fresh(state: SolverState, reference: SolverState) -> None:
+    """Assert `state` is indistinguishable from `reference`, a fresh state holding the same selection."""
+    assert np.array_equal(state.selected_index_array, reference.selected_index_array)
+    assert state.n_selected == reference.n_selected
+    assert np.array_equal(state.con_values, reference.con_values)
+    assert state.score.as_tuple() == pytest.approx(reference.score.as_tuple())
+    np.testing.assert_allclose(state.full_contribution_array, reference.full_contribution_array, rtol=1e-6, atol=1e-6)
+
+
+_METRIC_CONFIGS = [
+    (DiversityMetric.GEOMEAN_SEPARATION, [DiversityMetric.NON_ZERO_SEPARATION_FRAC]),  # separation tracker only
+    (DiversityMetric.MEAN_PAIRWISE_DISTANCE, []),  # mean-distance tracker only
+    (DiversityMetric.MIN_SEPARATION, [DiversityMetric.MEAN_PAIRWISE_DISTANCE]),  # both tracker families
+]
+
+
+@pytest.mark.parametrize("diversity_metric, tie_breakers", _METRIC_CONFIGS)
+@pytest.mark.parametrize(
+    "start, target",
+    [
+        ([0, 2, 4, 6], [0, 2, 4, 7]),  # small diff -> diff route
+        ([0, 1, 2, 3], [4, 5, 6, 7]),  # disjoint -> rebuild route
+        ([], [1, 3, 5, 7]),  # from empty -> diff route (adds only)
+        ([0, 2, 4, 6], []),  # to empty -> rebuild route
+        ([1, 3, 5, 7], [1, 3, 5, 7]),  # identical -> no-op diff
+        ([0, 1, 2], [2, 4, 5, 6, 7]),  # different sizes, low overlap -> rebuild route
+    ],
+)
+def test_adopt_selection_matches_fresh_state(diversity_metric, tie_breakers, start, target):
+    """Adopting a selection must be indistinguishable from having built it directly, on either route."""
+    # --- arrange -----------------------------------------
+    state = _adoption_state(diversity_metric, tie_breakers)
+    state.add_many(np.array(start, dtype=np.int32))
+    reference = _adoption_state(diversity_metric, tie_breakers)
+    reference.add_many(np.array(target, dtype=np.int32))
+
+    # --- act ---------------------------------------------
+    state.adopt_selection(np.array(target, dtype=np.int32))
+
+    # --- assert ------------------------------------------
+    _assert_equivalent_to_fresh(state, reference)
+
+
+def test_adopt_selection_accepts_unordered_input():
+    # --- arrange -----------------------------------------
+    state = _adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
+    reference = _adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
+    reference.add_many(np.array([1, 4, 6], dtype=np.int32))
+
+    # --- act ---------------------------------------------
+    state.adopt_selection(np.array([6, 1, 4], dtype=np.int32))
+
+    # --- assert ------------------------------------------
+    _assert_equivalent_to_fresh(state, reference)
+
+
+def test_adopt_selection_state_remains_fully_usable():
+    """After adoption the state supports mutators and savepoints as usual."""
+    # --- arrange -----------------------------------------
+    state = _adoption_state(DiversityMetric.MIN_SEPARATION, [DiversityMetric.MEAN_PAIRWISE_DISTANCE])
+    state.add_many(np.array([0, 1, 2, 3], dtype=np.int32))
+
+    # --- act ---------------------------------------------
+    state.adopt_selection(np.array([4, 5, 6, 7], dtype=np.int32))  # rebuild route
+    score_after_adopt = state.score.as_tuple()
+    with state.savepoint():
+        state.remove(np.int32(4))
+        state.add(np.int32(0))
+    state.adopt_selection(np.array([4, 5, 6, 0], dtype=np.int32))  # diff route
+
+    # --- assert ------------------------------------------
+    assert score_after_adopt != state.score.as_tuple()
+    assert state.selected_index_array.tolist() == [0, 4, 5, 6]
+
+
+def test_adopt_selection_validation():
+    # --- arrange -----------------------------------------
+    state = _adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
+    state.add_many(np.array([0, 1], dtype=np.int32))
+
+    # --- act & assert ------------------------------------
+    with pytest.raises(ValueError):
+        state.adopt_selection(np.array([1, 1, 2], dtype=np.int32))  # duplicates
+    with pytest.raises(ValueError):
+        state.adopt_selection(np.array([-1, 2], dtype=np.int32))  # negative index
+    with pytest.raises(ValueError):
+        state.adopt_selection(np.array([2, 8], dtype=np.int32))  # index >= n
+    with state.savepoint(), pytest.raises(RuntimeError):
+        state.adopt_selection(np.array([2, 3], dtype=np.int32))  # open savepoint
+    assert state.selected_index_array.tolist() == [0, 1]  # untouched by the rejected calls

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -595,8 +595,10 @@ def test_selected_index_array_is_ascending(new_solver_state_unconstrained):
 # =================================================================================================
 #  Adoption
 # =================================================================================================
-def _adoption_state(diversity_metric: DiversityMetric, diversity_tie_breakers: list[DiversityMetric]) -> SolverState:
-    """Build an 8-point constrained state for adoption tests."""
+def _make_adoption_state(
+    diversity_metric: DiversityMetric, diversity_tie_breakers: list[DiversityMetric]
+) -> SolverState:
+    """Build a small constrained state for adoption tests."""
     vectors = np.array([[0.0], [1.0], [3.0], [6.0], [10.0], [15.0], [21.0], [28.0]], dtype=np.float32)
     return SolverState.new(
         n=vectors.shape[0],
@@ -611,7 +613,7 @@ def _adoption_state(diversity_metric: DiversityMetric, diversity_tie_breakers: l
     )
 
 
-def _assert_equivalent_to_fresh(state: SolverState, reference: SolverState) -> None:
+def _assert_state_matches_reference(state: SolverState, reference: SolverState) -> None:
     """Assert `state` is indistinguishable from `reference`, a fresh state holding the same selection."""
     assert np.array_equal(state.selected_index_array, reference.selected_index_array)
     assert state.n_selected == reference.n_selected
@@ -642,35 +644,36 @@ _METRIC_CONFIGS = [
 def test_adopt_selection_matches_fresh_state(diversity_metric, tie_breakers, start, target):
     """Adopting a selection must be indistinguishable from having built it directly, on either route."""
     # --- arrange -----------------------------------------
-    state = _adoption_state(diversity_metric, tie_breakers)
+    state = _make_adoption_state(diversity_metric, tie_breakers)
     state.add_many(np.array(start, dtype=np.int32))
-    reference = _adoption_state(diversity_metric, tie_breakers)
+    reference = _make_adoption_state(diversity_metric, tie_breakers)
     reference.add_many(np.array(target, dtype=np.int32))
 
     # --- act ---------------------------------------------
     state.adopt_selection(np.array(target, dtype=np.int32))
 
     # --- assert ------------------------------------------
-    _assert_equivalent_to_fresh(state, reference)
+    _assert_state_matches_reference(state, reference)
 
 
 def test_adopt_selection_accepts_unordered_input():
+    """Adoption sorts its input itself; the caller's ordering carries no meaning."""
     # --- arrange -----------------------------------------
-    state = _adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
-    reference = _adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
+    state = _make_adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
+    reference = _make_adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
     reference.add_many(np.array([1, 4, 6], dtype=np.int32))
 
     # --- act ---------------------------------------------
     state.adopt_selection(np.array([6, 1, 4], dtype=np.int32))
 
     # --- assert ------------------------------------------
-    _assert_equivalent_to_fresh(state, reference)
+    _assert_state_matches_reference(state, reference)
 
 
 def test_adopt_selection_state_remains_fully_usable():
     """After adoption the state supports mutators and savepoints as usual."""
     # --- arrange -----------------------------------------
-    state = _adoption_state(DiversityMetric.MIN_SEPARATION, [DiversityMetric.MEAN_PAIRWISE_DISTANCE])
+    state = _make_adoption_state(DiversityMetric.MIN_SEPARATION, [DiversityMetric.MEAN_PAIRWISE_DISTANCE])
     state.add_many(np.array([0, 1, 2, 3], dtype=np.int32))
 
     # --- act ---------------------------------------------
@@ -687,8 +690,9 @@ def test_adopt_selection_state_remains_fully_usable():
 
 
 def test_adopt_selection_validation():
+    """Duplicate, out-of-range, and savepoint-open calls are rejected without touching the state."""
     # --- arrange -----------------------------------------
-    state = _adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
+    state = _make_adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
     state.add_many(np.array([0, 1], dtype=np.int32))
 
     # --- act & assert ------------------------------------

--- a/tests/_core/solver/test_solver_state.py
+++ b/tests/_core/solver/test_solver_state.py
@@ -629,6 +629,34 @@ _METRIC_CONFIGS = [
 ]
 
 
+def test_reset_returns_the_state_to_empty():
+    """A reset state is indistinguishable from a freshly built one, and stays fully usable."""
+    # --- arrange -----------------------------------------
+    state = _make_adoption_state(DiversityMetric.MIN_SEPARATION, [DiversityMetric.MEAN_PAIRWISE_DISTANCE])
+    state.add_many(np.array([0, 2, 4, 6], dtype=np.int32))
+    reference = _make_adoption_state(DiversityMetric.MIN_SEPARATION, [DiversityMetric.MEAN_PAIRWISE_DISTANCE])
+
+    # --- act ---------------------------------------------
+    state.reset()
+
+    # --- assert ------------------------------------------
+    _assert_state_matches_reference(state, reference)
+    state.add(np.int32(1))  # the reset state accepts mutations as usual
+    assert state.selected_index_array.tolist() == [1]
+
+
+def test_reset_inside_a_savepoint_is_rejected():
+    """A reset cannot be provisional, so an open savepoint rejects it."""
+    # --- arrange -----------------------------------------
+    state = _make_adoption_state(DiversityMetric.GEOMEAN_SEPARATION, [])
+    state.add_many(np.array([0, 1], dtype=np.int32))
+
+    # --- act & assert ------------------------------------
+    with state.savepoint(), pytest.raises(RuntimeError):
+        state.reset()
+    assert state.selected_index_array.tolist() == [0, 1]
+
+
 @pytest.mark.parametrize("diversity_metric, tie_breakers", _METRIC_CONFIGS)
 @pytest.mark.parametrize(
     "start, target",


### PR DESCRIPTION
**TL;DR**: `SolverState` can now **adopt a selection produced elsewhere** — replacing its current selection while bringing every piece of incremental bookkeeping (contribution trackers, constraint counters, score) along, as if the selection had been built natively.

## Description

### Problem addressed

Groundwork for **cooperative parallel solving**, where a worker periodically installs the best selection found by a sibling worker. `SolverState` only mutates incrementally (`add`/`remove` and their bulk variants); it had no way to take over a full selection. The naive route — rebuilding all tracker state from scratch — is expensive on the lazy distance backend, where every tracker update computes distances on the fly rather than reading precomputed ones.

### Implementation

- **`SolverState.adopt_selection`** diffs the incoming selection against the current one and applies the difference through the existing `remove_many`/`add_many` seams — typically a handful of tracker updates when the two selections mostly overlap.
- **Rebuild fallback**: when the diff would cost more mutator calls than starting over (selections barely overlap), the state resets to the empty selection and bulk-adds the new one. Which route ran is unobservable from the outside.
- **`reset()` on the diversity-contribution trackers** supports that fallback: separations return to their empty-selection `+inf` values, distance sums to zero — an O(n) fill with no distance computations. The lazily filled dataset-wide contribution caches are selection-independent and survive untouched.
- Adoption is **barred while a savepoint is open** (`RuntimeError`): the snapshot stack could otherwise restore state inconsistent with the adopted selection.

## Attention points

- **Route threshold**: the diff route is taken when `|to_remove| + |to_add| <= |new selection|`, i.e. rebuild wins only when the selections barely overlap. Both routes are exercised by the same equivalence tests, so the threshold can be retuned freely.
- **Input contract**: duplicate indices and out-of-range indices raise `ValueError` before any mutation, so a rejected call leaves the state untouched.

## Tests / Spikes

- **TEST:** adoption equivalence — an adopted state is asserted indistinguishable (selection, constraint counters, score, contribution arrays) from a state that built the same selection directly; parametrized over 3 metric configurations (separation-only, mean-distance-only, both tracker families) × 6 selection transitions covering both routes, including empty-to-full and full-to-empty edges.
- **TEST:** post-adoption usability — mutators and savepoints keep working after adoption on either route.
- **TEST:** validation — duplicates, out-of-range indices, and adoption inside an open savepoint are rejected without side effects.
- **TEST:** tracker `reset()` — both tracker families return to empty-selection values with the dataset-wide cache untouched.
- 5 test functions (23 parametrized cases) added; full suite passes (3965 tests).

## Changelog entry

None: internal groundwork with no user-facing change (`chore/` PR).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
