### PR TITLE
chore: add the group incumbent slot and cooperative coordinator

### DIFF
--- a/src/max_div/_core/solver/_parallel/__init__.py
+++ b/src/max_div/_core/solver/_parallel/__init__.py
@@ -5,15 +5,18 @@ the objective does not, because comparing what they found needs one answer to wh
 better.
 """
 
-from ._coordinator import IndependentCoordinator, WorkerCoordinator
+from ._coordinator import CooperativeCoordinator, IndependentCoordinator, WorkerCoordinator
 from ._executor import run_portfolio, solve_in_worker
+from ._incumbent_slot import IslandIncumbentSlot
 from ._result import WorkerResult, best_result
 from ._solution import ParallelMaxDivSolution, WorkerSummary
 from ._solver import ParallelMaxDivSolver, default_worker_count, warn_about_worker_count
 from ._worker_config import WorkerConfig
 
 __all__ = [
+    "CooperativeCoordinator",
     "IndependentCoordinator",
+    "IslandIncumbentSlot",
     "ParallelMaxDivSolution",
     "ParallelMaxDivSolver",
     "WorkerConfig",

--- a/src/max_div/_core/solver/_parallel/__init__.py
+++ b/src/max_div/_core/solver/_parallel/__init__.py
@@ -7,7 +7,7 @@ better.
 
 from ._coordinator import CooperativeCoordinator, IndependentCoordinator, WorkerCoordinator
 from ._executor import run_portfolio, solve_in_worker
-from ._incumbent_slot import IslandIncumbentSlot
+from ._incumbent_slot import GroupIncumbentSlot
 from ._result import WorkerResult, best_result
 from ._solution import ParallelMaxDivSolution, WorkerSummary
 from ._solver import ParallelMaxDivSolver, default_worker_count, warn_about_worker_count
@@ -15,8 +15,8 @@ from ._worker_config import WorkerConfig
 
 __all__ = [
     "CooperativeCoordinator",
+    "GroupIncumbentSlot",
     "IndependentCoordinator",
-    "IslandIncumbentSlot",
     "ParallelMaxDivSolution",
     "ParallelMaxDivSolver",
     "WorkerConfig",

--- a/src/max_div/_core/solver/_parallel/_coordinator.py
+++ b/src/max_div/_core/solver/_parallel/_coordinator.py
@@ -1,12 +1,14 @@
 """A worker calls its coordinator at every batch boundary.
 
-Independent workers do nothing there; the call exists so cooperative parallelism can reuse this
-path rather than add one.
+Independent workers do nothing there; cooperative workers exchange their selection with the
+island's shared incumbent slot.
 """
 
 from abc import ABC, abstractmethod
 
 from max_div._core.solver._solver_state import SolverState
+
+from ._incumbent_slot import IslandIncumbentSlot
 
 
 class WorkerCoordinator(ABC):
@@ -25,3 +27,21 @@ class IndependentCoordinator(WorkerCoordinator):
 
     def at_batch_boundary(self, state: SolverState) -> None:
         """Do nothing: an independent worker has nobody to tell and nothing to ask."""
+
+
+class CooperativeCoordinator(WorkerCoordinator):
+    """The members of one island hold this coordinator, all bound to the island's shared slot."""
+
+    def __init__(self, slot: IslandIncumbentSlot) -> None:
+        """Bind the coordinator to its island's incumbent slot."""
+        self._slot = slot
+
+    def at_batch_boundary(self, state: SolverState) -> None:
+        """Publish this worker's selection if it is the island's best, else adopt a strictly better one.
+
+        The slot visit is a single lock acquisition; the adoption — the expensive part — runs
+        after the lock is released, on a copy the slot handed back.
+        """
+        incoming = self._slot.exchange(state.score.as_tuple(), state.selected_index_array)
+        if incoming is not None:
+            state.adopt_selection(incoming)

--- a/src/max_div/_core/solver/_parallel/_coordinator.py
+++ b/src/max_div/_core/solver/_parallel/_coordinator.py
@@ -1,14 +1,23 @@
-"""A worker calls its coordinator at every batch boundary.
+"""A worker calls its coordinator at every batch boundary; this module is the topology reference.
 
-Independent workers do nothing there; cooperative workers exchange their selection with the
-island's shared incumbent slot.
+How the pieces connect, in every setup:
+
+- **One coordinator per worker**, handed to the worker process at spawn.  Workers never talk to
+  each other directly; a coordinator is their only sideways channel.
+- **Independent workers** hold the no-op `IndependentCoordinator`.
+- **A worker group's members** each hold a `CooperativeCoordinator` bound to the group's one
+  `GroupIncumbentSlot`; groups never share slots, so no information crosses group boundaries.
+- **Progress reporting is a separate channel entirely** — the one-way queue from workers to the
+  parent (see `_progress_channel`).  Coordinators carry search information sideways between a
+  group's workers and never progress; the queue carries progress up to the parent and never
+  search information.
 """
 
 from abc import ABC, abstractmethod
 
 from max_div._core.solver._solver_state import SolverState
 
-from ._incumbent_slot import IslandIncumbentSlot
+from ._incumbent_slot import GroupIncumbentSlot
 
 
 class WorkerCoordinator(ABC):
@@ -30,14 +39,14 @@ class IndependentCoordinator(WorkerCoordinator):
 
 
 class CooperativeCoordinator(WorkerCoordinator):
-    """The members of one island hold this coordinator, all bound to the island's shared slot."""
+    """The members of one worker group hold this coordinator, all bound to the group's shared slot."""
 
-    def __init__(self, slot: IslandIncumbentSlot) -> None:
-        """Bind the coordinator to its island's incumbent slot."""
+    def __init__(self, slot: GroupIncumbentSlot) -> None:
+        """Bind the coordinator to its worker group's incumbent slot."""
         self._slot = slot
 
     def at_batch_boundary(self, state: SolverState) -> None:
-        """Publish this worker's selection if it is the island's best, else adopt a strictly better one.
+        """Publish this worker's selection if it is the group's best, else adopt a strictly better one.
 
         The slot visit is a single lock acquisition; the adoption — the expensive part — runs
         after the lock is released, on a copy the slot handed back.

--- a/src/max_div/_core/solver/_parallel/_executor.py
+++ b/src/max_div/_core/solver/_parallel/_executor.py
@@ -44,7 +44,7 @@ _JOIN_SECONDS = 30.0
 def run_portfolio(
     configs: list[SolverConfig],
     spec: SharedStoreSpec,
-    coordinator: WorkerCoordinator,
+    coordinators: Sequence[WorkerCoordinator],
     progress_reporter: ProgressReporter | None = None,
 ) -> list[WorkerResult]:
     """Solve one configuration per worker over the published store, and return what each reported.
@@ -55,10 +55,14 @@ def run_portfolio(
 
     :param configs: one solver configuration per worker, in worker order.
     :param spec: where the published store lives; every worker attaches to it.
-    :param coordinator: reached by every worker at each batch boundary; an independent one shares nothing.
+    :param coordinators: one coordinator per worker, in worker order — island members share one
+                         bound to their island's slot, independent workers each get a no-op one.
     :param progress_reporter: renders the workers' combined progress from this (parent) process; a
                               reporter that renders nothing — or `None` — turns all forwarding off.
+    :raises ValueError: If the coordinator count does not match the worker count.
     """
+    if len(coordinators) != len(configs):
+        raise ValueError(f"Expected one coordinator per worker: got {len(coordinators)} for {len(configs)} workers.")
     requirements = progress_reporter.snapshot_requirements if (progress_reporter is not None) else None
     view = ParallelProgressView(progress_reporter, len(configs)) if (requirements is not None) else None  # ty: ignore[invalid-argument-type]  # requirements imply a reporter
 
@@ -66,7 +70,9 @@ def run_portfolio(
     messages: Queue = context.Queue()
     workers = [
         context.Process(
-            target=solve_in_worker, args=(index, config, spec, coordinator, messages, requirements), daemon=True
+            target=solve_in_worker,
+            args=(index, config, spec, coordinators[index], messages, requirements),
+            daemon=True,
         )
         for index, config in enumerate(configs)
     ]

--- a/src/max_div/_core/solver/_parallel/_executor.py
+++ b/src/max_div/_core/solver/_parallel/_executor.py
@@ -55,8 +55,8 @@ def run_portfolio(
 
     :param configs: one solver configuration per worker, in worker order.
     :param spec: where the published store lives; every worker attaches to it.
-    :param coordinators: one coordinator per worker, in worker order — island members share one
-                         bound to their island's slot, independent workers each get a no-op one.
+    :param coordinators: one coordinator per worker, in worker order; `_coordinator` documents
+                         the topology this list wires up.
     :param progress_reporter: renders the workers' combined progress from this (parent) process; a
                               reporter that renders nothing — or `None` — turns all forwarding off.
     :raises ValueError: If the coordinator count does not match the worker count.

--- a/src/max_div/_core/solver/_parallel/_incumbent_slot.py
+++ b/src/max_div/_core/solver/_parallel/_incumbent_slot.py
@@ -1,7 +1,8 @@
 """The incumbent slot holds one island's shared best: the top-scoring selection published so far.
 
-The slot lives in shared memory created by the parent process and inherited by every island
-member at spawn, like the shared distance store.  Everything in it is fixed-size, so it fits raw
+An island is a group of workers that exchange selections through one shared slot.  The slot lives
+in shared memory created by the parent process and inherited by every island member at spawn,
+like the shared distance store.  Everything in the slot is fixed-size, so it fits raw
 shared-memory arrays:
 
 - the score, as a float64 vector;
@@ -24,7 +25,7 @@ if TYPE_CHECKING:
 
 
 class IslandIncumbentSlot:
-    """The slot holds one island's shared best selection; every exchange happens under a single lock.
+    """The slot holds one island's shared best selection.
 
     Score tuples are compared lexicographically, exactly as `Score.as_tuple()` orders them, so
     "better" means the same thing here as in the final best-of-all selection.
@@ -48,8 +49,7 @@ class IslandIncumbentSlot:
     def exchange(self, score: tuple[float, ...], selection: NDArray[np.int32]) -> NDArray[np.int32] | None:
         """Publish the given selection if it is strictly the island's best, else return a better one.
 
-        The exchange is one atomic visit under the slot lock; the worker comes away with whichever
-        of the two selections scores strictly higher:
+        The exchange is one atomic visit under the slot lock:
 
         - the worker's beats the stored one (or the slot was never written): the worker's is
           stored, and None is returned — the worker keeps what it has;

--- a/src/max_div/_core/solver/_parallel/_incumbent_slot.py
+++ b/src/max_div/_core/solver/_parallel/_incumbent_slot.py
@@ -1,0 +1,74 @@
+"""One shared incumbent per island: the best selection any island member has published so far.
+
+The slot lives in shared memory created by the parent process and inherited by every island
+member at spawn, like the shared distance store.  Everything in it is fixed-size, so it fits raw
+shared-memory arrays: the score as a float64 vector (its length is a property of the shared
+metric configuration, so it is identical across an island's workers), the selection as an int32
+vector of up to k indices.  A version counter distinguishes a never-written slot from a written
+one and lets tests observe that exchanges happened.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from multiprocessing.context import BaseContext
+
+    from numpy.typing import NDArray
+
+
+class IslandIncumbentSlot:
+    """The shared best-selection slot of one island, exchanged through under a single lock.
+
+    Score tuples are compared lexicographically, exactly as `Score.as_tuple()` orders them, so
+    "better" means the same thing here as in the final best-of-all selection.
+    """
+
+    def __init__(self, context: BaseContext, k: int, score_length: int) -> None:
+        """Allocate the shared-memory fields; call in the parent, before workers spawn.
+
+        :param context: (BaseContext) the multiprocessing context the workers spawn from.
+        :param k: (int) maximum selection size the slot can hold.
+        :param score_length: (int) number of components in the workers' score tuples.
+        """
+        self._lock = context.Lock()
+        self._version = context.Value("q", 0, lock=False)
+        self._score = context.Array("d", score_length, lock=False)
+        self._selection = context.Array("i", k, lock=False)
+        self._n_selected = context.Value("i", 0, lock=False)
+
+    def exchange(self, score: tuple[float, ...], selection: NDArray[np.int32]) -> NDArray[np.int32] | None:
+        """Publish the given selection if it is strictly the island's best, else return a better one.
+
+        One atomic visit under the slot lock, from which a worker comes away with whichever of the
+        two selections scores strictly higher:
+
+        - the worker's beats the stored one (or the slot was never written): the worker's is
+          stored, and None is returned — the worker keeps what it has;
+        - the stored one beats the worker's: a copy of the stored selection is returned for the
+          worker to adopt;
+        - equal scores: nothing is stored and None is returned.
+
+        :param score: (tuple[float, ...]) the worker's current score, as `Score.as_tuple()` orders it.
+        :param selection: (int32 ndarray) the worker's current selection.
+        :returns: the stored selection to adopt, or None to keep the worker's own.
+        """
+        with self._lock:
+            if self._version.value == 0 or score > tuple(self._score):
+                self._score[:] = score
+                self._selection[: len(selection)] = selection
+                self._n_selected.value = len(selection)
+                self._version.value += 1
+                return None
+            if tuple(self._score) > score:
+                return np.array(self._selection[: self._n_selected.value], dtype=np.int32)
+            return None
+
+    @property
+    def version(self) -> int:
+        """Return how often a selection was stored; 0 means the slot was never written."""
+        with self._lock:
+            return self._version.value

--- a/src/max_div/_core/solver/_parallel/_incumbent_slot.py
+++ b/src/max_div/_core/solver/_parallel/_incumbent_slot.py
@@ -1,15 +1,12 @@
-"""The incumbent slot holds one island's shared best: the top-scoring selection published so far.
+"""The incumbent slot holds one worker group's shared best: the top-scoring selection published so far.
 
-An island is a group of workers that exchange selections through one shared slot.  The slot lives
-in shared memory created by the parent process and inherited by every island member at spawn,
-like the shared distance store.  Everything in the slot is fixed-size, so it fits raw
-shared-memory arrays:
+A worker group — what the parallel-metaheuristics literature calls an *island* — is a set of
+workers that exchange selections through one shared slot.  The slot lives in shared memory
+created by the parent process and inherited by every group member at spawn, like the shared
+distance store.  Everything in the slot is fixed-size, so it fits raw shared-memory arrays:
 
 - the score, as a float64 vector;
 - the selection, as an int32 vector of up to k indices.
-
-A version counter distinguishes a never-written slot from a written one and lets tests observe
-that exchanges happened.
 """
 
 from __future__ import annotations
@@ -24,8 +21,8 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 
-class IslandIncumbentSlot:
-    """The slot holds one island's shared best selection.
+class GroupIncumbentSlot:
+    """The slot holds one worker group's shared best selection.
 
     Score tuples are compared lexicographically, exactly as `Score.as_tuple()` orders them, so
     "better" means the same thing here as in the final best-of-all selection.
@@ -37,17 +34,19 @@ class IslandIncumbentSlot:
         :param context: (BaseContext) the multiprocessing context the workers spawn from.
         :param k: (int) maximum selection size the slot can hold.
         :param score_length: (int) number of components in the workers' score tuples — a property
-                             of the shared metric configuration, so identical across an island's
-                             workers.
+                             of the shared metric configuration, so identical across a worker
+                             group's workers.
         """
         self._lock = context.Lock()
-        self._version = context.Value("q", 0, lock=False)
+        # False until the first publish: an all-zero score array is a legal real score, so the
+        # never-written state needs its own flag rather than a sentinel score
+        self._written = context.Value("b", 0, lock=False)
         self._score = context.Array("d", score_length, lock=False)
         self._selection = context.Array("i", k, lock=False)
         self._n_selected = context.Value("i", 0, lock=False)
 
     def exchange(self, score: tuple[float, ...], selection: NDArray[np.int32]) -> NDArray[np.int32] | None:
-        """Publish the given selection if it is strictly the island's best, else return a better one.
+        """Publish the given selection if it is strictly the group's best, else return a better one.
 
         The exchange is one atomic visit under the slot lock:
 
@@ -62,18 +61,18 @@ class IslandIncumbentSlot:
         :returns: the stored selection to adopt, or None to keep the worker's own.
         """
         with self._lock:
-            if self._version.value == 0 or score > tuple(self._score):
+            if not self._written.value or score > tuple(self._score):
                 self._score[:] = score
                 self._selection[: len(selection)] = selection
                 self._n_selected.value = len(selection)
-                self._version.value += 1
+                self._written.value = True
                 return None
             if tuple(self._score) > score:
                 return np.array(self._selection[: self._n_selected.value], dtype=np.int32)
             return None
 
     @property
-    def version(self) -> int:
-        """Return how often a selection was stored; 0 means the slot was never written."""
+    def written(self) -> bool:
+        """Return whether any selection was ever stored."""
         with self._lock:
-            return self._version.value
+            return bool(self._written.value)

--- a/src/max_div/_core/solver/_parallel/_incumbent_slot.py
+++ b/src/max_div/_core/solver/_parallel/_incumbent_slot.py
@@ -1,11 +1,14 @@
-"""One shared incumbent per island: the best selection any island member has published so far.
+"""The incumbent slot holds one island's shared best: the top-scoring selection published so far.
 
 The slot lives in shared memory created by the parent process and inherited by every island
 member at spawn, like the shared distance store.  Everything in it is fixed-size, so it fits raw
-shared-memory arrays: the score as a float64 vector (its length is a property of the shared
-metric configuration, so it is identical across an island's workers), the selection as an int32
-vector of up to k indices.  A version counter distinguishes a never-written slot from a written
-one and lets tests observe that exchanges happened.
+shared-memory arrays:
+
+- the score, as a float64 vector;
+- the selection, as an int32 vector of up to k indices.
+
+A version counter distinguishes a never-written slot from a written one and lets tests observe
+that exchanges happened.
 """
 
 from __future__ import annotations
@@ -21,7 +24,7 @@ if TYPE_CHECKING:
 
 
 class IslandIncumbentSlot:
-    """The shared best-selection slot of one island, exchanged through under a single lock.
+    """The slot holds one island's shared best selection; every exchange happens under a single lock.
 
     Score tuples are compared lexicographically, exactly as `Score.as_tuple()` orders them, so
     "better" means the same thing here as in the final best-of-all selection.
@@ -32,7 +35,9 @@ class IslandIncumbentSlot:
 
         :param context: (BaseContext) the multiprocessing context the workers spawn from.
         :param k: (int) maximum selection size the slot can hold.
-        :param score_length: (int) number of components in the workers' score tuples.
+        :param score_length: (int) number of components in the workers' score tuples — a property
+                             of the shared metric configuration, so identical across an island's
+                             workers.
         """
         self._lock = context.Lock()
         self._version = context.Value("q", 0, lock=False)
@@ -43,8 +48,8 @@ class IslandIncumbentSlot:
     def exchange(self, score: tuple[float, ...], selection: NDArray[np.int32]) -> NDArray[np.int32] | None:
         """Publish the given selection if it is strictly the island's best, else return a better one.
 
-        One atomic visit under the slot lock, from which a worker comes away with whichever of the
-        two selections scores strictly higher:
+        The exchange is one atomic visit under the slot lock; the worker comes away with whichever
+        of the two selections scores strictly higher:
 
         - the worker's beats the stored one (or the slot was never written): the worker's is
           stored, and None is returned — the worker keeps what it has;

--- a/src/max_div/_core/solver/_parallel/_solver.py
+++ b/src/max_div/_core/solver/_parallel/_solver.py
@@ -65,7 +65,7 @@ class ParallelMaxDivSolver:
             results = run_portfolio(
                 self._solver_configs,
                 shared_distance_store.spec,
-                IndependentCoordinator(),
+                [IndependentCoordinator() for _ in self._solver_configs],
                 progress_reporter=progress_reporter,
             )
         winner = best_result(results)

--- a/tests/_core/solver/_parallel/test_coordinator.py
+++ b/tests/_core/solver/_parallel/test_coordinator.py
@@ -1,9 +1,18 @@
+import multiprocessing
+
 import numpy as np
 
+from max_div._core.metrics import DistanceMetric, DiversityMetric
+from max_div._core.metrics._distance import DistanceStore, compute_pdist
 from max_div._core.problem import MaxDivProblem
 from max_div._core.solver._builders import MaxDivSolverBuilder
 from max_div._core.solver._duration import iterations
-from max_div._core.solver._parallel import IndependentCoordinator, WorkerCoordinator
+from max_div._core.solver._parallel import (
+    CooperativeCoordinator,
+    IndependentCoordinator,
+    IslandIncumbentSlot,
+    WorkerCoordinator,
+)
 from max_div._core.solver._presets import SolverPreset
 from max_div._core.solver._progress_reporting import Verbosity
 from max_div._core.solver._solver_state import SolverState
@@ -51,3 +60,70 @@ def test_a_coordinator_does_not_change_the_search():
 
     # --- assert ------------------------------------------
     np.testing.assert_array_equal(np.sort(with_coordinator.i_selected), np.sort(without.i_selected))
+
+
+def _cooperation_state(indices: list[int]) -> SolverState:
+    """Build a solver state over a fixed line of points, holding the given selection."""
+    vectors = np.array([[0.0], [1.0], [2.0], [10.0], [20.0], [30.0]], dtype=np.float32)
+    state = SolverState.new(
+        n=vectors.shape[0],
+        store=DistanceStore.condensed(compute_pdist(vectors, DistanceMetric.L1_MANHATTAN), n=vectors.shape[0]),
+        k=3,
+        diversity_metric=DiversityMetric.MIN_SEPARATION,
+        diversity_tie_breakers=[],
+        constraints=[],
+    )
+    state.add_many(np.array(indices, dtype=np.int32))
+    return state
+
+
+def test_cooperative_coordinator_moves_the_best_selection_between_states():
+    """The better state's boundary publishes its selection; the worse state's boundary adopts it."""
+    # --- arrange -----------------------------------------
+    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=3, score_length=3)
+    coordinator = CooperativeCoordinator(slot)
+    spread_out = _cooperation_state([0, 3, 5])  # min separation 10
+    clustered = _cooperation_state([0, 1, 2])  # min separation 1
+
+    # --- act ---------------------------------------------
+    coordinator.at_batch_boundary(spread_out)
+    coordinator.at_batch_boundary(clustered)
+
+    # --- assert ------------------------------------------
+    assert clustered.selected_index_array.tolist() == [0, 3, 5]  # adopted the published incumbent
+    assert spread_out.selected_index_array.tolist() == [0, 3, 5]  # publisher keeps its own
+    assert slot.version == 1
+
+
+def test_cooperative_coordinator_keeps_the_better_state_untouched():
+    """A boundary where the worker already matches or beats the slot adopts nothing and stores nothing new."""
+    # --- arrange -----------------------------------------
+    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=3, score_length=3)
+    coordinator = CooperativeCoordinator(slot)
+    clustered = _cooperation_state([0, 1, 2])
+    spread_out = _cooperation_state([0, 3, 5])
+
+    # --- act ---------------------------------------------
+    coordinator.at_batch_boundary(clustered)  # publishes (empty slot)
+    coordinator.at_batch_boundary(spread_out)  # better: replaces the stored incumbent
+    coordinator.at_batch_boundary(spread_out)  # equal to the slot now: nothing happens
+
+    # --- assert ------------------------------------------
+    assert spread_out.selected_index_array.tolist() == [0, 3, 5]
+    assert slot.version == 2
+
+
+def test_a_lone_cooperative_worker_searches_exactly_as_if_alone():
+    """With nobody else publishing, a cooperative worker only ever publishes — the search is unchanged."""
+    # --- arrange -----------------------------------------
+    builder = MaxDivSolverBuilder(MaxDivProblem.new(np.random.default_rng(4).random((50, 3)).astype(np.float32), k=5))
+    n_score_components = 3 + len(builder._determine_diversity_tie_breakers())
+    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=5, score_length=n_score_components)
+
+    # --- act ---------------------------------------------
+    cooperative = _solve_with(CooperativeCoordinator(slot))
+    alone = _solve_with(None)
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(np.sort(cooperative.i_selected), np.sort(alone.i_selected))
+    assert slot.version >= 1  # the worker did publish along the way

--- a/tests/_core/solver/_parallel/test_coordinator.py
+++ b/tests/_core/solver/_parallel/test_coordinator.py
@@ -96,7 +96,7 @@ def test_cooperative_coordinator_moves_the_best_selection_between_states():
 
 
 def test_cooperative_coordinator_keeps_the_better_state_untouched():
-    """A boundary where the worker already matches or beats the slot adopts nothing and stores nothing new."""
+    """A worker that beats the slot publishes without adopting; one that matches it leaves the slot untouched."""
     # --- arrange -----------------------------------------
     slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=3, score_length=3)
     coordinator = CooperativeCoordinator(slot)

--- a/tests/_core/solver/_parallel/test_coordinator.py
+++ b/tests/_core/solver/_parallel/test_coordinator.py
@@ -9,8 +9,8 @@ from max_div._core.solver._builders import MaxDivSolverBuilder
 from max_div._core.solver._duration import iterations
 from max_div._core.solver._parallel import (
     CooperativeCoordinator,
+    GroupIncumbentSlot,
     IndependentCoordinator,
-    IslandIncumbentSlot,
     WorkerCoordinator,
 )
 from max_div._core.solver._presets import SolverPreset
@@ -80,7 +80,7 @@ def _cooperation_state(indices: list[int]) -> SolverState:
 def test_cooperative_coordinator_moves_the_best_selection_between_states():
     """The better state's boundary publishes its selection; the worse state's boundary adopts it."""
     # --- arrange -----------------------------------------
-    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=3, score_length=3)
+    slot = GroupIncumbentSlot(multiprocessing.get_context("spawn"), k=3, score_length=3)
     coordinator = CooperativeCoordinator(slot)
     spread_out = _cooperation_state([0, 3, 5])  # min separation 10
     clustered = _cooperation_state([0, 1, 2])  # min separation 1
@@ -92,13 +92,12 @@ def test_cooperative_coordinator_moves_the_best_selection_between_states():
     # --- assert ------------------------------------------
     assert clustered.selected_index_array.tolist() == [0, 3, 5]  # adopted the published incumbent
     assert spread_out.selected_index_array.tolist() == [0, 3, 5]  # publisher keeps its own
-    assert slot.version == 1
 
 
 def test_cooperative_coordinator_keeps_the_better_state_untouched():
     """A worker that beats the slot publishes without adopting; one that matches it leaves the slot untouched."""
     # --- arrange -----------------------------------------
-    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=3, score_length=3)
+    slot = GroupIncumbentSlot(multiprocessing.get_context("spawn"), k=3, score_length=3)
     coordinator = CooperativeCoordinator(slot)
     clustered = _cooperation_state([0, 1, 2])
     spread_out = _cooperation_state([0, 3, 5])
@@ -110,7 +109,9 @@ def test_cooperative_coordinator_keeps_the_better_state_untouched():
 
     # --- assert ------------------------------------------
     assert spread_out.selected_index_array.tolist() == [0, 3, 5]
-    assert slot.version == 2
+    late_arrival = _cooperation_state([0, 1, 2])  # a worse state adopting proves the replacement stored
+    coordinator.at_batch_boundary(late_arrival)
+    assert late_arrival.selected_index_array.tolist() == [0, 3, 5]
 
 
 def test_a_lone_cooperative_worker_searches_exactly_as_if_alone():
@@ -118,7 +119,7 @@ def test_a_lone_cooperative_worker_searches_exactly_as_if_alone():
     # --- arrange -----------------------------------------
     builder = MaxDivSolverBuilder(MaxDivProblem.new(np.random.default_rng(4).random((50, 3)).astype(np.float32), k=5))
     n_score_components = 3 + len(builder._determine_diversity_tie_breakers())
-    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=5, score_length=n_score_components)
+    slot = GroupIncumbentSlot(multiprocessing.get_context("spawn"), k=5, score_length=n_score_components)
 
     # --- act ---------------------------------------------
     cooperative = _solve_with(CooperativeCoordinator(slot))
@@ -126,4 +127,4 @@ def test_a_lone_cooperative_worker_searches_exactly_as_if_alone():
 
     # --- assert ------------------------------------------
     np.testing.assert_array_equal(np.sort(cooperative.i_selected), np.sort(alone.i_selected))
-    assert slot.version >= 1  # the worker did publish along the way
+    assert slot.written  # the worker did publish along the way

--- a/tests/_core/solver/_parallel/test_executor.py
+++ b/tests/_core/solver/_parallel/test_executor.py
@@ -10,8 +10,8 @@ from max_div._core.solver._distance_storage import build_shared_distance_store
 from max_div._core.solver._duration import iterations
 from max_div._core.solver._parallel import (
     CooperativeCoordinator,
+    GroupIncumbentSlot,
     IndependentCoordinator,
-    IslandIncumbentSlot,
     best_result,
     run_portfolio,
 )
@@ -98,13 +98,13 @@ def test_one_coordinator_per_worker_is_required():
         run_portfolio([config.with_seed(1), config.with_seed(2)], shared.spec, [IndependentCoordinator()])
 
 
-def test_an_island_of_cooperative_workers_solves_and_exchanges():
-    """Spawned workers sharing one incumbent slot all report results, and the slot saw traffic."""
+def test_a_group_of_cooperative_workers_solves_and_exchanges():
+    """Spawned workers sharing one incumbent slot all report results, and the slot was published to."""
     # --- arrange -----------------------------------------
     builder = _builder()
     resolved, config = builder.prepare_storage_and_config()
     n_score_components = 3 + len(config.diversity_tie_breakers)
-    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=builder._k, score_length=n_score_components)
+    slot = GroupIncumbentSlot(multiprocessing.get_context("spawn"), k=builder._k, score_length=n_score_components)
     coordinators = [CooperativeCoordinator(slot) for _ in _SEEDS]
 
     # --- act ---------------------------------------------
@@ -114,7 +114,7 @@ def test_an_island_of_cooperative_workers_solves_and_exchanges():
     # --- assert ------------------------------------------
     assert len(results) == len(_SEEDS)
     assert all(result.i_selected.size == builder._k for result in results)
-    assert slot.version >= 1  # at least the first boundary reached published into the empty slot
+    assert slot.written  # at least the first boundary reached published into the empty slot
 
 
 def test_portfolio_renders_coherent_progress(capsys):

--- a/tests/_core/solver/_parallel/test_executor.py
+++ b/tests/_core/solver/_parallel/test_executor.py
@@ -1,3 +1,4 @@
+import multiprocessing
 import queue
 
 import numpy as np
@@ -7,7 +8,13 @@ from max_div._core.problem import MaxDivProblem
 from max_div._core.solver._builders import MaxDivSolverBuilder
 from max_div._core.solver._distance_storage import build_shared_distance_store
 from max_div._core.solver._duration import iterations
-from max_div._core.solver._parallel import IndependentCoordinator, best_result, run_portfolio
+from max_div._core.solver._parallel import (
+    CooperativeCoordinator,
+    IndependentCoordinator,
+    IslandIncumbentSlot,
+    best_result,
+    run_portfolio,
+)
 from max_div._core.solver._parallel._executor import _drain, _notice_dead_workers, solve_in_worker
 from max_div._core.solver._parallel._progress_view import ParallelProgressView
 from max_div._core.solver._parallel._result import WorkerResult
@@ -30,7 +37,12 @@ def portfolio_results():
     builder = _builder()
     resolved, config = builder.prepare_storage_and_config()
     with build_shared_distance_store(builder._problem, resolved) as shared:
-        yield builder, run_portfolio([config.with_seed(seed) for seed in _SEEDS], shared.spec, IndependentCoordinator())
+        yield (
+            builder,
+            run_portfolio(
+                [config.with_seed(seed) for seed in _SEEDS], shared.spec, [IndependentCoordinator() for _ in _SEEDS]
+            ),
+        )
 
 
 def test_every_worker_reports_a_result(portfolio_results):
@@ -75,6 +87,36 @@ def test_the_best_reported_result_wins(portfolio_results):
     assert winner.score == max(result.score for result in results)
 
 
+def test_one_coordinator_per_worker_is_required():
+    """A coordinator count that does not match the worker count is rejected before any worker spawns."""
+    # --- arrange -----------------------------------------
+    builder = _builder()
+    resolved, config = builder.prepare_storage_and_config()
+
+    # --- act & assert ------------------------------------
+    with build_shared_distance_store(builder._problem, resolved) as shared, pytest.raises(ValueError):
+        run_portfolio([config.with_seed(1), config.with_seed(2)], shared.spec, [IndependentCoordinator()])
+
+
+def test_an_island_of_cooperative_workers_solves_and_exchanges():
+    """Spawned workers sharing one incumbent slot all report results, and the slot saw traffic."""
+    # --- arrange -----------------------------------------
+    builder = _builder()
+    resolved, config = builder.prepare_storage_and_config()
+    n_score_components = 3 + len(config.diversity_tie_breakers)
+    slot = IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=builder._k, score_length=n_score_components)
+    coordinators = [CooperativeCoordinator(slot) for _ in _SEEDS]
+
+    # --- act ---------------------------------------------
+    with build_shared_distance_store(builder._problem, resolved) as shared:
+        results = run_portfolio([config.with_seed(seed) for seed in _SEEDS], shared.spec, coordinators)
+
+    # --- assert ------------------------------------------
+    assert len(results) == len(_SEEDS)
+    assert all(result.i_selected.size == builder._k for result in results)
+    assert slot.version >= 1  # at least the first boundary reached published into the empty slot
+
+
 def test_portfolio_renders_coherent_progress(capsys):
     """A rendered portfolio prints one non-interleaved table and still collects every result."""
     # --- arrange -----------------------------------------
@@ -87,7 +129,7 @@ def test_portfolio_renders_coherent_progress(capsys):
         results = run_portfolio(
             [config.with_seed(seed) for seed in _SEEDS],
             shared.spec,
-            IndependentCoordinator(),
+            [IndependentCoordinator() for _ in _SEEDS],
             progress_reporter=reporter,
         )
 

--- a/tests/_core/solver/_parallel/test_incumbent_slot.py
+++ b/tests/_core/solver/_parallel/test_incumbent_slot.py
@@ -3,16 +3,16 @@ import multiprocessing
 import numpy as np
 import pytest
 
-from max_div._core.solver._parallel import IslandIncumbentSlot
+from max_div._core.solver._parallel import GroupIncumbentSlot
 
 
 # =================================================================================================
 #  Fixtures / helpers
 # =================================================================================================
 @pytest.fixture
-def slot() -> IslandIncumbentSlot:
+def slot() -> GroupIncumbentSlot:
     """Return a fresh, never-written slot."""
-    return IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=4, score_length=3)
+    return GroupIncumbentSlot(multiprocessing.get_context("spawn"), k=4, score_length=3)
 
 
 def _selection(*indices: int) -> np.ndarray:
@@ -23,18 +23,21 @@ def _selection(*indices: int) -> np.ndarray:
 # =================================================================================================
 #  Tests
 # =================================================================================================
-def test_first_exchange_publishes(slot: IslandIncumbentSlot):
+def test_first_exchange_publishes(slot: GroupIncumbentSlot):
     """The first visitor always publishes: a never-written slot holds nothing to compare against."""
+    # --- arrange -----------------------------------------
+    assert not slot.written
+
     # --- act ---------------------------------------------
     outcome = slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))
 
     # --- assert ------------------------------------------
     assert outcome is None
-    assert slot.version == 1
+    assert slot.written
 
 
-def test_better_score_publishes(slot: IslandIncumbentSlot):
-    """A strictly better score replaces the stored selection and bumps the version."""
+def test_better_score_publishes(slot: GroupIncumbentSlot):
+    """A strictly better score replaces the stored selection."""
     # --- arrange -----------------------------------------
     slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))
 
@@ -43,12 +46,11 @@ def test_better_score_publishes(slot: IslandIncumbentSlot):
 
     # --- assert ------------------------------------------
     assert outcome is None
-    assert slot.version == 2
     # a third, worse visitor receives the newly stored selection
     np.testing.assert_array_equal(slot.exchange((1.0, 1.0, 0.6), _selection(0, 1, 2, 3)), [4, 5, 6, 7])
 
 
-def test_worse_score_receives_the_stored_selection(slot: IslandIncumbentSlot):
+def test_worse_score_receives_the_stored_selection(slot: GroupIncumbentSlot):
     """A strictly worse visitor gets the stored selection back and stores nothing."""
     # --- arrange -----------------------------------------
     slot.exchange((1.0, 1.0, 0.5), _selection(3, 1, 0, 2))
@@ -59,10 +61,11 @@ def test_worse_score_receives_the_stored_selection(slot: IslandIncumbentSlot):
     # --- assert ------------------------------------------
     np.testing.assert_array_equal(outcome, [3, 1, 0, 2])  # stored order preserved
     assert outcome.dtype == np.int32
-    assert slot.version == 1
+    # the worse visitor stored nothing: a later visitor still receives the original selection
+    np.testing.assert_array_equal(slot.exchange((1.0, 0.9, 0.8), _selection(4, 5, 6, 7)), [3, 1, 0, 2])
 
 
-def test_equal_score_neither_publishes_nor_returns(slot: IslandIncumbentSlot):
+def test_equal_score_neither_publishes_nor_returns(slot: GroupIncumbentSlot):
     """Equal scores leave the slot untouched: adoption is strictly-better only."""
     # --- arrange -----------------------------------------
     slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))
@@ -72,10 +75,11 @@ def test_equal_score_neither_publishes_nor_returns(slot: IslandIncumbentSlot):
 
     # --- assert ------------------------------------------
     assert outcome is None
-    assert slot.version == 1
+    # the equal visitor stored nothing: a worse visitor still receives the original selection
+    np.testing.assert_array_equal(slot.exchange((1.0, 1.0, 0.4), _selection(4, 5, 6, 7)), [0, 1, 2, 3])
 
 
-def test_partial_selection_round_trips(slot: IslandIncumbentSlot):
+def test_partial_selection_round_trips(slot: GroupIncumbentSlot):
     """A selection smaller than k comes back at its own size, not padded to k."""
     # --- arrange -----------------------------------------
     slot.exchange((0.5, 1.0, 0.5), _selection(2, 3))
@@ -87,7 +91,7 @@ def test_partial_selection_round_trips(slot: IslandIncumbentSlot):
     np.testing.assert_array_equal(outcome, [2, 3])
 
 
-def test_returned_selection_is_an_independent_copy(slot: IslandIncumbentSlot):
+def test_returned_selection_is_an_independent_copy(slot: GroupIncumbentSlot):
     """Mutating a returned selection must not corrupt what the slot stores."""
     # --- arrange -----------------------------------------
     slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))

--- a/tests/_core/solver/_parallel/test_incumbent_slot.py
+++ b/tests/_core/solver/_parallel/test_incumbent_slot.py
@@ -1,0 +1,99 @@
+import multiprocessing
+
+import numpy as np
+import pytest
+
+from max_div._core.solver._parallel import IslandIncumbentSlot
+
+
+# =================================================================================================
+#  Fixtures / helpers
+# =================================================================================================
+@pytest.fixture
+def slot() -> IslandIncumbentSlot:
+    return IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=4, score_length=3)
+
+
+def _selection(*indices: int) -> np.ndarray:
+    """Build an int32 selection array from the given indices."""
+    return np.array(indices, dtype=np.int32)
+
+
+# =================================================================================================
+#  Tests
+# =================================================================================================
+def test_first_exchange_publishes(slot: IslandIncumbentSlot):
+    """The first visitor always publishes: a never-written slot holds nothing to compare against."""
+    # --- act ---------------------------------------------
+    outcome = slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))
+
+    # --- assert ------------------------------------------
+    assert outcome is None
+    assert slot.version == 1
+
+
+def test_better_score_publishes(slot: IslandIncumbentSlot):
+    """A strictly better score replaces the stored selection and bumps the version."""
+    # --- arrange -----------------------------------------
+    slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))
+
+    # --- act ---------------------------------------------
+    outcome = slot.exchange((1.0, 1.0, 0.7), _selection(4, 5, 6, 7))
+
+    # --- assert ------------------------------------------
+    assert outcome is None
+    assert slot.version == 2
+    # a third, worse visitor receives the newly stored selection
+    np.testing.assert_array_equal(slot.exchange((1.0, 1.0, 0.6), _selection(0, 1, 2, 3)), [4, 5, 6, 7])
+
+
+def test_worse_score_receives_the_stored_selection(slot: IslandIncumbentSlot):
+    """A strictly worse visitor gets the stored selection back and stores nothing."""
+    # --- arrange -----------------------------------------
+    slot.exchange((1.0, 1.0, 0.5), _selection(3, 1, 0, 2))
+
+    # --- act ---------------------------------------------
+    outcome = slot.exchange((1.0, 0.9, 0.8), _selection(4, 5, 6, 7))  # earlier component dominates
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(outcome, [3, 1, 0, 2])  # stored order preserved
+    assert outcome.dtype == np.int32
+    assert slot.version == 1
+
+
+def test_equal_score_neither_publishes_nor_returns(slot: IslandIncumbentSlot):
+    """Equal scores leave the slot untouched: adoption is strictly-better only."""
+    # --- arrange -----------------------------------------
+    slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))
+
+    # --- act ---------------------------------------------
+    outcome = slot.exchange((1.0, 1.0, 0.5), _selection(4, 5, 6, 7))
+
+    # --- assert ------------------------------------------
+    assert outcome is None
+    assert slot.version == 1
+
+
+def test_partial_selection_round_trips(slot: IslandIncumbentSlot):
+    """A selection smaller than k comes back at its own size, not padded to k."""
+    # --- arrange -----------------------------------------
+    slot.exchange((0.5, 1.0, 0.5), _selection(2, 3))
+
+    # --- act ---------------------------------------------
+    outcome = slot.exchange((0.4, 1.0, 0.5), _selection(1))
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(outcome, [2, 3])
+
+
+def test_returned_selection_is_an_independent_copy(slot: IslandIncumbentSlot):
+    """Mutating a returned selection must not corrupt what the slot stores."""
+    # --- arrange -----------------------------------------
+    slot.exchange((1.0, 1.0, 0.5), _selection(0, 1, 2, 3))
+
+    # --- act ---------------------------------------------
+    outcome = slot.exchange((1.0, 1.0, 0.4), _selection(4, 5, 6, 7))
+    outcome[:] = -1
+
+    # --- assert ------------------------------------------
+    np.testing.assert_array_equal(slot.exchange((1.0, 1.0, 0.4), _selection(4, 5, 6, 7)), [0, 1, 2, 3])

--- a/tests/_core/solver/_parallel/test_incumbent_slot.py
+++ b/tests/_core/solver/_parallel/test_incumbent_slot.py
@@ -11,6 +11,7 @@ from max_div._core.solver._parallel import IslandIncumbentSlot
 # =================================================================================================
 @pytest.fixture
 def slot() -> IslandIncumbentSlot:
+    """Return a fresh, never-written slot."""
     return IslandIncumbentSlot(multiprocessing.get_context("spawn"), k=4, score_length=3)
 
 


### PR DESCRIPTION
**TL;DR**: the cross-process half of cooperative parallel solving — a shared-memory **incumbent slot** per worker group, a **cooperative coordinator** that exchanges selections with it at batch boundaries, and the executor moving to **one coordinator per worker**. Internal only; nothing reaches the public API yet.

## Description

### Problem addressed

Parallel workers so far run fully independently: a worker stuck with a poor selection never benefits from a sibling having found a better one. The groundwork on the solver state (selection adoption) covers the in-process half; what was missing is the cross-process half — a place to publish the best selection and a hook that consults it while solving.

### Implementation

- **`GroupIncumbentSlot`** — a fixed-size shared-memory slot (score vector, selection vector, written flag, one lock) created by the parent and inherited by a group's workers at spawn, the same lifecycle as the shared distance store. Its single `exchange` method is one atomic visit: publish if strictly better, hand back the stored selection if strictly worse, do nothing on a tie.
- **`CooperativeCoordinator`** — plugs into the existing per-batch coordinator hook: it calls `exchange` with the worker's current score and selection, and adopts whatever strictly better selection comes back. Adoption (the expensive part) runs after the lock is released.
- **Executor** — `run_portfolio` now takes one coordinator per worker instead of a single shared one, so a worker group's members can share a slot-bound coordinator while others stay independent. The parallel solver still passes all-independent coordinators; group wiring arrives with the public API.
- Score tuples are compared exactly as the final best-of-all pick compares them, so "better" means one thing at every level.

## Attention points

- **Strictly-better-only exchanges**: on equal scores nothing is stored and nothing is adopted, so workers never churn on ties.
- **A worker's score is monotone across batches** (swaps are only kept when not worse), which is why publishing alone can never perturb a lone worker's search — pinned by a test.
- **Fixed-size slot fields**: the score length is a property of the shared metric configuration and identical across a group's workers; a mismatched length would raise at exchange time.

## Tests / Spikes

- **TEST:** slot semantics — publish-on-first-visit, better/worse/equal outcomes, partial selections, and that returned selections are independent copies.
- **TEST:** coordinator over real solver states — the better state's boundary publishes, the worse state's boundary adopts, ties leave everything untouched.
- **TEST:** a lone cooperative worker reproduces the exact selection of solving alone, while still publishing.
- **TEST:** end-to-end spawned worker group — three workers sharing one slot all report results and the slot records traffic.
- 11 tests added; full suite passes (3976 tests).

## Changelog entry

None: internal groundwork with no user-facing change (`chore/` PR).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

